### PR TITLE
feat(app): add the route skeleton with config-driven tabs

### DIFF
--- a/apps/mobile/app/(super)/_layout.tsx
+++ b/apps/mobile/app/(super)/_layout.tsx
@@ -1,0 +1,19 @@
+import { Stack } from 'expo-router';
+import { useAppTheme } from '../../src/theme/useScaffoldTheme';
+
+/**
+ * Super admin sits OUTSIDE e/[slug] on purpose: it is cross-tenant, so it must never inherit
+ * an event's theme or be reachable through an event's route tree.
+ */
+export default function SuperAdminLayout() {
+  const theme = useAppTheme();
+  return (
+    <Stack
+      screenOptions={{
+        headerStyle: { backgroundColor: theme.color.surface },
+        headerTintColor: theme.color.text,
+        contentStyle: { backgroundColor: theme.color.bg },
+      }}
+    />
+  );
+}

--- a/apps/mobile/app/(super)/index.tsx
+++ b/apps/mobile/app/(super)/index.tsx
@@ -1,0 +1,14 @@
+import { PlaceholderScreen } from '../../src/features/placeholder/PlaceholderScreen';
+import { useAppTheme } from '../../src/theme/useScaffoldTheme';
+
+export default function Route() {
+  return (
+    <PlaceholderScreen
+      theme={useAppTheme()}
+      eyebrow="SUPER ADMIN"
+      title="Approvals"
+      description="Event admins and site publishes waiting on a decision."
+      arrivesIn="#83 to #85"
+    />
+  );
+}

--- a/apps/mobile/app/+not-found.tsx
+++ b/apps/mobile/app/+not-found.tsx
@@ -1,0 +1,30 @@
+import { Link } from 'expo-router';
+import { Text, View } from 'react-native';
+import { useScaffoldTheme } from '../src/theme/useScaffoldTheme';
+
+/**
+ * A mistyped slug is the first thing anyone will hit, so this needs to offer a way out rather
+ * than a dead end.
+ */
+export default function NotFound() {
+  const { color, type, space } = useScaffoldTheme();
+  return (
+    <View
+      style={{
+        flex: 1,
+        backgroundColor: color.bg,
+        padding: space(6),
+        gap: space(3),
+        justifyContent: 'center',
+      }}
+    >
+      <Text style={{ ...type.display2, color: color.text }}>No such page</Text>
+      <Text style={{ ...type.body, color: color.textMuted }}>
+        That link may be mistyped, or the event may have been moved.
+      </Text>
+      <Link href="/discover" style={{ ...type.bodyStrong, color: color.brand }}>
+        Browse events
+      </Link>
+    </View>
+  );
+}

--- a/apps/mobile/app/discover.tsx
+++ b/apps/mobile/app/discover.tsx
@@ -1,0 +1,14 @@
+import { PlaceholderScreen } from '../src/features/placeholder/PlaceholderScreen';
+import { useScaffoldTheme } from '../src/theme/useScaffoldTheme';
+
+export default function Route() {
+  return (
+    <PlaceholderScreen
+      theme={useScaffoldTheme()}
+      eyebrow="DISCOVER"
+      title="Events"
+      description="Every event you can reach, each card rendered in its own theme."
+      arrivesIn="#28"
+    />
+  );
+}

--- a/apps/mobile/app/discover.tsx
+++ b/apps/mobile/app/discover.tsx
@@ -8,7 +8,7 @@ export default function Route() {
       eyebrow="DISCOVER"
       title="Events"
       description="Every event you can reach, each card rendered in its own theme."
-      arrivesIn="#28"
+      arrivesIn="#42"
     />
   );
 }

--- a/apps/mobile/app/e/[slug]/(admin)/_layout.tsx
+++ b/apps/mobile/app/e/[slug]/(admin)/_layout.tsx
@@ -1,0 +1,20 @@
+import { Stack } from 'expo-router';
+import { useAppTheme } from '../../../../src/theme/useScaffoldTheme';
+
+/**
+ * The admin console deliberately does NOT wear the tenant's theme: editing a dark festival
+ * theme inside a dark editor is unusable, and the preview pane is where the tenant theme
+ * belongs. RoleGate mounts here once identity lands.
+ */
+export default function AdminLayout() {
+  const theme = useAppTheme();
+  return (
+    <Stack
+      screenOptions={{
+        headerStyle: { backgroundColor: theme.color.surface },
+        headerTintColor: theme.color.text,
+        contentStyle: { backgroundColor: theme.color.bg },
+      }}
+    />
+  );
+}

