### PR TITLE
chore: keep agent worktrees out of the tooling's sight

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ blob-report/
 
 # Expo web export output
 apps/*/dist/
+
+# Agent worktrees live here
+.claude/

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,4 @@ coverage
 *.tsbuildinfo
 .expo
 web-build
+.claude

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -49,6 +49,8 @@ export default tseslint.config(
   {
     ignores: [
       '**/node_modules/**',
+      // Worktrees are copies of this repo; linting them lints everything twice.
+      '.claude/**',
       '**/dist/**',
       '**/build/**',
       '**/coverage/**',

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -16,6 +16,11 @@ const transform = {
 
 export default {
   passWithNoTests: true,
+  /* Agent worktrees are created at .claude/worktrees/<name>/, inside the repo. Each contains a
+     full copy of every workspace package, so Metro's Haste map — which Jest shares — finds
+     several modules claiming the name `@occasio/theme` and refuses to resolve any of them.
+     Invisible until someone runs a git worktree, then it breaks every suite at once. */
+  modulePathIgnorePatterns: ['<rootDir>/.claude/'],
   projects: [
     {
       displayName: 'unit',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,5 +19,6 @@
     "apps/*/app/**/*",
     "apps/*/*.d.ts",
     "tools/**/*.ts"
-  ]
+  ],
+  "exclude": [".claude", "node_modules"]
 }


### PR DESCRIPTION
Closes #112.

## What changed

`git worktree` puts working copies under `.claude/worktrees/<name>/`, **inside** the repo. Each holds a full copy of every workspace package, so the Haste map Jest shares with Metro found three modules claiming `@occasio/theme` and refused to resolve any of them:

```
The name `@occasio/theme` was looked up in the Haste module map. It cannot be
resolved, because there exists several different files, or packages, that
provide a module for that particular name and platform.
```

Every suite failed at once, with an error that names the symptom and not the cause.

Jest, ESLint, Prettier, TypeScript and git now all ignore `.claude/`.

## Why it is separate

It blocks all local work, and it has nothing to do with any feature currently in flight — folding it into an unrelated PR is exactly what the out-of-scope check exists to catch.

## Checks

- [x] `npm run verify` passes locally — 27 tests across 5 suites, which is what was broken
- [x] Scoped to one issue
- [x] Title is in conventional-commit form
- [x] No new architectural rules, so no new enforcement probe needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Excluded internal worktree files from formatting, linting, testing, and TypeScript processing.
  - Prevented duplicated workspace copies from affecting development checks.
  - Updated repository ignore rules to keep these files out of version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->