### PR TITLE
feat(ui): publish theme tokens as CSS variables on web

### DIFF
--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,6 +1,8 @@
 export { ThemeProvider, ThemeContext } from './theme/ThemeProvider';
 export { useTheme } from './theme/useTheme';
 export { createStyles } from './theme/createStyles';
+export { ThemeScope } from './theme/ThemeScope';
+export { toCssVars } from './theme/cssVars';
 export { createStyleCache, DEFAULT_MAX_THEMES, type StyleCache } from './theme/styleCache';
 
 export const UI_PACKAGE_VERSION = '0.0.0' as const;

--- a/packages/ui/src/theme/ThemeProvider.tsx
+++ b/packages/ui/src/theme/ThemeProvider.tsx
@@ -1,5 +1,6 @@
 import { resolveTheme, type ResolvedTheme, type Scheme, type ThemeInput } from '@occasio/theme';
 import { createContext, useMemo, type ReactNode } from 'react';
+import { ThemeScope } from './ThemeScope';
 
 /**
  * Supplies the resolved theme to a subtree.
@@ -38,5 +39,9 @@ export function ThemeProvider({
     [input, systemScheme, forceScheme, reducedMotion],
   );
 
-  return <ThemeContext.Provider value={theme}>{children}</ThemeContext.Provider>;
+  return (
+    <ThemeContext.Provider value={theme}>
+      <ThemeScope theme={theme}>{children}</ThemeScope>
+    </ThemeContext.Provider>
+  );
 }

--- a/packages/ui/src/theme/ThemeScope.tsx
+++ b/packages/ui/src/theme/ThemeScope.tsx
@@ -1,0 +1,18 @@
+import type { ResolvedTheme } from '@occasio/theme';
+import type { ReactNode } from 'react';
+
+type Props = {
+  readonly theme: ResolvedTheme;
+  readonly children: ReactNode;
+};
+
+/**
+ * Native (and the default): a pass-through.
+ *
+ * CSS custom properties have no meaning outside the DOM, and wrapping every themed subtree in
+ * an extra View on native would add a layout node for nothing. The web variant lives in
+ * ThemeScope.web.tsx; Metro picks it automatically.
+ */
+export function ThemeScope({ children }: Props) {
+  return <>{children}</>;
+}

--- a/packages/ui/src/theme/ThemeScope.web.tsx
+++ b/packages/ui/src/theme/ThemeScope.web.tsx
@@ -1,0 +1,24 @@
+import type { ResolvedTheme } from '@occasio/theme';
+import type { CSSProperties, ReactNode } from 'react';
+import { toCssVars } from './cssVars';
+
+type Props = {
+  readonly theme: ResolvedTheme;
+  readonly children: ReactNode;
+};
+
+/**
+ * Web: publishes the theme's tokens as CSS custom properties on a scope element.
+ *
+ * Scoped to an element rather than `document.documentElement` so nesting works: a nested
+ * ThemeProvider gets its own scope, and CSS inside it resolves to that theme's values. Writing
+ * to the document root would mean the last provider to mount silently wins, which would break
+ * the theme editor's preview in a way nobody would attribute to CSS variables.
+ *
+ * `display: contents` keeps the wrapper out of layout entirely — it exists to carry variables,
+ * not to affect the box model.
+ */
+export function ThemeScope({ theme, children }: Props) {
+  const style: CSSProperties = { display: 'contents', ...toCssVars(theme) };
+  return <div style={style}>{children}</div>;
+}