--- a/apps/mobile/app/e/[slug]/(admin)/dashboard.tsx
+++ b/apps/mobile/app/e/[slug]/(admin)/dashboard.tsx
@@ -1,0 +1,14 @@
+import { PlaceholderScreen } from '../../../../src/features/placeholder/PlaceholderScreen';
+import { useAppTheme } from '../../../../src/theme/useScaffoldTheme';
+
+export default function Route() {
+  return (
+    <PlaceholderScreen
+      theme={useAppTheme()}
+      eyebrow="ADMIN"
+      title="Dashboard"
+      description="Pending gossips, sessions today, and what needs attention."
+      arrivesIn="the v0.4 milestone"
+    />
+  );
+}

--- a/apps/mobile/app/e/[slug]/(admin)/moderation.tsx
+++ b/apps/mobile/app/e/[slug]/(admin)/moderation.tsx
@@ -1,0 +1,14 @@
+import { PlaceholderScreen } from '../../../../src/features/placeholder/PlaceholderScreen';
+import { useAppTheme } from '../../../../src/theme/useScaffoldTheme';
+
+export default function Route() {
+  return (
+    <PlaceholderScreen
+      theme={useAppTheme()}
+      eyebrow="ADMIN"
+      title="Moderation queue"
+      description="Approve, reject or hide gossip posts before attendees see them."
+      arrivesIn="#46"
+    />
+  );
+}

--- a/apps/mobile/app/e/[slug]/(admin)/moderation.tsx
+++ b/apps/mobile/app/e/[slug]/(admin)/moderation.tsx
@@ -8,7 +8,7 @@ export default function Route() {
       eyebrow="ADMIN"
       title="Moderation queue"
       description="Approve, reject or hide gossip posts before attendees see them."
-      arrivesIn="#46"
+      arrivesIn="#58"
     />
   );
 }

--- a/apps/mobile/app/e/[slug]/(admin)/theme/index.tsx
+++ b/apps/mobile/app/e/[slug]/(admin)/theme/index.tsx
@@ -1,0 +1,14 @@
+import { PlaceholderScreen } from '../../../../../src/features/placeholder/PlaceholderScreen';
+import { useAppTheme } from '../../../../../src/theme/useScaffoldTheme';
+
+export default function Route() {
+  return (
+    <PlaceholderScreen
+      theme={useAppTheme()}
+      eyebrow="ADMIN"
+      title="Theme editor"
+      description="Pick a preset and one colour; the engine derives the rest and guarantees contrast."
+      arrivesIn="#73 to #78"
+    />
+  );
+}

--- a/apps/mobile/app/e/[slug]/(admin)/theme/index.tsx
+++ b/apps/mobile/app/e/[slug]/(admin)/theme/index.tsx
@@ -8,7 +8,7 @@ export default function Route() {
       eyebrow="ADMIN"
       title="Theme editor"
       description="Pick a preset and one colour; the engine derives the rest and guarantees contrast."
-      arrivesIn="#73 to #78"
+      arrivesIn="#74 to #78"
     />
   );
 }

--- a/apps/mobile/app/e/[slug]/(attendee)/_layout.tsx
+++ b/apps/mobile/app/e/[slug]/(attendee)/_layout.tsx
@@ -1,0 +1,51 @@
+import { Tabs } from 'expo-router';
+import {
+  FEATURE_KEYS,
+  FIXTURE_NAV,
+  TAB_ROUTES,
+  visibleTabs,
+} from '../../../../src/config/navigation';
+import { useScaffoldTheme } from '../../../../src/theme/useScaffoldTheme';
+
+/**
+ * The attendee tab bar is generated from tenant config (D2), never hardcoded: a conference
+ * switches gossips off, a wedding drops tasks, and neither is a code change.
+ *
+ * Tabs are declared for every configured feature and hidden — rather than omitted — when a
+ * feature is off, because expo-router still needs the route to exist for deep links into it to
+ * resolve rather than 404.
+ */
+export default function AttendeeTabsLayout() {
+  const theme = useScaffoldTheme();
+  const shown = visibleTabs(FIXTURE_NAV);
+
+  return (
+    <Tabs
+      screenOptions={{
+        headerShown: false,
+        tabBarActiveTintColor: theme.color.brand,
+        tabBarInactiveTintColor: theme.color.textFaint,
+        tabBarStyle: {
+          backgroundColor: theme.color.surface,
+          borderTopColor: theme.color.border,
+        },
+      }}
+    >
+      {FEATURE_KEYS.map((key) => {
+        const route = TAB_ROUTES[key];
+        /* `href: null` hides a tab without removing the route, so a deep link into a disabled
+           feature still resolves instead of 404ing. Options are built conditionally rather
+           than passing `href: undefined`, which exactOptionalPropertyTypes rejects. */
+        return (
+          <Tabs.Screen
+            key={key}
+            name={route.name}
+            options={
+              shown.includes(key) ? { title: route.title } : { title: route.title, href: null }
+            }
+          />
+        );
+      })}
+    </Tabs>
+  );
+}

