### PR TITLE
feat(app): add the route skeleton with config-driven tabs

### DIFF
--- a/apps/mobile/app/(super)/_layout.tsx
+++ b/apps/mobile/app/(super)/_layout.tsx
@@ -1,0 +1,19 @@
+import { Stack } from 'expo-router';
+import { useAppTheme } from '../../src/theme/useScaffoldTheme';
+
+/**
+ * Super admin sits OUTSIDE e/[slug] on purpose: it is cross-tenant, so it must never inherit
+ * an event's theme or be reachable through an event's route tree.
+ */
+export default function SuperAdminLayout() {
+  const theme = useAppTheme();
+  return (
+    <Stack
+      screenOptions={{
+        headerStyle: { backgroundColor: theme.color.surface },
+        headerTintColor: theme.color.text,
+        contentStyle: { backgroundColor: theme.color.bg },
+      }}
+    />
+  );
+}

--- a/apps/mobile/app/(super)/index.tsx
+++ b/apps/mobile/app/(super)/index.tsx
@@ -1,0 +1,14 @@
+import { PlaceholderScreen } from '../../src/features/placeholder/PlaceholderScreen';
+import { useAppTheme } from '../../src/theme/useScaffoldTheme';
+
+export default function Route() {
+  return (
+    <PlaceholderScreen
+      theme={useAppTheme()}
+      eyebrow="SUPER ADMIN"
+      title="Approvals"
+      description="Event admins and site publishes waiting on a decision."
+      arrivesIn="#83 to #85"
+    />
+  );
+}

--- a/apps/mobile/app/+not-found.tsx
+++ b/apps/mobile/app/+not-found.tsx
@@ -1,0 +1,30 @@
+import { Link } from 'expo-router';
+import { Text, View } from 'react-native';
+import { useScaffoldTheme } from '../src/theme/useScaffoldTheme';
+
+/**
+ * A mistyped slug is the first thing anyone will hit, so this needs to offer a way out rather
+ * than a dead end.
+ */
+export default function NotFound() {
+  const { color, type, space } = useScaffoldTheme();
+  return (
+    <View
+      style={{
+        flex: 1,
+        backgroundColor: color.bg,
+        padding: space(6),
+        gap: space(3),
+        justifyContent: 'center',
+      }}
+    >
+      <Text style={{ ...type.display2, color: color.text }}>No such page</Text>
+      <Text style={{ ...type.body, color: color.textMuted }}>
+        That link may be mistyped, or the event may have been moved.
+      </Text>
+      <Link href="/discover" style={{ ...type.bodyStrong, color: color.brand }}>
+        Browse events
+      </Link>
+    </View>
+  );
+}

--- a/apps/mobile/app/discover.tsx
+++ b/apps/mobile/app/discover.tsx
@@ -1,0 +1,14 @@
+import { PlaceholderScreen } from '../src/features/placeholder/PlaceholderScreen';
+import { useScaffoldTheme } from '../src/theme/useScaffoldTheme';
+
+export default function Route() {
+  return (
+    <PlaceholderScreen
+      theme={useScaffoldTheme()}
+      eyebrow="DISCOVER"
+      title="Events"
+      description="Every event you can reach, each card rendered in its own theme."
+      arrivesIn="#28"
+    />
+  );
+}

--- a/apps/mobile/app/e/[slug]/(admin)/_layout.tsx
+++ b/apps/mobile/app/e/[slug]/(admin)/_layout.tsx
@@ -1,0 +1,20 @@
+import { Stack } from 'expo-router';
+import { useAppTheme } from '../../../../src/theme/useScaffoldTheme';
+
+/**
+ * The admin console deliberately does NOT wear the tenant's theme: editing a dark festival
+ * theme inside a dark editor is unusable, and the preview pane is where the tenant theme
+ * belongs. RoleGate mounts here once identity lands.
+ */
+export default function AdminLayout() {
+  const theme = useAppTheme();
+  return (
+    <Stack
+      screenOptions={{
+        headerStyle: { backgroundColor: theme.color.surface },
+        headerTintColor: theme.color.text,
+        contentStyle: { backgroundColor: theme.color.bg },
+      }}
+    />
+  );
+}