--- a/packages/ui/src/theme/cssVars.test.ts
+++ b/packages/ui/src/theme/cssVars.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from '@jest/globals';
+import { resolveTheme, themeInputFromPreset } from '@occasio/theme';
+import { toCssVars } from './cssVars';
+
+const theme = resolveTheme(themeInputFromPreset('romantic', '#7C3A5A'), { forceScheme: 'light' });
+const vars = toCssVars(theme);
+
+describe('toCssVars', () => {
+  it('emits every name as a CSS custom property', () => {
+    const wrong = Object.keys(vars).filter((k) => !k.startsWith('--occasio-'));
+    expect(wrong).toEqual([]);
+  });
+
+  it('carries the resolved values through unchanged rather than recomputing them', () => {
+    expect(vars['--occasio-color-brand']).toBe(theme.color.brand);
+    expect(vars['--occasio-color-interactive-hover']).toBe(theme.color.interactive.hover);
+    expect(vars['--occasio-ramp-brand-9']).toBe(theme.color.ramp.brand[8]);
+  });
+
+  it('gives numeric tokens CSS units, since a bare number is invalid in CSS', () => {
+    expect(vars['--occasio-radius-lg']).toBe(`${String(theme.radius.lg)}px`);
+    expect(vars['--occasio-space-4']).toBe(`${String(theme.space(4))}px`);
+    expect(vars['--occasio-motion-base']).toBe(`${String(theme.motion.base)}ms`);
+  });
+
+  it('flattens the nested colour object rather than emitting "[object Object]"', () => {
+    /* theme.color contains `interactive` and `ramp`, which are objects. Naive iteration
+       stringifies them into unusable values. */
+    expect(Object.values(vars)).not.toContain('[object Object]');
+    expect(vars['--occasio-color-interactive']).toBeUndefined();
+    expect(vars['--occasio-color-ramp']).toBeUndefined();
+  });
+
+  it('produces different values for different tenants', () => {
+    const other = toCssVars(
+      resolveTheme(themeInputFromPreset('festival', '#E8582B'), { forceScheme: 'dark' }),
+    );
+    expect(other['--occasio-color-brand']).not.toBe(vars['--occasio-color-brand']);
+  });
+});

--- a/packages/ui/src/theme/cssVars.test.ts
+++ b/packages/ui/src/theme/cssVars.test.ts
@@ -31,6 +31,37 @@ describe('toCssVars', () => {
     expect(vars['--occasio-color-ramp']).toBeUndefined();
   });
 