--- a/apps/mobile/app/e/[slug]/(attendee)/_layout.tsx
+++ b/apps/mobile/app/e/[slug]/(attendee)/_layout.tsx
@@ -1,5 +1,5 @@
 import { Tabs } from 'expo-router';
-import { FIXTURE_NAV, planTabs } from '../../../../src/config/navigation';
+import { FIXTURE_NAV, NON_TAB_ROUTES, planTabs } from '../../../../src/config/navigation';
 import { useScaffoldTheme } from '../../../../src/theme/useScaffoldTheme';
 
 /**
@@ -18,6 +18,9 @@ export default function AttendeeTabsLayout() {
     <Tabs
       screenOptions={{
         headerShown: false,
+        /* No icon set yet — without this react-navigation renders a default placeholder glyph,
+           which looks like a rendering fault. Labels only until the design system lands. */
+        tabBarIcon: () => null,
         tabBarActiveTintColor: theme.color.brand,
         tabBarInactiveTintColor: theme.color.textFaint,
         tabBarStyle: {
@@ -32,6 +35,9 @@ export default function AttendeeTabsLayout() {
           name={tab.name}
           options={tab.hidden ? { title: tab.title, href: null } : { title: tab.title }}
         />
+      ))}
+      {NON_TAB_ROUTES.map((name) => (
+        <Tabs.Screen key={name} name={name} options={{ href: null }} />
       ))}
     </Tabs>
   );

--- a/apps/mobile/app/e/[slug]/(attendee)/_layout.tsx
+++ b/apps/mobile/app/e/[slug]/(attendee)/_layout.tsx
@@ -1,23 +1,18 @@
 import { Tabs } from 'expo-router';
-import {
-  FEATURE_KEYS,
-  FIXTURE_NAV,
-  TAB_ROUTES,
-  visibleTabs,
-} from '../../../../src/config/navigation';
+import { FIXTURE_NAV, planTabs } from '../../../../src/config/navigation';
 import { useScaffoldTheme } from '../../../../src/theme/useScaffoldTheme';
 
 /**
  * The attendee tab bar is generated from tenant config (D2), never hardcoded: a conference
  * switches gossips off, a wedding drops tasks, and neither is a code change.
  *
- * Tabs are declared for every configured feature and hidden — rather than omitted — when a
- * feature is off, because expo-router still needs the route to exist for deep links into it to
- * resolve rather than 404.
+ * The route stays an adapter — the ordering and enabled/disabled logic lives in `planTabs`,
+ * which is pure and tested. `<Tabs.Screen>` construction has to stay here rather than moving to
+ * features/, because features are forbidden from importing expo-router (that ban is what keeps
+ * screens renderable inside the theme editor's preview).
  */
 export default function AttendeeTabsLayout() {
   const theme = useScaffoldTheme();
-  const shown = visibleTabs(FIXTURE_NAV);
 
   return (
     <Tabs
@@ -31,21 +26,13 @@ export default function AttendeeTabsLayout() {
         },
       }}
     >
-      {FEATURE_KEYS.map((key) => {
-        const route = TAB_ROUTES[key];
-        /* `href: null` hides a tab without removing the route, so a deep link into a disabled
-           feature still resolves instead of 404ing. Options are built conditionally rather
-           than passing `href: undefined`, which exactOptionalPropertyTypes rejects. */
-        return (
-          <Tabs.Screen
-            key={key}
-            name={route.name}
-            options={
-              shown.includes(key) ? { title: route.title } : { title: route.title, href: null }
-            }
-          />
-        );
-      })}
+      {planTabs(FIXTURE_NAV).map((tab) => (
+        <Tabs.Screen
+          key={tab.key}
+          name={tab.name}
+          options={tab.hidden ? { title: tab.title, href: null } : { title: tab.title }}
+        />
+      ))}
     </Tabs>
   );
 }

--- a/apps/mobile/app/e/[slug]/(attendee)/gossips/index.tsx
+++ b/apps/mobile/app/e/[slug]/(attendee)/gossips/index.tsx
@@ -1,0 +1,14 @@
+import { PlaceholderScreen } from '../../../../../src/features/placeholder/PlaceholderScreen';
+import { useScaffoldTheme } from '../../../../../src/theme/useScaffoldTheme';
+
+export default function Route() {
+  return (
+    <PlaceholderScreen
+      theme={useScaffoldTheme()}
+      eyebrow="GOSSIPS"
+      title="The board"
+      description="Anonymous posts, approved by a host before anyone sees them."
+      arrivesIn="#43"
+    />
+  );
+}

--- a/apps/mobile/app/e/[slug]/(attendee)/gossips/index.tsx
+++ b/apps/mobile/app/e/[slug]/(attendee)/gossips/index.tsx
@@ -8,7 +8,7 @@ export default function Route() {
       eyebrow="GOSSIPS"
       title="The board"
       description="Anonymous posts, approved by a host before anyone sees them."
-      arrivesIn="#43"
+      arrivesIn="#56"
     />
   );
 }