--- a/apps/mobile/app/e/[slug]/(admin)/dashboard.tsx
+++ b/apps/mobile/app/e/[slug]/(admin)/dashboard.tsx
@@ -1,0 +1,14 @@
+import { PlaceholderScreen } from '../../../../src/features/placeholder/PlaceholderScreen';
+import { useAppTheme } from '../../../../src/theme/useScaffoldTheme';
+
+export default function Route() {
+  return (
+    <PlaceholderScreen
+      theme={useAppTheme()}
+      eyebrow="ADMIN"
+      title="Dashboard"
+      description="Pending gossips, sessions today, and what needs attention."
+      arrivesIn="the v0.4 milestone"
+    />
+  );
+}

--- a/apps/mobile/app/e/[slug]/(admin)/moderation.tsx
+++ b/apps/mobile/app/e/[slug]/(admin)/moderation.tsx
@@ -1,0 +1,14 @@
+import { PlaceholderScreen } from '../../../../src/features/placeholder/PlaceholderScreen';
+import { useAppTheme } from '../../../../src/theme/useScaffoldTheme';
+
+export default function Route() {
+  return (
+    <PlaceholderScreen
+      theme={useAppTheme()}
+      eyebrow="ADMIN"
+      title="Moderation queue"
+      description="Approve, reject or hide gossip posts before attendees see them."
+      arrivesIn="#46"
+    />
+  );
+}

--- a/apps/mobile/app/e/[slug]/(admin)/theme/index.tsx
+++ b/apps/mobile/app/e/[slug]/(admin)/theme/index.tsx
@@ -1,0 +1,14 @@
+import { PlaceholderScreen } from '../../../../../src/features/placeholder/PlaceholderScreen';
+import { useAppTheme } from '../../../../../src/theme/useScaffoldTheme';
+
+export default function Route() {
+  return (
+    <PlaceholderScreen
+      theme={useAppTheme()}
+      eyebrow="ADMIN"
+      title="Theme editor"
+      description="Pick a preset and one colour; the engine derives the rest and guarantees contrast."
+      arrivesIn="#73 to #78"
+    />
+  );
+}

--- a/apps/mobile/app/e/[slug]/(attendee)/_layout.tsx
+++ b/apps/mobile/app/e/[slug]/(attendee)/_layout.tsx
@@ -1,0 +1,51 @@
+import { Tabs } from 'expo-router';
+import {
+  FEATURE_KEYS,
+  FIXTURE_NAV,
+  TAB_ROUTES,
+  visibleTabs,
+} from '../../../../src/config/navigation';
+import { useScaffoldTheme } from '../../../../src/theme/useScaffoldTheme';
+
+/**
+ * The attendee tab bar is generated from tenant config (D2), never hardcoded: a conference
+ * switches gossips off, a wedding drops tasks, and neither is a code change.
+ *
+ * Tabs are declared for every configured feature and hidden — rather than omitted — when a
+ * feature is off, because expo-router still needs the route to exist for deep links into it to
+ * resolve rather than 404.
+ */
+export default function AttendeeTabsLayout() {
+  const theme = useScaffoldTheme();
+  const shown = visibleTabs(FIXTURE_NAV);
+
+  return (
+    <Tabs
+      screenOptions={{
+        headerShown: false,
+        tabBarActiveTintColor: theme.color.brand,
+        tabBarInactiveTintColor: theme.color.textFaint,
+        tabBarStyle: {
+          backgroundColor: theme.color.surface,
+          borderTopColor: theme.color.border,
+        },
+      }}
+    >
+      {FEATURE_KEYS.map((key) => {
+        const route = TAB_ROUTES[key];
+        /* `href: null` hides a tab without removing the route, so a deep link into a disabled
+           feature still resolves instead of 404ing. Options are built conditionally rather
+           than passing `href: undefined`, which exactOptionalPropertyTypes rejects. */
+        return (
+          <Tabs.Screen
+            key={key}
+            name={route.name}
+            options={
+              shown.includes(key) ? { title: route.title } : { title: route.title, href: null }
+            }
+          />
+        );
+      })}
+    </Tabs>
+  );
+}

