### PR TITLE
ci: make the web-build gate do real work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,4 +82,10 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
       - run: npm ci
-      - run: npm run build:web --if-present
+      # No --if-present: the script exists now, and a gate that silently skips is worse
+      # than no gate. If the export breaks, this job must fail.
+      - run: npm run build:web
+      - name: Fail if the export produced nothing
+        run: |
+          test -f apps/mobile/dist/index.html
+          test -n "$(find apps/mobile/dist/_expo -name '*.js' -print -quit)"

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ blob-report/
 !.vscode/extensions.json
 !.vscode/settings.json
 .artifacts/
+
+# Expo web export output
+apps/*/dist/

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -8,7 +8,7 @@
     "web": "expo start --web",
     "android": "expo start --android",
     "ios": "expo start --ios",
-    "export:web": "expo export --platform web"
+    "export:web": "expo export --platform web --output-dir dist"
   },
   "dependencies": {
     "@expo/metro-runtime": "~57.0.15",

--- a/package.json
+++ b/package.json
@@ -14,16 +14,17 @@
     "tools/*"
   ],
   "scripts": {
-    "typecheck": "tsc --noEmit",
-    "lint": "eslint .",
-    "lint:fix": "eslint . --fix",
+    "build:web": "npm run export:web --workspace @occasio/mobile",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "preview:theme": "tsx tools/theme-preview/generate.ts",
     "test": "jest",
     "test:contracts": "jest --selectProjects contracts",
+    "typecheck": "tsc --noEmit",
     "verify": "npm run typecheck && npm run lint && npm run format:check && npm run verify:enforcement && npm test",
-    "verify:enforcement": "node tools/enforcement/verify-enforcement.mjs",
-    "preview:theme": "tsx tools/theme-preview/generate.ts"
+    "verify:enforcement": "node tools/enforcement/verify-enforcement.mjs"
   },
   "devDependencies": {
     "@eslint/js": "^9.37.0",


### PR DESCRIPTION
Closes #20.

## What changed

The `web-build` CI job ran `npm run build:web --if-present` against a script that did not exist. It passed having built nothing — a green tick that means nothing, which is worse than no gate because it reads as protection.

- `npm run build:web` exists and runs `expo export --platform web`
- `--if-present` removed, so a missing script fails loudly rather than skipping quietly
- The job asserts the export produced `index.html` and a JS bundle, rather than trusting a zero exit code

## Verified, not assumed

The issue's third criterion was "a `.native.ts` accidentally imported on web is caught". Rather than claim it, I probed it — a module existing only as `.native.ts`, imported from shared code:

```
Web Bundling failed
Error: Unable to resolve module ./thing from apps/mobile/src/__probe/use.ts
npm error code 1
```

Non-zero exit, so CI fails. Probe removed afterwards.

## Checks

- [x] `npm run verify` passes locally
- [x] Scoped to one issue — the Playwright harness stays in #21
- [x] Title is in conventional-commit form
- [x] No new architectural rules, so no new enforcement probe needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved web build validation to confirm successful exports and required output files.
  - Standardised the location of generated web export files.
  - Added safeguards to prevent generated web build output from being tracked in version control.
  - Maintained the existing project scripts while reorganising their presentation for consistency.
  - Build checks now report missing or unsuccessful web export commands more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->