--- a/apps/mobile/app/e/[slug]/(attendee)/index.tsx
+++ b/apps/mobile/app/e/[slug]/(attendee)/index.tsx
@@ -8,7 +8,7 @@ export default function Route() {
       eyebrow="HOME"
       title="Event home"
       description="Hero, what is happening now, what is next, and who is hosting."
-      arrivesIn="#39"
+      arrivesIn="#52"
     />
   );
 }

--- a/apps/mobile/app/e/[slug]/(attendee)/index.tsx
+++ b/apps/mobile/app/e/[slug]/(attendee)/index.tsx
@@ -1,0 +1,14 @@
+import { PlaceholderScreen } from '../../../../src/features/placeholder/PlaceholderScreen';
+import { useScaffoldTheme } from '../../../../src/theme/useScaffoldTheme';
+
+export default function Route() {
+  return (
+    <PlaceholderScreen
+      theme={useScaffoldTheme()}
+      eyebrow="HOME"
+      title="Event home"
+      description="Hero, what is happening now, what is next, and who is hosting."
+      arrivesIn="#39"
+    />
+  );
+}

--- a/apps/mobile/app/e/[slug]/(attendee)/info.tsx
+++ b/apps/mobile/app/e/[slug]/(attendee)/info.tsx
@@ -8,7 +8,7 @@ export default function Route() {
       eyebrow="INFO"
       title="Venue and travel"
       description="Where it is, how to get there, and the questions everyone asks."
-      arrivesIn="#40"
+      arrivesIn="#53"
     />
   );
 }

--- a/apps/mobile/app/e/[slug]/(attendee)/info.tsx
+++ b/apps/mobile/app/e/[slug]/(attendee)/info.tsx
@@ -1,0 +1,14 @@
+import { PlaceholderScreen } from '../../../../src/features/placeholder/PlaceholderScreen';
+import { useScaffoldTheme } from '../../../../src/theme/useScaffoldTheme';
+
+export default function Route() {
+  return (
+    <PlaceholderScreen
+      theme={useScaffoldTheme()}
+      eyebrow="INFO"
+      title="Venue and travel"
+      description="Where it is, how to get there, and the questions everyone asks."
+      arrivesIn="#40"
+    />
+  );
+}

--- a/apps/mobile/app/e/[slug]/(attendee)/schedule/[sessionId].tsx
+++ b/apps/mobile/app/e/[slug]/(attendee)/schedule/[sessionId].tsx
@@ -8,7 +8,7 @@ export default function Route() {
       eyebrow="SESSION"
       title="Session detail"
       description="Hero, time, venue, hosts, and directions into the OS maps app."
-      arrivesIn="#32"
+      arrivesIn="#48"
     />
   );
 }

--- a/apps/mobile/app/e/[slug]/(attendee)/schedule/[sessionId].tsx
+++ b/apps/mobile/app/e/[slug]/(attendee)/schedule/[sessionId].tsx
@@ -1,0 +1,14 @@
+import { PlaceholderScreen } from '../../../../../src/features/placeholder/PlaceholderScreen';
+import { useScaffoldTheme } from '../../../../../src/theme/useScaffoldTheme';
+
+export default function Route() {
+  return (
+    <PlaceholderScreen
+      theme={useScaffoldTheme()}
+      eyebrow="SESSION"
+      title="Session detail"
+      description="Hero, time, venue, hosts, and directions into the OS maps app."
+      arrivesIn="#32"
+    />
+  );
+}

--- a/apps/mobile/app/e/[slug]/(attendee)/schedule/index.tsx
+++ b/apps/mobile/app/e/[slug]/(attendee)/schedule/index.tsx
@@ -8,7 +8,7 @@ export default function Route() {
       eyebrow="SCHEDULE"
       title="Story cards"
       description="Swipeable day cards by default, with a list view for scanning and for reduced motion."
-      arrivesIn="#33 and #35"
+      arrivesIn="#49 and #50"
     />
   );
 }

--- a/apps/mobile/app/e/[slug]/(attendee)/schedule/index.tsx
+++ b/apps/mobile/app/e/[slug]/(attendee)/schedule/index.tsx
@@ -1,0 +1,14 @@
+import { PlaceholderScreen } from '../../../../../src/features/placeholder/PlaceholderScreen';
+import { useScaffoldTheme } from '../../../../../src/theme/useScaffoldTheme';
+
+export default function Route() {
+  return (
+    <PlaceholderScreen
+      theme={useScaffoldTheme()}
+      eyebrow="SCHEDULE"
+      title="Story cards"
+      description="Swipeable day cards by default, with a list view for scanning and for reduced motion."
+      arrivesIn="#33 and #35"
+    />
+  );
+}