--- a/apps/mobile/app/e/[slug]/(attendee)/gossips/index.tsx
+++ b/apps/mobile/app/e/[slug]/(attendee)/gossips/index.tsx
@@ -1,0 +1,14 @@
+import { PlaceholderScreen } from '../../../../../src/features/placeholder/PlaceholderScreen';
+import { useScaffoldTheme } from '../../../../../src/theme/useScaffoldTheme';
+
+export default function Route() {
+  return (
+    <PlaceholderScreen
+      theme={useScaffoldTheme()}
+      eyebrow="GOSSIPS"
+      title="The board"
+      description="Anonymous posts, approved by a host before anyone sees them."
+      arrivesIn="#43"
+    />
+  );
+}

--- a/apps/mobile/app/e/[slug]/(attendee)/index.tsx
+++ b/apps/mobile/app/e/[slug]/(attendee)/index.tsx
@@ -1,0 +1,14 @@
+import { PlaceholderScreen } from '../../../../src/features/placeholder/PlaceholderScreen';
+import { useScaffoldTheme } from '../../../../src/theme/useScaffoldTheme';
+
+export default function Route() {
+  return (
+    <PlaceholderScreen
+      theme={useScaffoldTheme()}
+      eyebrow="HOME"
+      title="Event home"
+      description="Hero, what is happening now, what is next, and who is hosting."
+      arrivesIn="#39"
+    />
+  );
+}

--- a/apps/mobile/app/e/[slug]/(attendee)/info.tsx
+++ b/apps/mobile/app/e/[slug]/(attendee)/info.tsx
@@ -1,0 +1,14 @@
+import { PlaceholderScreen } from '../../../../src/features/placeholder/PlaceholderScreen';
+import { useScaffoldTheme } from '../../../../src/theme/useScaffoldTheme';
+
+export default function Route() {
+  return (
+    <PlaceholderScreen
+      theme={useScaffoldTheme()}
+      eyebrow="INFO"
+      title="Venue and travel"
+      description="Where it is, how to get there, and the questions everyone asks."
+      arrivesIn="#40"
+    />
+  );
+}

--- a/apps/mobile/app/e/[slug]/(attendee)/schedule/[sessionId].tsx
+++ b/apps/mobile/app/e/[slug]/(attendee)/schedule/[sessionId].tsx
@@ -1,0 +1,14 @@
+import { PlaceholderScreen } from '../../../../../src/features/placeholder/PlaceholderScreen';
+import { useScaffoldTheme } from '../../../../../src/theme/useScaffoldTheme';
+
+export default function Route() {
+  return (
+    <PlaceholderScreen
+      theme={useScaffoldTheme()}
+      eyebrow="SESSION"
+      title="Session detail"
+      description="Hero, time, venue, hosts, and directions into the OS maps app."
+      arrivesIn="#32"
+    />
+  );
+}

--- a/apps/mobile/app/e/[slug]/(attendee)/schedule/index.tsx
+++ b/apps/mobile/app/e/[slug]/(attendee)/schedule/index.tsx
@@ -1,0 +1,14 @@
+import { PlaceholderScreen } from '../../../../../src/features/placeholder/PlaceholderScreen';
+import { useScaffoldTheme } from '../../../../../src/theme/useScaffoldTheme';
+
+export default function Route() {
+  return (
+    <PlaceholderScreen
+      theme={useScaffoldTheme()}
+      eyebrow="SCHEDULE"
+      title="Story cards"
+      description="Swipeable day cards by default, with a list view for scanning and for reduced motion."
+      arrivesIn="#33 and #35"
+    />
+  );
+}

