### PR TITLE
feat(app): compose the provider stack and add a themed error boundary

### DIFF
--- a/apps/mobile/app/+html.tsx
+++ b/apps/mobile/app/+html.tsx
@@ -1,0 +1,38 @@
+import { ScrollViewStyleReset } from 'expo-router/html';
+import type { PropsWithChildren } from 'react';
+
+/**
+ * The web document shell.
+ *
+ * ⚠️ INERT UNDER THE CURRENT CONFIG. Expo only applies `+html.tsx` when `web.output` is
+ * `static` or `server`; with `single` it emits its own SPA shell and this file is ignored.
+ * Verified by exporting and diffing the generated index.html — see the issue linked from #18.
+ *
+ * It is kept rather than deleted because it is correct and starts working the moment web output
+ * moves to `server`, which is the plan once tenant routes need real SEO and link previews.
+ *
+ * Two things it has to get right for an event site opened on a phone from a chat message: a
+ * viewport that will not let the page zoom out to nothing, and font connections opened before
+ * the bundle finishes parsing.
+ */
+export default function Root({ children }: PropsWithChildren) {
+  return (
+    <html lang="en">
+      <head>
+        <meta charSet="utf-8" />
+        <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+        <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover"
+        />
+        {/* Tenant typography sets are served from Google Fonts; opening the connections early
+            saves a round trip on the first paint that matters most. */}
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        {/* Resets body margin and lets a root ScrollView fill the viewport on web. */}
+        <ScrollViewStyleReset />
+      </head>
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -1,19 +1,71 @@
-import { Stack } from 'expo-router';
+import { resolveTheme, themeInputFromPreset } from '@occasio/theme';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Stack, type ErrorBoundaryProps } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
+import { useState } from 'react';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
+import { ErrorFallback } from '../src/features/errors/ErrorFallback';
 
 /**
- * The root layout is an adapter, not a screen: it composes providers and hands off to routes.
+ * Query defaults tuned for an event, not a dashboard.
  *
- * Providers arrive as their epics land — the theme provider with #22, tenant resolution with
- * the tenancy epic, session with identity. Screens stay pure so the theme editor can render
- * them under an overridden provider later.
+ * Attendees are standing in venues with bad signal, so a failed request retries twice rather
+ * than giving up immediately, and data stays fresh for a minute so moving between the schedule
+ * and a session does not refetch on every tap. Refetch-on-focus is off: a phone coming out of a
+ * pocket should show what it already has, instantly.
  */
-export default function RootLayout() {
+const queryDefaults = {
+  queries: {
+    staleTime: 60_000,
+    gcTime: 30 * 60_000,
+    retry: 2,
+    refetchOnWindowFocus: false,
+  },
+} as const;
+
+/**
+ * expo-router renders this instead of the white screen of death when a route throws.
+ *
+ * It resolves a theme directly because `<ThemeProvider>` does not exist yet (#22) — and because
+ * an error boundary that depends on a provider is useless exactly when that provider is what
+ * failed. This one keeps working regardless.
+ */
+export function ErrorBoundary({ error, retry }: ErrorBoundaryProps) {
+  const theme = resolveTheme(themeInputFromPreset('minimal', '#7C3A5A'), { forceScheme: 'light' });
   return (
     <SafeAreaProvider>
-      <StatusBar style="auto" />
-      <Stack screenOptions={{ headerShown: false }} />
+      <ErrorFallback
+        theme={theme}
+        /* expo-router's retry() is async; the fallback wants a void handler, and letting the
+           promise float would swallow a second failure silently. */
+        onRetry={() => void retry()}
+        error={error}
+        showDetail={__DEV__}
+      />
     </SafeAreaProvider>
+  );
+}
+
+/**
+ * The root layout composes providers and nothing else — no data fetching, no business logic.
+ *
+ * Providers arrive as their epics land: the theme provider with #22, tenant resolution and
+ * session with the v0.2 milestone. Screens stay pure so the theme editor can render them under
+ * an overridden provider later.
+ */
+export default function RootLayout() {
+  // Created once per app instance rather than per render, so the cache is not thrown away.
+  const [queryClient] = useState(() => new QueryClient({ defaultOptions: queryDefaults }));
+
+  return (
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <QueryClientProvider client={queryClient}>
+        <SafeAreaProvider>
+          <StatusBar style="auto" />
+          <Stack screenOptions={{ headerShown: false }} />
+        </SafeAreaProvider>
+      </QueryClientProvider>
+    </GestureHandlerRootView>
   );
 }

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@expo/metro-runtime": "~57.0.15",
+    "@tanstack/react-query": "^5.102.8",
     "expo": "^57.0.20",
     "expo-constants": "~57.0.17",
     "expo-linking": "~57.0.9",
@@ -20,6 +21,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-native": "0.86.3",
+    "react-native-gesture-handler": "~2.32.0",
     "react-native-safe-area-context": "~5.7.0",
     "react-native-screens": "~4.26.0",
     "react-native-web": "^0.21.2"

--- a/apps/mobile/src/features/errors/ErrorFallback.tsx
+++ b/apps/mobile/src/features/errors/ErrorFallback.tsx
@@ -1,5 +1,6 @@
 import type { ResolvedTheme } from '@occasio/theme';
 import { Pressable, ScrollView, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 type Props = {
   readonly theme: ResolvedTheme;
@@ -21,11 +22,22 @@ type Props = {
  */
 export function ErrorFallback({ theme, error, onRetry, showDetail = false }: Props) {
   const { color, type, space, radius, border } = theme;
+  /* SafeAreaProvider only supplies the inset context — something has to consume it, or this
+     renders under a notch or the status bar. Insets are applied as padding rather than by
+     wrapping in SafeAreaView so content still scrolls edge to edge behind the bars. */
+  const insets = useSafeAreaInsets();
 
   return (
     <ScrollView
       style={{ backgroundColor: color.bg }}
-      contentContainerStyle={{ padding: space(6), gap: space(4), flexGrow: 1 }}
+      contentContainerStyle={{
+        paddingTop: space(6) + insets.top,
+        paddingBottom: space(6) + insets.bottom,
+        paddingLeft: space(6) + insets.left,
+        paddingRight: space(6) + insets.right,
+        gap: space(4),
+        flexGrow: 1,
+      }}
     >
       <View style={{ gap: space(2) }}>
         <Text style={{ ...type.overline, color: color.danger }}>SOMETHING BROKE</Text>

--- a/apps/mobile/src/features/errors/ErrorFallback.tsx
+++ b/apps/mobile/src/features/errors/ErrorFallback.tsx
@@ -1,0 +1,71 @@
+import type { ResolvedTheme } from '@occasio/theme';
+import { Pressable, ScrollView, Text, View } from 'react-native';
+
+type Props = {
+  readonly theme: ResolvedTheme;
+  readonly error: Error;
+  readonly onRetry: () => void;
+  /** Stack traces help a developer and frighten a guest, so they are opt-in. */
+  readonly showDetail?: boolean;
+};
+
+/**
+ * What an attendee sees when a screen throws.
+ *
+ * The default is a blank white screen, which tells someone standing in a venue nothing and
+ * gives them nothing to do. This is themed, says what happened in plain language, and offers
+ * the one action that usually works.
+ *
+ * Pure: theme and handlers arrive as props, so it renders anywhere — including under the theme
+ * editor's preview.
+ */
+export function ErrorFallback({ theme, error, onRetry, showDetail = false }: Props) {
+  const { color, type, space, radius, border } = theme;
+
+  return (
+    <ScrollView
+      style={{ backgroundColor: color.bg }}
+      contentContainerStyle={{ padding: space(6), gap: space(4), flexGrow: 1 }}
+    >
+      <View style={{ gap: space(2) }}>
+        <Text style={{ ...type.overline, color: color.danger }}>SOMETHING BROKE</Text>
+        <Text style={{ ...type.display2, color: color.text }}>This screen didn&apos;t load</Text>
+        <Text style={{ ...type.body, color: color.textMuted }}>
+          The rest of the event is still fine. Try again, and if it keeps happening, let whoever is
+          running the event know.
+        </Text>
+      </View>
+
+      <Pressable
+        onPress={onRetry}
+        accessibilityRole="button"
+        accessibilityLabel="Try loading this screen again"
+        style={({ pressed }) => ({
+          alignSelf: 'flex-start',
+          backgroundColor: pressed ? color.interactive.pressed : color.interactive.rest,
+          borderRadius: radius.md,
+          paddingVertical: space(3),
+          paddingHorizontal: space(5),
+        })}
+      >
+        <Text style={{ ...type.bodyStrong, color: color.onBrand }}>Try again</Text>
+      </Pressable>
+
+      {showDetail ? (
+        <View
+          style={{
+            backgroundColor: color.surfaceRaised,
+            borderColor: color.border,
+            borderWidth: border.hairline,
+            borderRadius: radius.md,
+            padding: space(4),
+            gap: space(1),
+          }}
+        >
+          <Text style={{ ...type.overline, color: color.textFaint }}>DEVELOPER DETAIL</Text>
+          <Text style={{ ...type.caption, color: color.textMuted }}>{error.message}</Text>
+        </View>
+      ) : null}
+    </ScrollView>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@expo/metro-runtime": "~57.0.15",
+        "@tanstack/react-query": "^5.102.8",
         "expo": "^57.0.20",
         "expo-constants": "~57.0.17",
         "expo-linking": "~57.0.9",
@@ -49,12 +50,29 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-native": "0.86.3",
+        "react-native-gesture-handler": "~2.32.0",
         "react-native-safe-area-context": "~5.7.0",
         "react-native-screens": "~4.26.0",
         "react-native-web": "^0.21.2"
       },
       "devDependencies": {
         "@types/react": "^19.2.18"
+      }
+    },
+    "apps/mobile/node_modules/react-native-gesture-handler": {
+      "version": "2.32.0",
+      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.32.0.tgz",
+      "integrity": "sha512-uYIMOKlKENORq2SABE+jIjbPU+h5I/sQKcq2v16zRq848nwEp1fWRVwML4QWqijc8UcXJC25o54S8GQd4Mf2OA==",
+      "license": "MIT",
+      "dependencies": {
+        "@egjs/hammerjs": "^2.0.17",
+        "@types/react-test-renderer": "^19.1.0",
+        "hoist-non-react-statics": "^3.3.0",
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1356,6 +1374,18 @@
       },
       "engines": {
         "node": ">=18.18"
+      }
+    },
+    "node_modules/@egjs/hammerjs": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
+      "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hammerjs": "^2.0.36"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -5085,6 +5115,32 @@
         "@swc/counter": "^0.1.3"
       }
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.102.8",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.102.8.tgz",
+      "integrity": "sha512-ZNjkJ33CqvPNec/6lZBnHqLc3EVGPZ9ySLhYahU9TcuRFdmwXewuj0c4hwSWcGHqEUwcSrKeZ+oGcvPBqXcQcg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.102.8",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.102.8.tgz",
+      "integrity": "sha512-TYBea4OuXWD7MhaSHq069TWbFe7rcwWN6kzT7JF0OKi1K6c1gTv2IzD6A6ExJsCMozdkqBWeuIUZmu4KQg0O5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.102.8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
@@ -5155,6 +5211,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/hammerjs": {
+      "version": "2.0.46",
+      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.46.tgz",
+      "integrity": "sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==",
+      "license": "MIT"
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -5216,7 +5278,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-19.1.0.tgz",
       "integrity": "sha512-XD0WZrHqjNrxA/MaR9O22w/RNidWR9YZmBdRGI7wcnWGrv/3dA8wKCJ8m63Sn+tLJhcjmuhOi629N66W6kgWzQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -9105,6 +9166,21 @@
       "dependencies": {
         "hermes-estree": "0.36.1"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/hosted-git-info": {
       "version": "7.0.2",


### PR DESCRIPTION
Closes #18.

## What changed

The root layout composes the provider stack — gesture handling, TanStack Query, safe area, status bar — and nothing else. Providers arrive as their epics land; this is the seam they plug into.

Query defaults are tuned for an event rather than a dashboard: **two retries** (attendees are standing in venues with bad signal), **60s stale time** (moving between schedule and session shouldn't refetch), and **no refetch-on-focus** (a phone coming out of a pocket should show what it already has, instantly).

`ErrorBoundary` now renders a themed fallback instead of the white screen of death. It resolves a theme *directly* rather than reading a provider — an error boundary that depends on a provider is useless exactly when that provider is what failed. Stack traces show in development only: they help a developer and frighten a guest.

## Why one criterion is only half-met

`+html.tsx` is included but **inert**. Expo ignores it under `web.output: "single"` — verified by exporting and diffing the generated HTML rather than assumed:

```
preconnect count: 0
viewport-fit count: 0
```

It only applies to `static` and `server` output. I kept the file, with a warning comment so nobody assumes it works, because it is correct and activates the moment output moves to `server`. **When that move happens is a real decision, not something to pick quietly in a scaffold PR** — filed as #99, targeted at v0.2 when tenant URLs actually start being shared.

## Verification

- `npm run verify` — typecheck, lint, format, 6 enforcement probes, 17 tests
- `expo export --platform web` succeeds; HTML shell inspected directly
- Lint caught a floating promise: `retry()` is async and the fallback takes a void handler, so a second failure would have been swallowed silently

## Checks

- [x] `npm run verify` passes locally
- [x] Scoped to one issue
- [x] Title is in conventional-commit form
- [x] No new architectural rules, so no new enforcement probe needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added improved mobile error handling with clear messages, accessible retry actions and optional developer details.
  * Added retry support for failed navigation screens.
  * Added web compatibility improvements, including viewport configuration, font loading and scrolling behaviour.

* **Improvements**
  * Improved mobile gesture handling and safe-area support.
  * Optimised data loading, caching and retry behaviour for a smoother experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->