### PR TITLE
fix(ci): apply the worktree ignore where Jest actually reads it

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -10,17 +10,24 @@ const moduleNameMapper = {
   '^@occasio/([^/]+)/(.*)$': '<rootDir>/packages/$1/src/$2',
 };
 
+/*
+ * Agent worktrees are created at .claude/worktrees/<name>/, inside the repo, each holding a
+ * full copy of every workspace package. The Haste map Jest shares with Metro then finds several
+ * packages claiming `@occasio/theme` and refuses to resolve any of them.
+ *
+ * This MUST live inside each project. Jest does not pass top-level options down to `projects`,
+ * so setting it alongside `projects` silently does nothing — which is exactly what happened the
+ * first time, and it looked fixed because the only suite importing a workspace package by name
+ * was not running at that moment.
+ */
+const modulePathIgnorePatterns = ['<rootDir>/.claude/'];
+
 const transform = {
   '^.+\\.(t|j)sx?$': ['@swc/jest', { jsc: { parser: { syntax: 'typescript', tsx: true } } }],
 };
 
 export default {
   passWithNoTests: true,
-  /* Agent worktrees are created at .claude/worktrees/<name>/, inside the repo. Each contains a
-     full copy of every workspace package, so Metro's Haste map — which Jest shares — finds
-     several modules claiming the name `@occasio/theme` and refuses to resolve any of them.
-     Invisible until someone runs a git worktree, then it breaks every suite at once. */
-  modulePathIgnorePatterns: ['<rootDir>/.claude/'],
   projects: [
     {
       displayName: 'unit',
@@ -33,6 +40,7 @@ export default {
       ],
       testPathIgnorePatterns: ['\\.contract\\.test\\.'],
       moduleNameMapper,
+      modulePathIgnorePatterns,
       transform,
     },
     {
@@ -40,6 +48,7 @@ export default {
       rootDir: '.',
       testMatch: ['<rootDir>/packages/*/src/**/*.contract.test.ts'],
       moduleNameMapper,
+      modulePathIgnorePatterns,
       transform,
     },
   ],


### PR DESCRIPTION
Closes #112, properly this time.

## What was wrong with the previous fix

#113 set `modulePathIgnorePatterns` at the **top level** of `jest.config.mjs`, alongside `projects`. Jest does not pass top-level options down to projects, so the option was inert and the Haste collision remained:

```
The name `@occasio/theme` was looked up in the Haste module map...
  * .claude/worktrees/agent-a/packages/theme/package.json
  * .claude/worktrees/agent-b/packages/theme/package.json
  * packages/theme/package.json
```

## Why I did not catch it

My verification was against a tree that could not reproduce the bug. The only suite importing a workspace package **by name** was stashed at the time; every other suite uses relative imports, so nothing tripped the collision. `npm run verify` went green and I merged.

That is the same failure this repo keeps finding in its own gates — a check that passes because it never exercised the thing it was supposed to check.

## The fix

The option now lives **inside each project**, declared once and spread into both so they cannot drift, with a comment saying why it must not move back up.

## Verified properly

With both agent worktrees still on disk, a probe importing `@occasio/theme` by package name:

```
before:  Haste module map collision, suite failed to run
after:   Tests: 3 passed, 3 total
```

## Checks

- [x] `npm run verify` passes locally
- [x] Scoped to one issue
- [x] Title is in conventional-commit form
- [x] No new architectural rules, so no new enforcement probe needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration to exclude Claude worktree directories from module resolution in unit and contract test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->