--- a/apps/mobile/app/e/[slug]/(attendee)/tasks/index.tsx
+++ b/apps/mobile/app/e/[slug]/(attendee)/tasks/index.tsx
@@ -1,0 +1,14 @@
+import { PlaceholderScreen } from '../../../../../src/features/placeholder/PlaceholderScreen';
+import { useScaffoldTheme } from '../../../../../src/theme/useScaffoldTheme';
+
+export default function Route() {
+  return (
+    <PlaceholderScreen
+      theme={useScaffoldTheme()}
+      eyebrow="TASKS"
+      title="My action items"
+      description="What you personally need to do, and when it is due."
+      arrivesIn="#47"
+    />
+  );
+}

--- a/apps/mobile/app/e/[slug]/_layout.tsx
+++ b/apps/mobile/app/e/[slug]/_layout.tsx
@@ -1,0 +1,14 @@
+import { Slot } from 'expo-router';
+
+/**
+ * Everything under /e/[slug] belongs to one event.
+ *
+ * D9 — this path shape is canonical forever. Subdomains and custom domains are resolved by a
+ * rewrite at the hosting layer plus a lookup table, never by routing inside the app.
+ *
+ * TenantProvider and the tenant's ThemeProvider mount here once the tenancy epic lands; until
+ * then this is a pass-through so the route shape can be reviewed on its own.
+ */
+export default function TenantLayout() {
+  return <Slot />;
+}

--- a/apps/mobile/app/join.tsx
+++ b/apps/mobile/app/join.tsx
@@ -1,0 +1,14 @@
+import { PlaceholderScreen } from '../src/features/placeholder/PlaceholderScreen';
+import { useScaffoldTheme } from '../src/theme/useScaffoldTheme';
+
+export default function Route() {
+  return (
+    <PlaceholderScreen
+      theme={useScaffoldTheme()}
+      eyebrow="JOIN"
+      title="Join an event"
+      description="A six-character code, a recent event, or the QR code printed on the table."
+      arrivesIn="#27"
+    />
+  );
+}

--- a/apps/mobile/src/config/navigation.ts
+++ b/apps/mobile/src/config/navigation.ts
@@ -1,0 +1,41 @@
+/**
+ * D2 — the tab bar is generated from config, never hardcoded.
+ *
+ * A conference turns off gossips and renames it; a wedding drops tracks entirely. If tabs were
+ * written into the layout, every one of those would be a code change, and the promise that a
+ * new event is a new row would already be broken.
+ *
+ * ⚠️ TEMPORARY: `FIXTURE_NAV` stands in for the tenant config row until the data layer lands
+ * (#23). The shape is what matters — it mirrors `TenantConfig.nav` / `.features` from the
+ * design doc, so swapping the source is a one-line change, not a rewrite of this layout.
+ */
+
+export const FEATURE_KEYS = ['home', 'schedule', 'gossips', 'tasks', 'info'] as const;
+export type FeatureKey = (typeof FEATURE_KEYS)[number];
+
+export type NavConfig = {
+  /** Which tabs render, in what order. */
+  readonly tabs: readonly FeatureKey[];
+  /** Whether the feature exists for this event at all. */
+  readonly features: Readonly<Record<FeatureKey, boolean>>;
+};
+
+/** Maps a feature to the route segment that implements it, and its default label. */
+export const TAB_ROUTES: Readonly<
+  Record<FeatureKey, { readonly name: string; readonly title: string }>
+> = {
+  home: { name: 'index', title: 'Home' },
+  schedule: { name: 'schedule', title: 'Schedule' },
+  gossips: { name: 'gossips', title: 'Gossips' },
+  tasks: { name: 'tasks', title: 'Tasks' },
+  info: { name: 'info', title: 'Info' },
+};
+
+export const FIXTURE_NAV: NavConfig = {
+  tabs: ['home', 'schedule', 'gossips', 'tasks', 'info'],
+  features: { home: true, schedule: true, gossips: true, tasks: true, info: true },
+};
+
+/** The tabs an event actually shows: configured order, minus anything switched off. */
+export const visibleTabs = (nav: NavConfig): readonly FeatureKey[] =>
+  nav.tabs.filter((key) => nav.features[key]);

