### PR TITLE
ci: make the visual gate render every route for real

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
     name: Typecheck, lint & unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -36,8 +36,8 @@ jobs:
     name: Adapter contract tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -52,12 +52,14 @@ jobs:
     name: Visual regression across tenants
     runs-on: ubuntu-latest
     container:
-      # Must match the exact `playwright` version in package.json: the image ships browsers
-      # built for that client, and a mismatch fails at launch. Bump both together.
-      image: mcr.microsoft.com/playwright:v1.63.0-noble
+      # Pinned by digest, not tag: a tag is mutable, so an unpinned image means CI runs
+      # whatever was pushed there last. The digest below is v1.63.0-noble, which must match
+      # the exact `playwright` version in package.json -- the image ships browsers built for
+      # that client and a mismatch fails at launch. Bump the digest and the package together.
+      image: mcr.microsoft.com/playwright@sha256:eff16c30e6f3f4af0a03fa4b706120d5e9b0891c344a27d64559aff5900a4a27
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -65,7 +67,7 @@ jobs:
       # No --if-present. The script exists, and a gate that skips silently is not a gate.
       - name: Render every route at both widths, light and dark
         run: npm run test:visual
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         # Uploaded on success too: the screenshots are the point, not just the failures.
         if: always()
         with:
@@ -78,8 +80,8 @@ jobs:
     name: Web export build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,9 @@ jobs:
     name: Visual regression across tenants
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.56.0-noble
+      # Must match the exact `playwright` version in package.json: the image ships browsers
+      # built for that client, and a mismatch fails at launch. Bump both together.
+      image: mcr.microsoft.com/playwright:v1.63.0-noble
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -60,15 +62,15 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
       - run: npm ci
-      - name: Screenshot every fixture tenant in light and dark
-        run: npm run test:visual --if-present
+      # No --if-present. The script exists, and a gate that skips silently is not a gate.
+      - name: Render every route at both widths, light and dark
+        run: npm run test:visual
       - uses: actions/upload-artifact@v4
-        if: failure()
+        # Uploaded on success too: the screenshots are the point, not just the failures.
+        if: always()
         with:
-          name: visual-diffs
-          path: |
-            test-results/
-            playwright-report/
+          name: visual-screenshots
+          path: .artifacts/visual/
           retention-days: 7
 
   # D19 gate 4 — Metro and platform-split mistakes (a .native.ts reaching web).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,9 @@ jobs:
     name: Draft the release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with: { fetch-depth: 0 }
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           generate_release_notes: true
           draft: true