--- a/apps/mobile/app/e/[slug]/(attendee)/tasks/index.tsx
+++ b/apps/mobile/app/e/[slug]/(attendee)/tasks/index.tsx
@@ -1,0 +1,14 @@
+import { PlaceholderScreen } from '../../../../../src/features/placeholder/PlaceholderScreen';
+import { useScaffoldTheme } from '../../../../../src/theme/useScaffoldTheme';
+
+export default function Route() {
+  return (
+    <PlaceholderScreen
+      theme={useScaffoldTheme()}
+      eyebrow="TASKS"
+      title="My action items"
+      description="What you personally need to do, and when it is due."
+      arrivesIn="#47"
+    />
+  );
+}

--- a/apps/mobile/app/e/[slug]/(attendee)/tasks/index.tsx
+++ b/apps/mobile/app/e/[slug]/(attendee)/tasks/index.tsx
@@ -8,7 +8,7 @@ export default function Route() {
       eyebrow="TASKS"
       title="My action items"
       description="What you personally need to do, and when it is due."
-      arrivesIn="#47"
+      arrivesIn="#60"
     />
   );
 }

--- a/apps/mobile/app/e/[slug]/_layout.tsx
+++ b/apps/mobile/app/e/[slug]/_layout.tsx
@@ -1,0 +1,14 @@
+import { Slot } from 'expo-router';
+
+/**
+ * Everything under /e/[slug] belongs to one event.
+ *
+ * D9 — this path shape is canonical forever. Subdomains and custom domains are resolved by a
+ * rewrite at the hosting layer plus a lookup table, never by routing inside the app.
+ *
+ * TenantProvider and the tenant's ThemeProvider mount here once the tenancy epic lands; until
+ * then this is a pass-through so the route shape can be reviewed on its own.
+ */
+export default function TenantLayout() {
+  return <Slot />;
+}

--- a/apps/mobile/app/join.tsx
+++ b/apps/mobile/app/join.tsx
@@ -1,0 +1,14 @@
+import { PlaceholderScreen } from '../src/features/placeholder/PlaceholderScreen';
+import { useScaffoldTheme } from '../src/theme/useScaffoldTheme';
+
+export default function Route() {
+  return (
+    <PlaceholderScreen
+      theme={useScaffoldTheme()}
+      eyebrow="JOIN"
+      title="Join an event"
+      description="A six-character code, a recent event, or the QR code printed on the table."
+      arrivesIn="#27"
+    />
+  );
+}

--- a/apps/mobile/app/join.tsx
+++ b/apps/mobile/app/join.tsx
@@ -8,7 +8,7 @@ export default function Route() {
       eyebrow="JOIN"
       title="Join an event"
       description="A six-character code, a recent event, or the QR code printed on the table."
-      arrivesIn="#27"
+      arrivesIn="#41"
     />
   );
 }

--- a/apps/mobile/src/config/navigation.test.ts
+++ b/apps/mobile/src/config/navigation.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from '@jest/globals';
+import { FIXTURE_NAV, planTabs, type NavConfig } from './navigation';
+
+const nav = (over: Partial<NavConfig>): NavConfig => ({ ...FIXTURE_NAV, ...over });
+
+describe('planTabs', () => {
+  it('renders tabs in the order the event configured, not the order they are declared in code', () => {
+    const plan = planTabs(nav({ tabs: ['schedule', 'info', 'home'] }));
+    expect(plan.filter((t) => !t.hidden).map((t) => t.key)).toEqual(['schedule', 'info', 'home']);
+  });
+
+  it('keeps disabled features routable but out of the visible order', () => {
+    const plan = planTabs(
+      nav({
+        tabs: ['home', 'gossips', 'schedule'],
+        features: { home: true, schedule: true, gossips: false, tasks: false, info: false },
+      }),
+    );
+    expect(plan.filter((t) => !t.hidden).map((t) => t.key)).toEqual(['home', 'schedule']);
+    /* Still declared, so a deep link into a switched-off feature resolves rather than 404s. */
+    expect(
+      plan
+        .filter((t) => t.hidden)
+        .map((t) => t.key)
+        .sort(),
+    ).toEqual(['gossips', 'info', 'tasks']);
+  });
+
+  it('declares every feature exactly once, however the event is configured', () => {
+    const keys = planTabs(nav({ tabs: ['info'] })).map((t) => t.key);
+    expect(new Set(keys).size).toBe(keys.length);
+    expect(keys).toHaveLength(5);
+  });
+});

--- a/apps/mobile/src/config/navigation.test.ts
+++ b/apps/mobile/src/config/navigation.test.ts
@@ -26,6 +26,13 @@ describe('planTabs', () => {
     ).toEqual(['gossips', 'info', 'tasks']);
   });
 