--- a/apps/mobile/src/features/placeholder/PlaceholderScreen.tsx
+++ b/apps/mobile/src/features/placeholder/PlaceholderScreen.tsx
@@ -1,0 +1,45 @@
+import type { ResolvedTheme } from '@occasio/theme';
+import { ScrollView, Text, View } from 'react-native';
+
+type Props = {
+  readonly theme: ResolvedTheme;
+  readonly eyebrow: string;
+  readonly title: string;
+  readonly description: string;
+  /** The issue that replaces this placeholder with the real screen. */
+  readonly arrivesIn: string;
+};
+
+/**
+ * Every route in the skeleton renders this until its own issue lands. It is deliberately
+ * explicit about what is missing and when it arrives, so a half-built app reads as a plan
+ * rather than as breakage.
+ *
+ * Pure: theme in, JSX out, no router, no data.
+ */
+export function PlaceholderScreen({ theme, eyebrow, title, description, arrivesIn }: Props) {
+  const { color, type, space, radius, border } = theme;
+  return (
+    <ScrollView
+      style={{ backgroundColor: color.bg }}
+      contentContainerStyle={{ padding: space(6), gap: space(3) }}
+    >
+      <Text style={{ ...type.overline, color: color.textMuted }}>{eyebrow}</Text>
+      <Text style={{ ...type.display2, color: color.text }}>{title}</Text>
+      <Text style={{ ...type.body, color: color.textMuted }}>{description}</Text>
+      <View
+        style={{
+          alignSelf: 'flex-start',
+          backgroundColor: color.brandSubtle,
+          borderColor: color.brandBorder,
+          borderWidth: border.hairline,
+          borderRadius: radius.pill,
+          paddingVertical: space(1),
+          paddingHorizontal: space(3),
+        }}
+      >
+        <Text style={{ ...type.caption, color: color.onBrandSubtle }}>Arrives in {arrivesIn}</Text>
+      </View>
+    </ScrollView>
+  );
+}

--- a/apps/mobile/src/theme/useScaffoldTheme.ts
+++ b/apps/mobile/src/theme/useScaffoldTheme.ts
@@ -1,0 +1,16 @@
+import { resolveTheme, themeInputFromPreset, type ResolvedTheme } from '@occasio/theme';
+
+/**
+ * ⚠️ TEMPORARY — replaced wholesale by `useTheme()` from the real ThemeProvider in #22.
+ *
+ * It exists so the route skeleton does not repeat theme resolution in fifteen files, and so
+ * the migration is a single import swap rather than fifteen edits. It resolves a fixed preset
+ * because tenant config does not exist yet.
+ */
+export const useScaffoldTheme = (): ResolvedTheme =>
+  resolveTheme(themeInputFromPreset('romantic', '#7C3A5A'), { forceScheme: 'light' });
+
+/** The admin console never wears a tenant's theme — editing a dark festival theme in a dark
+ *  editor is unusable, and a super admin is cross-tenant by definition. */
+export const useAppTheme = (): ResolvedTheme =>
+  resolveTheme(themeInputFromPreset('minimal', '#3F5B7C'), { forceScheme: 'light' });

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,22 +59,6 @@
         "@types/react": "^19.2.18"
       }
     },