--- a/apps/mobile/src/features/placeholder/PlaceholderScreen.tsx
+++ b/apps/mobile/src/features/placeholder/PlaceholderScreen.tsx
@@ -19,7 +19,6 @@ type Props = {
  */
 export function PlaceholderScreen({ theme, eyebrow, title, description, arrivesIn }: Props) {
   const { color, type, space, radius, border } = theme;
-  console.error('probe: unhealthy route');
   return (
     <ScrollView
       style={{ backgroundColor: color.bg }}

--- a/apps/mobile/src/features/placeholder/PlaceholderScreen.tsx
+++ b/apps/mobile/src/features/placeholder/PlaceholderScreen.tsx
@@ -19,6 +19,7 @@ type Props = {
  */
 export function PlaceholderScreen({ theme, eyebrow, title, description, arrivesIn }: Props) {
   const { color, type, space, radius, border } = theme;
+  console.error('probe: unhealthy route');
   return (
     <ScrollView
       style={{ backgroundColor: color.bg }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "eslint-plugin-import": "^2.32.0",
         "globals": "^16.5.0",
         "jest": "^30.0.0",
+        "playwright": "1.63.0",
         "prettier": "^3.6.0",
         "tsx": "^4.23.13",
         "typescript": "^5.9.0",
@@ -12742,6 +12743,35 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.63.0.tgz",
+      "integrity": "sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.63.0.tgz",
+      "integrity": "sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/plist": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "preview:theme": "tsx tools/theme-preview/generate.ts",
     "test": "jest",
     "test:contracts": "jest --selectProjects contracts",
+    "test:visual": "npm run build:web && node tools/visual/capture.mjs",
     "typecheck": "tsc --noEmit",
     "verify": "npm run typecheck && npm run lint && npm run format:check && npm run verify:enforcement && npm test",
     "verify:enforcement": "node tools/enforcement/verify-enforcement.mjs"
@@ -40,6 +41,7 @@
     "eslint-plugin-import": "^2.32.0",
     "globals": "^16.5.0",
     "jest": "^30.0.0",
+    "playwright": "1.63.0",
     "prettier": "^3.6.0",
     "tsx": "^4.23.13",
     "typescript": "^5.9.0",

--- a/tools/visual/capture.mjs
+++ b/tools/visual/capture.mjs
@@ -52,56 +52,79 @@ const run = async () => {
   const failures = [];
   let shots = 0;
 
-  for (const viewport of VIEWPORTS) {
-    for (const scheme of SCHEMES) {
-      const context = await browser.newContext({
-        viewport: { width: viewport.width, height: viewport.height },
-        colorScheme: scheme,
-        deviceScaleFactor: 2,
-        reducedMotion: 'reduce',
-      });
-      for (const [path, name] of ROUTES) {
-        const page = await context.newPage();
-        const problems = [];
-        page.on('pageerror', (e) => problems.push(`threw: ${String(e).slice(0, 160)}`));
-        page.on('console', (m) => {
-          if (m.type() === 'error') problems.push(`console: ${m.text().slice(0, 160)}`);
+  try {
+    for (const viewport of VIEWPORTS) {
+      for (const scheme of SCHEMES) {
+        const context = await browser.newContext({
+          viewport: { width: viewport.width, height: viewport.height },
+          colorScheme: scheme,
+          deviceScaleFactor: 2,
+          reducedMotion: 'reduce',
         });
-        await page.goto(`http://127.0.0.1:${String(server.port)}${path}`, {
-          waitUntil: 'networkidle',
-        });
-        await page.waitForTimeout(400);
+        try {
+          for (const [path, name] of ROUTES) {
+            const page = await context.newPage();
+            const problems = [];
+            page.on('pageerror', (e) => problems.push(`threw: ${String(e).slice(0, 160)}`));
+            page.on('console', (m) => {
+              if (m.type() === 'error') problems.push(`console: ${m.text().slice(0, 160)}`);
+            });
 
-        const text = (
-          await page
-            .locator('body')
-            .innerText()
-            .catch(() => '')
-        ).trim();
-        if (text.length < 10) problems.push(`rendered ${String(text.length)} chars of text`);
+            /* A route that fails to navigate is a finding, not a reason to abandon the run.
+               Aborting here would leave later routes uncaptured, the manifest unwritten and
+               the browser and server leaked -- and would report one failure while hiding the
+               rest, which is the least useful way for a gate to fail. */
+            try {
+              await page.goto(`http://127.0.0.1:${String(server.port)}${path}`, {
+                waitUntil: 'networkidle',
+                timeout: 30_000,
+              });
+              await page.waitForTimeout(400);
 
-        const file = join(OUT, `${name}-${viewport.name}-${scheme}.png`);
-        await page.screenshot({ path: file });
-        shots += 1;
-        if (problems.length > 0)
-          failures.push(`${path} [${viewport.name}/${scheme}] ${problems[0]}`);
-        await page.close();
+              const text = (
+                await page
+                  .locator('body')
+                  .innerText()
+                  .catch(() => '')
+              ).trim();
+              if (text.length < 10) problems.push(`rendered ${String(text.length)} chars of text`);
+
+              await page.screenshot({ path: join(OUT, `${name}-${viewport.name}-${scheme}.png`) });
+              shots += 1;
+            } catch (error) {
+              problems.push(`navigation failed: ${String(error).slice(0, 160)}`);
+            } finally {
+              await page.close();
+            }
+
+            if (problems.length > 0) {
+              failures.push(`${path} [${viewport.name}/${scheme}] ${problems[0]}`);
+            }
+          }
+        } finally {
+          await context.close();
+        }
       }
-      await context.close();
     }
+  } finally {
+    await browser.close();
+    await server.close();
+    writeFileSync(
+      join(OUT, 'manifest.json'),
+      JSON.stringify(
+        {
+          routes: ROUTES.length,
+          viewports: VIEWPORTS.length,
+          schemes: SCHEMES.length,
+          expected: ROUTES.length * VIEWPORTS.length * SCHEMES.length,
+          shots,
+          failures,
+        },
+        null,
+        2,
+      ),
+    );
   }
-
-  await browser.close();
-  await server.close();
-
-  writeFileSync(
-    join(OUT, 'manifest.json'),
-    JSON.stringify(
-      { routes: ROUTES.length, viewports: VIEWPORTS.length, schemes: SCHEMES.length, shots },
-      null,
-      2,
-    ),
-  );
 
   console.log(`captured ${String(shots)} screenshots into ${OUT}`);
   if (failures.length > 0) {

--- a/tools/visual/capture.mjs
+++ b/tools/visual/capture.mjs
@@ -113,8 +113,11 @@ const run = async () => {
       }
     }
   } finally {
-    await browser?.close();
-    await server?.close();
+    /* Each cleanup step is independent. A browser.close() rejection -- which is exactly what a
+       crashed or disconnected browser produces -- must not stop the server closing or the
+       manifest being written, because a crashed run is when that evidence matters most. */
+    await browser?.close().catch(() => undefined);
+    await server?.close().catch(() => undefined);
     writeFileSync(
       join(OUT, 'manifest.json'),
       JSON.stringify(

--- a/tools/visual/capture.mjs
+++ b/tools/visual/capture.mjs
@@ -1,0 +1,115 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { chromium } from 'playwright';
+import { serve } from './serve.mjs';
+
+/**
+ * The `visual` CI gate (D19).
+ *
+ * Renders every route at phone and desktop widths in both colour schemes, and fails on a page
+ * that throws, logs an error, or comes back visually empty. Screenshots are written for a human
+ * to look at and are uploaded by CI when the job fails.
+ *
+ * This captures; it does not yet diff against committed baselines — that is #90. Baselines are
+ * deliberately deferred until the UI is real: committing them now, against placeholder screens
+ * that v0.2 replaces wholesale, would train everyone to re-approve snapshots reflexively, which
+ * is how a visual gate stops meaning anything.
+ */
+
+const DIST = 'apps/mobile/dist';
+const OUT = '.artifacts/visual';
+
+/** Grows as fixtures land (#26 onward); today the app resolves a single theme. */
+const TENANTS = ['santi-riyanks'];
+
+const ROUTES = [
+  ['/', 'index'],
+  ['/discover', 'discover'],
+  ['/join', 'join'],
+  ['/no-such-page', 'not-found'],
+  ...TENANTS.flatMap((t) => [
+    [`/e/${t}`, `${t}-home`],
+    [`/e/${t}/schedule`, `${t}-schedule`],
+    [`/e/${t}/gossips`, `${t}-gossips`],
+    [`/e/${t}/tasks`, `${t}-tasks`],
+    [`/e/${t}/info`, `${t}-info`],
+    [`/e/${t}/theme`, `${t}-admin-theme`],
+  ]),
+];
+
+const VIEWPORTS = [
+  { name: 'phone', width: 390, height: 844 },
+  { name: 'desktop', width: 1440, height: 900 },
+];
+const SCHEMES = ['light', 'dark'];
+
+const run = async () => {
+  rmSync(OUT, { recursive: true, force: true });
+  mkdirSync(OUT, { recursive: true });
+
+  const server = await serve(DIST);
+  const browser = await chromium.launch();
+  const failures = [];
+  let shots = 0;
+
+  for (const viewport of VIEWPORTS) {
+    for (const scheme of SCHEMES) {
+      const context = await browser.newContext({
+        viewport: { width: viewport.width, height: viewport.height },
+        colorScheme: scheme,
+        deviceScaleFactor: 2,
+        reducedMotion: 'reduce',
+      });
+      for (const [path, name] of ROUTES) {
+        const page = await context.newPage();
+        const problems = [];
+        page.on('pageerror', (e) => problems.push(`threw: ${String(e).slice(0, 160)}`));
+        page.on('console', (m) => {
+          if (m.type() === 'error') problems.push(`console: ${m.text().slice(0, 160)}`);
+        });
+        await page.goto(`http://127.0.0.1:${String(server.port)}${path}`, {
+          waitUntil: 'networkidle',
+        });
+        await page.waitForTimeout(400);
+
+        const text = (
+          await page
+            .locator('body')
+            .innerText()
+            .catch(() => '')
+        ).trim();
+        if (text.length < 10) problems.push(`rendered ${String(text.length)} chars of text`);
+
+        const file = join(OUT, `${name}-${viewport.name}-${scheme}.png`);
+        await page.screenshot({ path: file });
+        shots += 1;
+        if (problems.length > 0)
+          failures.push(`${path} [${viewport.name}/${scheme}] ${problems[0]}`);
+        await page.close();
+      }
+      await context.close();
+    }
+  }
+
+  await browser.close();
+  await server.close();
+
+  writeFileSync(
+    join(OUT, 'manifest.json'),
+    JSON.stringify(
+      { routes: ROUTES.length, viewports: VIEWPORTS.length, schemes: SCHEMES.length, shots },
+      null,
+      2,
+    ),
+  );
+
+  console.log(`captured ${String(shots)} screenshots into ${OUT}`);
+  if (failures.length > 0) {
+    console.error(`\n${String(failures.length)} route(s) did not render cleanly:`);
+    for (const f of failures) console.error(`  ${f}`);
+    process.exit(1);
+  }
+  console.log('every route rendered cleanly');
+};
+
+await run();

--- a/tools/visual/capture.mjs
+++ b/tools/visual/capture.mjs
@@ -47,12 +47,18 @@ const run = async () => {
   rmSync(OUT, { recursive: true, force: true });
   mkdirSync(OUT, { recursive: true });
 
-  const server = await serve(DIST);
-  const browser = await chromium.launch();
   const failures = [];
   let shots = 0;
+  /* Declared before the try so cleanup can run even when setup is what failed: if
+     chromium.launch() rejects after the server is listening, an outer try that starts
+     below it never runs, the port stays open and no manifest is written. */
+  let server;
+  let browser;
 
   try {
+    server = await serve(DIST);
+    browser = await chromium.launch();
+
     for (const viewport of VIEWPORTS) {
       for (const scheme of SCHEMES) {
         const context = await browser.newContext({
@@ -107,8 +113,8 @@ const run = async () => {
       }
     }
   } finally {
-    await browser.close();
-    await server.close();
+    await browser?.close();
+    await server?.close();
     writeFileSync(
       join(OUT, 'manifest.json'),
       JSON.stringify(

--- a/tools/visual/serve.mjs
+++ b/tools/visual/serve.mjs
@@ -3,10 +3,16 @@ import { createServer } from 'node:http';
 import { extname, join, normalize } from 'node:path';
 
 const TYPES = {
-  '.html': 'text/html; charset=utf-8', '.js': 'text/javascript; charset=utf-8',
-  '.css': 'text/css; charset=utf-8', '.json': 'application/json; charset=utf-8',
-  '.png': 'image/png', '.jpg': 'image/jpeg', '.svg': 'image/svg+xml',
-  '.ttf': 'font/ttf', '.woff2': 'font/woff2', '.ico': 'image/x-icon',
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.svg': 'image/svg+xml',
+  '.ttf': 'font/ttf',
+  '.woff2': 'font/woff2',
+  '.ico': 'image/x-icon',
 };
 
 /**
@@ -48,6 +54,7 @@ export const serve = (root, port = 0) => {
       stream.pipe(res);
     });
     server.listen(port, '127.0.0.1', () =>
-      resolve({ port: server.address().port, close: () => new Promise((r) => server.close(r)) }));
+      resolve({ port: server.address().port, close: () => new Promise((r) => server.close(r)) }),
+    );
   });
 };

--- a/tools/visual/serve.mjs
+++ b/tools/visual/serve.mjs
@@ -1,37 +1,53 @@
-import { createReadStream, existsSync, statSync } from 'node:fs';
+import { createReadStream, existsSync, readFileSync, statSync } from 'node:fs';
 import { createServer } from 'node:http';
 import { extname, join, normalize } from 'node:path';
 
 const TYPES = {
-  '.html': 'text/html; charset=utf-8',
-  '.js': 'text/javascript; charset=utf-8',
-  '.css': 'text/css; charset=utf-8',
-  '.json': 'application/json; charset=utf-8',
-  '.png': 'image/png',
-  '.jpg': 'image/jpeg',
-  '.svg': 'image/svg+xml',
-  '.ttf': 'font/ttf',
-  '.woff2': 'font/woff2',
-  '.ico': 'image/x-icon',
+  '.html': 'text/html; charset=utf-8', '.js': 'text/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8', '.json': 'application/json; charset=utf-8',
+  '.png': 'image/png', '.jpg': 'image/jpeg', '.svg': 'image/svg+xml',
+  '.ttf': 'font/ttf', '.woff2': 'font/woff2', '.ico': 'image/x-icon',
 };
 
 /**
  * Static server with an SPA fallback.
  *
- * `web.output` is "single", so every unknown path has to serve index.html — exactly what a
- * host has to be configured to do in production. A plain file server 404s on /e/some-event,
- * which would make the whole harness test nothing but the index route.
+ * `web.output` is "single", so every unknown path has to serve index.html — exactly what a host
+ * has to be configured to do in production. A plain file server 404s on /e/some-event, which
+ * would make the harness test nothing but the index route.
+ *
+ * Two robustness details, both learned the hard way: the shell is read once at startup rather
+ * than re-opened per request (a rebuild mid-run otherwise makes it vanish), and stream errors
+ * are answered rather than thrown — an unhandled 'error' event takes down the whole process and
+ * surfaces as a confusing route failure instead of a server failure.
  */
-export const serve = (root, port = 0) =>
-  new Promise((resolve) => {
+export const serve = (root, port = 0) => {
+  const shellPath = join(root, 'index.html');
+  if (!existsSync(shellPath)) {
+    throw new Error(`No ${shellPath}. Run the web build before capturing.`);
+  }
+  const shell = readFileSync(shellPath);
+
+  return new Promise((resolve) => {
     const server = createServer((req, res) => {
       const url = new URL(req.url ?? '/', 'http://localhost');
-      let file = join(root, normalize(decodeURIComponent(url.pathname)));
-      if (!existsSync(file) || statSync(file).isDirectory()) file = join(root, 'index.html');
+      const file = join(root, normalize(decodeURIComponent(url.pathname)));
+
+      const isFile = file.startsWith(root) && existsSync(file) && !statSync(file).isDirectory();
+      if (!isFile) {
+        res.writeHead(200, { 'content-type': TYPES['.html'] });
+        res.end(shell);
+        return;
+      }
+
       res.writeHead(200, { 'content-type': TYPES[extname(file)] ?? 'application/octet-stream' });
-      createReadStream(file).pipe(res);
+      const stream = createReadStream(file);
+      stream.on('error', () => {
+        res.end();
+      });
+      stream.pipe(res);
     });
     server.listen(port, '127.0.0.1', () =>
-      resolve({ port: server.address().port, close: () => new Promise((r) => server.close(r)) }),
-    );
+      resolve({ port: server.address().port, close: () => new Promise((r) => server.close(r)) }));
   });
+};

--- a/tools/visual/serve.mjs
+++ b/tools/visual/serve.mjs
@@ -1,0 +1,37 @@
+import { createReadStream, existsSync, statSync } from 'node:fs';
+import { createServer } from 'node:http';
+import { extname, join, normalize } from 'node:path';
+
+const TYPES = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.svg': 'image/svg+xml',
+  '.ttf': 'font/ttf',
+  '.woff2': 'font/woff2',
+  '.ico': 'image/x-icon',
+};
+
+/**
+ * Static server with an SPA fallback.
+ *
+ * `web.output` is "single", so every unknown path has to serve index.html — exactly what a
+ * host has to be configured to do in production. A plain file server 404s on /e/some-event,
+ * which would make the whole harness test nothing but the index route.
+ */
+export const serve = (root, port = 0) =>
+  new Promise((resolve) => {
+    const server = createServer((req, res) => {
+      const url = new URL(req.url ?? '/', 'http://localhost');
+      let file = join(root, normalize(decodeURIComponent(url.pathname)));
+      if (!existsSync(file) || statSync(file).isDirectory()) file = join(root, 'index.html');
+      res.writeHead(200, { 'content-type': TYPES[extname(file)] ?? 'application/octet-stream' });
+      createReadStream(file).pipe(res);
+    });
+    server.listen(port, '127.0.0.1', () =>
+      resolve({ port: server.address().port, close: () => new Promise((r) => server.close(r)) }),
+    );
+  });


### PR DESCRIPTION
Closes #21.

> **Stacked on #105** (`feat/20-web-build`) — it needs `build:web`. Review #105 first.

## What changed

The `visual` job ran `npm run test:visual --if-present` against a script that did not exist, so it pulled a 2GB container to do nothing and reported green.

There is now a real harness:

- Exports the web build, then serves it **with an SPA fallback**. `web.output` is `single`, so a plain file server 404s on everything but `/` — the gate would have tested one route and called it coverage.
- Renders **10 routes × 2 widths (390 / 1440) × 2 colour schemes = 40 screenshots**
- **Fails** on a route that throws, logs a console error, or renders visually empty
- CI uploads the screenshots on success *and* failure — the screenshots are the point, not just the diffs

## Verified it can fail

Injecting a `console.error` into the shared placeholder component was caught and reported against every affected route. Probe removed.

## A pin that was already wrong

The container was `v1.56.0-noble` while the installed client is `1.63.0`. The image ships browsers built for its own client version, so this job would have failed at launch the first time it did real work — the exact drift the pinning existed to prevent, sitting undetected because the job never ran anything.

Both are `1.63.0` now, `playwright` is pinned **exactly** rather than with a caret, and the workflow says in a comment that they move together.

## What this deliberately does not do

It does not diff against committed baselines. That is **#90**, and it is deferred on purpose: baselines taken against placeholder screens that v0.2 replaces wholesale would train everyone to re-approve snapshots reflexively, which is precisely how a visual gate stops meaning anything.

Tenant coverage is one event today because fixtures do not exist yet; `TENANTS` in the harness is a list that grows when the data layer lands.

## Checks

- [x] `npm run verify` passes locally
- [x] Scoped to one issue
- [x] Title is in conventional-commit form
- [x] No new architectural rules, so no new enforcement probe needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added automated visual checks across mobile and desktop layouts, including light and dark display modes.
  - Visual checks capture screenshots and report page, browser-console and content-rendering issues.
  - Added coverage for configured web routes using a local preview server.

- **Chores**
  - Improved the reliability and reproducibility of verification and release workflows by locking tooling to known versions.
  - Visual test screenshots are now consistently retained for review when checks run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->