+  it('survives a config that lists the same tab twice', () => {
+    /* Tenant config is data — a hand-edited row can repeat a key, which would declare the same
+       route twice and collide React keys. */
+    const plan = planTabs(nav({ tabs: ['home', 'schedule', 'home'] }));
+    expect(plan.filter((t) => !t.hidden).map((t) => t.key)).toEqual(['home', 'schedule']);
+  });
+
   it('declares every feature exactly once, however the event is configured', () => {
     const keys = planTabs(nav({ tabs: ['info'] })).map((t) => t.key);
     expect(new Set(keys).size).toBe(keys.length);

--- a/apps/mobile/src/config/navigation.ts
+++ b/apps/mobile/src/config/navigation.ts
@@ -46,6 +46,15 @@ export const FIXTURE_NAV: NavConfig = {
 export const visibleTabs = (nav: NavConfig): readonly FeatureKey[] =>
   [...new Set(nav.tabs)].filter((key) => nav.features[key]);
 
+/**
+ * Routes that live inside the tabs group but are not tabs.
+ *
+ * expo-router turns every route it discovers in a Tabs layout into a tab, so a detail screen
+ * nested under a tab's folder shows up as a stray sixth tab unless it is explicitly hidden.
+ * Found by screenshotting the running app — nothing in the type system or the tests catches it.
+ */
+export const NON_TAB_ROUTES = ['schedule/[sessionId]'] as const;
+
 export type TabPlan = {
   readonly key: FeatureKey;
   readonly name: string;

--- a/apps/mobile/src/config/navigation.ts
+++ b/apps/mobile/src/config/navigation.ts
@@ -39,3 +39,33 @@ export const FIXTURE_NAV: NavConfig = {
 /** The tabs an event actually shows: configured order, minus anything switched off. */
 export const visibleTabs = (nav: NavConfig): readonly FeatureKey[] =>
   nav.tabs.filter((key) => nav.features[key]);
+
+export type TabPlan = {
+  readonly key: FeatureKey;
+  readonly name: string;
+  readonly title: string;
+  /** Hidden tabs are still declared so a deep link into a disabled feature resolves. */
+  readonly hidden: boolean;
+};
+
+/**
+ * The ordered list of tabs to declare.
+ *
+ * Order comes from `nav.tabs`, not from `FEATURE_KEYS` — an event that lists schedule before
+ * home must get schedule first, and `href: null` hides a tab without reordering it. Disabled
+ * features are appended after the visible ones so they remain routable but never affect the
+ * order of what is on screen.
+ *
+ * Pure and separately tested, because getting this wrong silently produces the right tabs in
+ * the wrong sequence, which no type check would catch.
+ */
+export const planTabs = (nav: NavConfig): readonly TabPlan[] => {
+  const shown = visibleTabs(nav);
+  const hidden = FEATURE_KEYS.filter((key) => !shown.includes(key));
+  return [...shown, ...hidden].map((key) => ({
+    key,
+    name: TAB_ROUTES[key].name,
+    title: TAB_ROUTES[key].title,
+    hidden: !shown.includes(key),
+  }));
+};

--- a/apps/mobile/src/config/navigation.ts
+++ b/apps/mobile/src/config/navigation.ts
@@ -36,9 +36,15 @@ export const FIXTURE_NAV: NavConfig = {
   features: { home: true, schedule: true, gossips: true, tasks: true, info: true },
 };
 
-/** The tabs an event actually shows: configured order, minus anything switched off. */
+/**
+ * The tabs an event actually shows: configured order, minus anything switched off.
+ *
+ * Deduplicated first — tenant config is data, and a hand-edited row can list the same tab
+ * twice. That would declare the same route twice and collide React keys, so it is normalised
+ * here rather than trusted.
+ */
 export const visibleTabs = (nav: NavConfig): readonly FeatureKey[] =>
-  nav.tabs.filter((key) => nav.features[key]);
+  [...new Set(nav.tabs)].filter((key) => nav.features[key]);
 
 export type TabPlan = {
   readonly key: FeatureKey;

--- a/apps/mobile/src/config/navigation.ts
+++ b/apps/mobile/src/config/navigation.ts
@@ -1,0 +1,41 @@
+/**
+ * D2 — the tab bar is generated from config, never hardcoded.
+ *
+ * A conference turns off gossips and renames it; a wedding drops tracks entirely. If tabs were
+ * written into the layout, every one of those would be a code change, and the promise that a
+ * new event is a new row would already be broken.
+ *
+ * ⚠️ TEMPORARY: `FIXTURE_NAV` stands in for the tenant config row until the data layer lands
+ * (#23). The shape is what matters — it mirrors `TenantConfig.nav` / `.features` from the
+ * design doc, so swapping the source is a one-line change, not a rewrite of this layout.
+ */
+
+export const FEATURE_KEYS = ['home', 'schedule', 'gossips', 'tasks', 'info'] as const;
+export type FeatureKey = (typeof FEATURE_KEYS)[number];
+
+export type NavConfig = {
+  /** Which tabs render, in what order. */
+  readonly tabs: readonly FeatureKey[];
+  /** Whether the feature exists for this event at all. */
+  readonly features: Readonly<Record<FeatureKey, boolean>>;
+};
+
+/** Maps a feature to the route segment that implements it, and its default label. */
+export const TAB_ROUTES: Readonly<
+  Record<FeatureKey, { readonly name: string; readonly title: string }>
+> = {
+  home: { name: 'index', title: 'Home' },
+  schedule: { name: 'schedule', title: 'Schedule' },
+  gossips: { name: 'gossips', title: 'Gossips' },
+  tasks: { name: 'tasks', title: 'Tasks' },
+  info: { name: 'info', title: 'Info' },
+};
+
+export const FIXTURE_NAV: NavConfig = {
+  tabs: ['home', 'schedule', 'gossips', 'tasks', 'info'],
+  features: { home: true, schedule: true, gossips: true, tasks: true, info: true },
+};
+
+/** The tabs an event actually shows: configured order, minus anything switched off. */
+export const visibleTabs = (nav: NavConfig): readonly FeatureKey[] =>
+  nav.tabs.filter((key) => nav.features[key]);

--- a/apps/mobile/src/features/placeholder/PlaceholderScreen.tsx
+++ b/apps/mobile/src/features/placeholder/PlaceholderScreen.tsx
@@ -1,0 +1,45 @@
+import type { ResolvedTheme } from '@occasio/theme';
+import { ScrollView, Text, View } from 'react-native';
+
+type Props = {
+  readonly theme: ResolvedTheme;
+  readonly eyebrow: string;
+  readonly title: string;
+  readonly description: string;
+  /** The issue that replaces this placeholder with the real screen. */
+  readonly arrivesIn: string;
+};
+
+/**
+ * Every route in the skeleton renders this until its own issue lands. It is deliberately
+ * explicit about what is missing and when it arrives, so a half-built app reads as a plan
+ * rather than as breakage.
+ *
+ * Pure: theme in, JSX out, no router, no data.
+ */
+export function PlaceholderScreen({ theme, eyebrow, title, description, arrivesIn }: Props) {
+  const { color, type, space, radius, border } = theme;
+  return (
+    <ScrollView
+      style={{ backgroundColor: color.bg }}
+      contentContainerStyle={{ padding: space(6), gap: space(3) }}
+    >
+      <Text style={{ ...type.overline, color: color.textMuted }}>{eyebrow}</Text>
+      <Text style={{ ...type.display2, color: color.text }}>{title}</Text>
+      <Text style={{ ...type.body, color: color.textMuted }}>{description}</Text>
+      <View
+        style={{
+          alignSelf: 'flex-start',
+          backgroundColor: color.brandSubtle,
+          borderColor: color.brandBorder,
+          borderWidth: border.hairline,
+          borderRadius: radius.pill,
+          paddingVertical: space(1),
+          paddingHorizontal: space(3),
+        }}
+      >
+        <Text style={{ ...type.caption, color: color.onBrandSubtle }}>Arrives in {arrivesIn}</Text>
+      </View>
+    </ScrollView>
+  );
+}

--- a/apps/mobile/src/theme/useScaffoldTheme.ts
+++ b/apps/mobile/src/theme/useScaffoldTheme.ts
@@ -1,0 +1,16 @@
+import { resolveTheme, themeInputFromPreset, type ResolvedTheme } from '@occasio/theme';
+
+/**
+ * ⚠️ TEMPORARY — replaced wholesale by `useTheme()` from the real ThemeProvider in #22.
+ *
+ * It exists so the route skeleton does not repeat theme resolution in fifteen files, and so
+ * the migration is a single import swap rather than fifteen edits. It resolves a fixed preset
+ * because tenant config does not exist yet.
+ */
+export const useScaffoldTheme = (): ResolvedTheme =>
+  resolveTheme(themeInputFromPreset('romantic', '#7C3A5A'), { forceScheme: 'light' });
+
+/** The admin console never wears a tenant's theme — editing a dark festival theme in a dark
+ *  editor is unusable, and a super admin is cross-tenant by definition. */
+export const useAppTheme = (): ResolvedTheme =>
+  resolveTheme(themeInputFromPreset('minimal', '#3F5B7C'), { forceScheme: 'light' });

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -54,6 +54,8 @@ export default tseslint.config(
       '**/coverage/**',
       '**/.expo/**',
       '**/web-build/**',
+      // Local build scratch (preview exports, mock builders). Gitignored, not source.
+      '.artifacts/**',
       '**/*.tsbuildinfo',
     ],
   },

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -23,6 +23,8 @@ export default {
       testMatch: [
         '<rootDir>/packages/*/src/**/*.test.ts',
         '<rootDir>/packages/*/src/**/*.test.tsx',
+        // App-level logic is testable too — navigation ordering is pure and had a real bug.
+        '<rootDir>/apps/*/src/**/*.test.ts',
       ],
       testPathIgnorePatterns: ['\\.contract\\.test\\.'],
       moduleNameMapper,

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,22 +59,6 @@
         "@types/react": "^19.2.18"
       }
     },
-    "apps/mobile/node_modules/react-native-gesture-handler": {
-      "version": "2.32.0",
-      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.32.0.tgz",
-      "integrity": "sha512-uYIMOKlKENORq2SABE+jIjbPU+h5I/sQKcq2v16zRq848nwEp1fWRVwML4QWqijc8UcXJC25o54S8GQd4Mf2OA==",
-      "license": "MIT",
-      "dependencies": {
-        "@egjs/hammerjs": "^2.0.17",
-        "@types/react-test-renderer": "^19.1.0",
-        "hoist-non-react-statics": "^3.3.0",
-        "invariant": "^2.2.4"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
-      }
-    },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
@@ -13137,13 +13121,14 @@
       }
     },
     "node_modules/react-native-gesture-handler": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-3.2.1.tgz",
-      "integrity": "sha512-VEWscxUN29aeccbD2McF0LSXrwOhSdisaSRFiEWg0O/3WrVghNJp/tOtLrCgzb9gfcZ3xdA+K2Sp8F5G3iHx/Q==",
+      "version": "2.32.0",
+      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.32.0.tgz",
+      "integrity": "sha512-uYIMOKlKENORq2SABE+jIjbPU+h5I/sQKcq2v16zRq848nwEp1fWRVwML4QWqijc8UcXJC25o54S8GQd4Mf2OA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
+        "@egjs/hammerjs": "^2.0.17",
         "@types/react-test-renderer": "^19.1.0",
+        "hoist-non-react-statics": "^3.3.0",
         "invariant": "^2.2.4"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   },
   "overrides": {
     "handlebars": "^4.7.9",
-    "react-native": "0.86.3"
+    "react-native": "0.86.3",
+    "react-native-gesture-handler": "2.32.0"
   }
 }