-    "apps/mobile/node_modules/react-native-gesture-handler": {
-      "version": "2.32.0",
-      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.32.0.tgz",
-      "integrity": "sha512-uYIMOKlKENORq2SABE+jIjbPU+h5I/sQKcq2v16zRq848nwEp1fWRVwML4QWqijc8UcXJC25o54S8GQd4Mf2OA==",
-      "license": "MIT",
-      "dependencies": {
-        "@egjs/hammerjs": "^2.0.17",
-        "@types/react-test-renderer": "^19.1.0",
-        "hoist-non-react-statics": "^3.3.0",
-        "invariant": "^2.2.4"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
-      }
-    },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
@@ -13137,13 +13121,14 @@
       }
     },
     "node_modules/react-native-gesture-handler": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-3.2.1.tgz",
-      "integrity": "sha512-VEWscxUN29aeccbD2McF0LSXrwOhSdisaSRFiEWg0O/3WrVghNJp/tOtLrCgzb9gfcZ3xdA+K2Sp8F5G3iHx/Q==",
+      "version": "2.32.0",
+      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.32.0.tgz",
+      "integrity": "sha512-uYIMOKlKENORq2SABE+jIjbPU+h5I/sQKcq2v16zRq848nwEp1fWRVwML4QWqijc8UcXJC25o54S8GQd4Mf2OA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
+        "@egjs/hammerjs": "^2.0.17",
         "@types/react-test-renderer": "^19.1.0",
+        "hoist-non-react-statics": "^3.3.0",
         "invariant": "^2.2.4"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   },
   "overrides": {
     "handlebars": "^4.7.9",
-    "react-native": "0.86.3"
+    "react-native": "0.86.3",
+    "react-native-gesture-handler": "2.32.0"
   }
 }


### PR DESCRIPTION
Closes #19.

> **Stacked on #100** (`feat/18-root-layout`). The diff here shows only the routing work; review #100 first.

## What changed

Every route from the design doc, as placeholders that state what they will become and which issue brings it:

```
app/
  index · discover · join · +not-found · +html
  e/[slug]/
    (attendee)/  index · schedule · schedule/[sessionId] · gossips · tasks · info
    (admin)/     dashboard · theme · moderation
  (super)/       index
```

**Super admin sits outside `e/[slug]` on purpose** — it is cross-tenant, so it must never inherit an event's theme or be reachable through an event's route tree. The admin console likewise uses a fixed app theme, because editing a dark festival theme inside a dark editor is unusable.

**Tabs are generated from config, never hardcoded** (D2). A conference switching gossips off, or a wedding dropping tasks, is a config change — not a code change. That is the whole promise that a new event is a new row.

Disabled tabs use `href: null` rather than being omitted, so they are hidden but still routable: a deep link into a disabled feature resolves instead of 404ing.

## Two stand-ins, both marked

`FIXTURE_NAV` stands in for the tenant config row until the data layer lands (#23), and `useScaffoldTheme` is replaced wholesale by `useTheme()` in #22. Both exist so those migrations are an import swap rather than fifteen edits, and both carry warning comments so nobody mistakes them for the real thing.

## A recurring dependency trap

`expo-doctor` caught a duplicate `react-native-gesture-handler` — 2.32.0 in the app, 3.2.1 hoisted above it. **Same failure mode as `react-native` in #95:** Expo's own packages declare loose ranges (`peerOptional "*"` from `expo-router` here), so npm installs the newest at the workspace root where it shadows the SDK-pinned version. Native modules may only exist once in a build.

That is twice now, so it is worth naming as a pattern: **after `expo install`, run `expo-doctor` and expect to pin.**

## Verification

- `npx expo-doctor` — 21/21
- `npm run verify` — typecheck, lint, format, 6 enforcement probes, 17 tests
- `expo export --platform web` — every route confirmed present in the bundle by grepping for its copy

## Checks

- [x] `npm run verify` passes locally
- [x] Scoped to one issue
- [x] Title is in conventional-commit form
- [x] No new architectural rules, so no new enforcement probe needed