+  it('emits every token group, not just colour', () => {
+    /* A partial mirror is a trap: CSS that reaches for a missing token silently renders
+       nothing, and the omission is invisible until someone writes that rule. */
+    for (const name of [
+      '--occasio-border-hairline',
+      '--occasio-type-display1-size',
+      '--occasio-type-overline-weight',
+      '--occasio-image-hero-aspect',
+      '--occasio-motion-fast',
+      '--occasio-breakpoint-md',
+    ]) {
+      expect(vars[name]).toBeDefined();
+    }
+  });
+
+  it('leaves aspect-ratio unitless, because CSS aspect-ratio takes a number', () => {
+    expect(vars['--occasio-image-hero-aspect']).not.toContain('px');
+    expect(Number.isNaN(Number(vars['--occasio-image-hero-aspect']))).toBe(false);
+  });
+
+  it('collapses durations to zero when motion is off', () => {
+    const still = toCssVars(
+      resolveTheme(themeInputFromPreset('minimal', '#3F5B7C'), {
+        forceScheme: 'light',
+        reducedMotion: true,
+      }),
+    );
+    expect(still['--occasio-motion-enabled']).toBe('0');
+    expect(still['--occasio-motion-base']).toBe('0ms');
+  });
+
   it('produces different values for different tenants', () => {
     const other = toCssVars(
       resolveTheme(themeInputFromPreset('festival', '#E8582B'), { forceScheme: 'dark' }),

--- a/packages/ui/src/theme/cssVars.ts
+++ b/packages/ui/src/theme/cssVars.ts
@@ -40,12 +40,50 @@ export const toCssVars = (theme: ResolvedTheme): Readonly<Record<string, string>
     vars[`${PREFIX}-space-${String(step)}`] = `${String(theme.space(step))}px`;
   }
 
-  vars[`${PREFIX}-font-display`] = theme.type.family.display;
-  vars[`${PREFIX}-font-body`] = theme.type.family.body;
+  for (const [name, value] of Object.entries(theme.border)) {
+    vars[`${PREFIX}-border-${name}`] = `${String(value)}px`;
+  }
+
+  /* The full type scale, so CSS can set text without duplicating the numbers. Families are
+     emitted with a fallback stack, since a tenant font may still be loading (#31). */
+  vars[`${PREFIX}-font-display`] = `${theme.type.family.display}, Georgia, serif`;
+  vars[`${PREFIX}-font-body`] = `${theme.type.family.body}, system-ui, sans-serif`;
+  vars[`${PREFIX}-font-mono`] = `${theme.type.family.mono}, ui-monospace, monospace`;
+  for (const role of [
+    'display1',
+    'display2',
+    'title1',
+    'title2',
+    'body',
+    'bodyStrong',
+    'caption',
+    'overline',
+  ] as const) {
+    const token = theme.type[role];
+    vars[`${PREFIX}-type-${role}-size`] = `${String(token.fontSize)}px`;
+    vars[`${PREFIX}-type-${role}-line-height`] = `${String(token.lineHeight)}px`;
+    vars[`${PREFIX}-type-${role}-tracking`] = `${String(token.letterSpacing)}px`;
+    vars[`${PREFIX}-type-${role}-weight`] = token.fontWeight;
+  }
+
+  /* Unitless on purpose: this is a CSS `aspect-ratio`, which takes a number. */
+  vars[`${PREFIX}-image-hero-aspect`] = String(theme.image.heroAspect);
+  vars[`${PREFIX}-image-radius`] = `${String(theme.image.radius)}px`;
+  vars[`${PREFIX}-image-treatment`] = theme.image.treatment;
   vars[`${PREFIX}-scrim-from`] = theme.image.scrimGradient[0];
   vars[`${PREFIX}-scrim-to`] = theme.image.scrimGradient[1];
+
+  /* Durations collapse to 0ms when motion is off, so a CSS transition honours reduced motion
+     without every rule having to check a flag. */
+  vars[`${PREFIX}-motion-enabled`] = theme.motion.enabled ? '1' : '0';
+  vars[`${PREFIX}-motion-fast`] = `${String(theme.motion.fast)}ms`;
   vars[`${PREFIX}-motion-base`] = `${String(theme.motion.base)}ms`;
+  vars[`${PREFIX}-motion-slow`] = `${String(theme.motion.slow)}ms`;
+
   vars[`${PREFIX}-max-content-width`] = `${String(theme.layout.maxContentWidth)}px`;
+  for (const [name, value] of Object.entries(theme.layout.breakpoints)) {
+    vars[`${PREFIX}-breakpoint-${name}`] = `${String(value)}px`;
+  }
 
   return vars;
 };

--- a/packages/ui/src/theme/cssVars.ts
+++ b/packages/ui/src/theme/cssVars.ts
@@ -1,0 +1,51 @@
+import type { ResolvedTheme } from '@occasio/theme';
+
+/**
+ * Flattens a resolved theme into CSS custom properties.
+ *
+ * React Native styles cannot express gradients, `backdrop-filter`, `::selection`, scrollbar
+ * styling or print rules. Mirroring the tokens into CSS variables costs almost nothing and
+ * unlocks all of that on web without a second source of truth — the values still come from the
+ * resolver, they are merely also readable from CSS.
+ *
+ * Pure and DOM-free so the mapping is testable directly rather than through a rendered tree.
+ */
+
+const PREFIX = '--occasio';
+
+export const toCssVars = (theme: ResolvedTheme): Readonly<Record<string, string>> => {
+  const vars: Record<string, string> = {};
+
+  for (const [name, value] of Object.entries(theme.color)) {
+    if (typeof value === 'string') vars[`${PREFIX}-color-${name}`] = value;
+  }
+  for (const [name, value] of Object.entries(theme.color.interactive)) {
+    vars[`${PREFIX}-color-interactive-${name}`] = value;
+  }
+  theme.color.ramp.brand.forEach((step, i) => {
+    vars[`${PREFIX}-ramp-brand-${String(i + 1)}`] = step;
+  });
+  theme.color.ramp.neutral.forEach((step, i) => {
+    vars[`${PREFIX}-ramp-neutral-${String(i + 1)}`] = step;
+  });
+  theme.color.ramp.accent.forEach((step, i) => {
+    vars[`${PREFIX}-ramp-accent-${String(i + 1)}`] = step;
+  });
+
+  for (const [name, value] of Object.entries(theme.radius)) {
+    vars[`${PREFIX}-radius-${name}`] = `${String(value)}px`;
+  }
+  /* space() is a function, so the scale is emitted as the steps a stylesheet can actually use. */
+  for (const step of [1, 2, 3, 4, 5, 6, 8, 10, 12]) {
+    vars[`${PREFIX}-space-${String(step)}`] = `${String(theme.space(step))}px`;
+  }
+
+  vars[`${PREFIX}-font-display`] = theme.type.family.display;
+  vars[`${PREFIX}-font-body`] = theme.type.family.body;
+  vars[`${PREFIX}-scrim-from`] = theme.image.scrimGradient[0];
+  vars[`${PREFIX}-scrim-to`] = theme.image.scrimGradient[1];
+  vars[`${PREFIX}-motion-base`] = `${String(theme.motion.base)}ms`;
+  vars[`${PREFIX}-max-content-width`] = `${String(theme.layout.maxContentWidth)}px`;
+
+  return vars;
+};


### PR DESCRIPTION
Closes #23.

## What changed

The resolved theme is now also published as CSS custom properties on web. React Native styles cannot express gradients, `backdrop-filter`, `::selection`, scrollbar styling or print rules; this unlocks all of it without a second source of truth, since the values still come from the resolver.

**Scoped to an element, not `document.documentElement`.** Nesting is load-bearing — writing to the document root would mean the last provider to mount silently wins, breaking the theme editor's preview in a way nobody would attribute to CSS variables. `display: contents` keeps the wrapper out of layout, and native gets a pass-through since custom properties mean nothing off the DOM.

## Verified in a browser, not asserted

```json
{ "scopeCount": 2,
  "scopes": [
    { "brand": "#6b89ac", "display": "contents", "nestedInsideAnother": false, "varCount": 90 },
    { "brand": "#b46c8d", "display": "contents", "nestedInsideAnother": true,  "varCount": 90 }]}
```

Outer is the console theme, inner the tenant theme, correctly nested — the nesting guarantee demonstrated in the DOM rather than argued from React semantics.

**My first probe was wrong, which is worth recording.** It filtered on *computed* style and reported 30 scopes with identical values. Custom properties inherit, so every descendant reports them; the probe measured inheritance, not scoping, and would have "passed" even if nesting were broken. Filtering on inline declarations gives the real answer.

`toCssVars` is pure and DOM-free so the mapping is unit-tested, including the trap that `theme.color` contains nested `interactive` and `ramp` objects that naive iteration turns into a useless string.

## Checks

- [x] `npm run verify` — 32 tests across 6 suites
- [x] `npm run test:visual` — 40 routes render clean with the scope element in place
- [x] Scoped to one issue
- [x] Title is in conventional-commit form
- [x] No new architectural rules, so no new enforcement probe needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scoped theme support that applies resolved theme values without affecting page layout.
  * Added CSS custom property generation for colours, spacing, typography, borders, motion, images, and content sizing.
  * Made theme scoping and CSS variable utilities publicly available for broader customisation.

* **Tests**
  * Added coverage for CSS variable naming, resolved values, units, nested colours, motion settings, and tenant-specific themes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->