### PR DESCRIPTION
Closes #19.

> Supersedes #101, which GitHub closed irrecoverably when its base branch was deleted on merge. Same branch, rebased onto `main` with `git rebase --onto`; the diff is unchanged.

## What changed

Every route from the design doc, as placeholders that state what they will become and which issue brings it:

```
app/
  index · discover · join · +not-found · +html
  e/[slug]/
    (attendee)/  index · schedule · schedule/[sessionId] · gossips · tasks · info
    (admin)/     dashboard · theme · moderation
  (super)/       index
```

**Super admin sits outside `e/[slug]` on purpose** — it is cross-tenant, so it must never inherit an event's theme or be reachable through an event's route tree. The admin console likewise uses a fixed app theme, because editing a dark festival theme inside a dark editor is unusable.

**Tabs are generated from config, never hardcoded** (D2). A conference switching gossips off, or a wedding dropping tasks, is a config change — not a code change. That is the whole promise that a new event is a new row.

Disabled tabs use `href: null` rather than being omitted, so they are hidden but still routable: a deep link into a disabled feature resolves instead of 404ing.

## Two stand-ins, both marked

`FIXTURE_NAV` stands in for the tenant config row until the data layer lands (#23), and `useScaffoldTheme` is replaced wholesale by `useTheme()` in #22. Both exist so those migrations are an import swap rather than fifteen edits, and both carry warning comments so nobody mistakes them for the real thing.

## A recurring dependency trap

`expo-doctor` caught a duplicate `react-native-gesture-handler` — 2.32.0 in the app, 3.2.1 hoisted above it. **Same failure mode as `react-native` in #95:** Expo's own packages declare loose ranges (`peerOptional "*"` from `expo-router` here), so npm installs the newest at the workspace root where it shadows the SDK-pinned version. Native modules may only exist once in a build.

That is twice now, so it is worth naming as a pattern: **after `expo install`, run `expo-doctor` and expect to pin.**

## Verification

- `npx expo-doctor` — 21/21
- `npm run verify` — typecheck, lint, format, 6 enforcement probes, 17 tests
- `expo export --platform web` — every route confirmed present in the bundle by grepping for its copy

## Checks

- [x] `npm run verify` passes locally
- [x] Scoped to one issue
- [x] Title is in conventional-commit form
- [x] No new architectural rules, so no new enforcement probe needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added mobile screens for discovering and joining events, schedules, sessions, venue information, tasks and community posts.
  - Added administrative screens for dashboards, moderation, theme management and approvals.
  - Added configuration-driven navigation that hides disabled tabs while preserving deep links.
  - Added themed placeholder screens with release availability details.
  - Added a friendly not-found screen with a link to Discover.

- **Visual Updates**
  - Applied consistent attendee, administrative and super-admin colour themes across screens and navigation headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->