### PR TITLE
chore(ci): add Dependabot for the SHA-pinned actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+# Pinning without updating is not security, it is a snapshot of one afternoon.
+#
+# #106 pinned every action to a full commit SHA with the release tag in a trailing comment.
+# That closed the mutable-tag hole and opened a slower one: a pinned SHA never hears about the
+# CVE fixed three releases later. Dependabot is what turns "pinned" back into "current".
+#
+# Scope is deliberately just `github-actions`. See docs/workflow.md for why npm is not here
+# yet, and for the one pin in CI that Dependabot structurally cannot manage.
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    # For this ecosystem the directory is the repo root; Dependabot finds .github/workflows
+    # underneath it, including reusable workflows.
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: '06:00'
+      timezone: Etc/UTC
+    # Four actions across two workflows. Grouping them means one PR with one CI run and one
+    # review, instead of four PRs that each rerun all four gates. Security updates are still
+    # opened individually and immediately — grouping only applies to scheduled version updates.
+    groups:
+      actions:
+        patterns:
+          - '*'
+    open-pull-requests-limit: 5
+    labels:
+      - 'area:infra'
+    # PR titles become squashed commit messages and feed the generated release notes (D36),
+    # so they have to be conventional-commit form: `chore(deps): bump ...`.
+    commit-message:
+      prefix: chore
+      include: scope

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -167,6 +167,60 @@ If you delete first, check the child is still open rather than assuming it retar
 [#4](https://github.com/dharlabs/occasio/issues/4). Until then, treat their green ticks as
 meaning nothing.
 
+## Keeping the pins current
+
+Every action in `.github/workflows` is pinned to a full commit SHA with its release tag in a
+trailing comment, and the `visual` gate's Playwright container is pinned by digest ([#106]).
+A tag is mutable, so an unpinned action runs whatever was pushed there last. A SHA is not.
+
+The cost of that is a pin with no expiry: it stays at whatever was current the day somebody
+wrote it, security fixes included. [`.github/dependabot.yml`](../.github/dependabot.yml) is what
+closes that half of the trade for the actions. It watches the `github-actions` ecosystem weekly,
+bumps the SHA, and rewrites the trailing `# v4` comment so the comment cannot drift into a lie.
+All four actions are grouped into one PR — one review, one CI run. Security updates are exempt
+from grouping and arrive on their own, immediately.
+
+Read the group PR rather than rubber-stamping it. Dependabot rewrites the version comment only
+when the SHA it lands on is a tagged release; when it is not, the SHA moves and the comment does
+not.
+
+### The Playwright pin moves by hand, and never alone
+
+**`ci.yml`'s container digest and the `playwright` version in `package.json` are one pin written
+in two places.** The image ships browser binaries built for one client version, so a mismatch
+fails when a browser launches rather than when anything installs — the breakage surfaces in the
+`visual` gate, some distance from the change that caused it.
+
+Dependabot cannot hold those two together, for two independent reasons:
+
+- It does not read `jobs.<id>.container.image` at all. Its `docker` ecosystem covers
+  Dockerfiles, Compose files and Kubernetes manifests, not workflow YAML
+  ([dependabot-core#5819](https://github.com/dependabot/dependabot-core/issues/5819), open since
+  2022).
+- Even if it did, nothing would tell it the two must land together, so it would open two
+  unrelated PRs and the first one merged would break CI.
+
+Which is why the npm ecosystem is deliberately **absent** from `dependabot.yml`. Enabling it
+without an `ignore` for `playwright` would produce a plausible-looking PR that moves the client
+past its container. That is a separate decision from this one; make it deliberately.
+
+Bump both in a single PR:
+
+```bash
+npm install --save-exact --save-dev playwright@1.64.0
+
+# The digest the registry serves for the matching image tag:
+curl -sSI -H 'Accept: application/vnd.oci.image.index.v1+json' \
+  https://mcr.microsoft.com/v2/playwright/manifests/v1.64.0-noble |
+  grep -i docker-content-digest
+```
+
+Paste that digest into `ci.yml`'s `image:`, update the version named in the comment above it,
+and run `npm run test:visual` before pushing. `--save-exact` is not optional: the version is
+pinned without a range precisely so `npm ci` cannot float the client away from the container.
+
+[#106]: https://github.com/dharlabs/occasio/pull/106
+
 ## Releases
 
 A milestone completing is the release trigger. There is no fixed cadence — six meaningful

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -176,13 +176,13 @@ A tag is mutable, so an unpinned action runs whatever was pushed there last. A S
 The cost of that is a pin with no expiry: it stays at whatever was current the day somebody
 wrote it, security fixes included. [`.github/dependabot.yml`](../.github/dependabot.yml) is what
 closes that half of the trade for the actions. It watches the `github-actions` ecosystem weekly,
-bumps the SHA, and rewrites the trailing `# v4` comment so the comment cannot drift into a lie.
-All four actions are grouped into one PR — one review, one CI run. Security updates are exempt
-from grouping and arrive on their own, immediately.
+bumps the SHA, and — when the new SHA maps to a tag — rewrites the trailing `# v4` comment with
+it. All four actions are grouped into one PR: one review, one CI run. Security updates are
+exempt from grouping and arrive on their own, immediately.
 
-Read the group PR rather than rubber-stamping it. Dependabot rewrites the version comment only
-when the SHA it lands on is a tagged release; when it is not, the SHA moves and the comment does
-not.
+Read the group PR rather than rubber-stamping it, and check both halves of every pin. When
+Dependabot lands on a commit that carries no tag, the SHA moves and the comment stays where it
+was — which is worse than a stale pin, because it is a stale pin that reads as a current one.
 
 ### The Playwright pin moves by hand, and never alone
 
@@ -209,10 +209,13 @@ Bump both in a single PR:
 ```bash
 npm install --save-exact --save-dev playwright@1.64.0
 
-# The digest the registry serves for the matching image tag:
-curl -sSI -H 'Accept: application/vnd.oci.image.index.v1+json' \
+# The digest the registry serves for the matching image tag. Prints `sha256:…` and nothing
+# else: HTTP headers end in CRLF, and a stray carriage return pasted into ci.yml is a pin
+# that looks right and resolves to nothing.
+curl -fsSI -H 'Accept: application/vnd.oci.image.index.v1+json' \
   https://mcr.microsoft.com/v2/playwright/manifests/v1.64.0-noble |
-  grep -i docker-content-digest
+  tr -d '\r' |
+  awk -F': ' 'tolower($1) == "docker-content-digest" { print $2; exit }'
 ```
 
 Paste that digest into `ci.yml`'s `image:`, update the version named in the comment above it,


### PR DESCRIPTION
Closes #107

## What changed

`.github/dependabot.yml` now watches the `github-actions` ecosystem weekly, so the SHA pins
introduced in #106 get bumped instead of quietly ageing. Dependabot rewrites the trailing
`# v4` comment along with the SHA, which is the part that keeps the pins readable rather than
just safe. All four actions are grouped into one PR — one review, one CI run — and security
updates bypass grouping and still arrive individually. `docs/workflow.md` gains a
"Keeping the pins current" section covering this and, more importantly, the pin Dependabot
cannot manage.

## Why this way

**The Playwright container digest stays manual, and the doc says so out loud.** Two independent
reasons, both checked rather than assumed:

- Dependabot does not read `jobs.<id>.container.image`. Its `docker` ecosystem covers
  Dockerfiles, Compose files and Kubernetes manifests — not workflow YAML.
  [dependabot-core#5819](https://github.com/dependabot/dependabot-core/issues/5819) is the open
  feature request, filed in 2022.
- Even with that support, it would open a digest PR and a `playwright` package PR with nothing
  linking them. Whichever merged first would break the `visual` gate, because the image ships
  browsers built for one client version and the mismatch fails at browser launch — far from the
  change that caused it.

**So npm is deliberately not in this config.** Enabling it without an `ignore` for `playwright`
would manufacture exactly that broken PR on a weekly schedule. Turning npm updates on is a real
decision and deserves its own issue, not a side effect of this one.

`commit-message.prefix: chore` + `include: scope` is there because a Dependabot PR title becomes
the squashed commit and feeds the generated release notes (D36), so it has to be conventional
form.

While documenting the bump procedure I verified the existing pin: the registry serves
`sha256:eff16c30…` for `mcr.microsoft.com/playwright:v1.63.0-noble`, which matches both the
digest in `ci.yml` and `playwright@1.63.0` in `package.json`. The pin and its comment are
currently accurate.

One caveat recorded in the doc rather than smoothed over: Dependabot rewrites the version
comment only when the SHA it lands on is a tagged release. When it is not, the SHA moves and the
comment does not — so the grouped PR gets read, not rubber-stamped.

## Checks

- [x] `npm run verify` passes locally
- [x] Scoped to one issue — anything else was split out
- [x] Title is in conventional-commit form (it becomes the squashed commit)
- [x] New architectural rules, if any, have a probe in `tools/enforcement/` — n/a, no new rule

Not verified: Dependabot's behaviour on this repo cannot be exercised until the config is on
`main`. The config is schema-shaped and parses, but the first grouped PR is the real proof.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance for maintaining pinned GitHub Actions and Playwright container versions.
  - Documented the coordinated update process, required commands, and verification steps.

- **Chores**
  - Added weekly automated checks for GitHub Actions updates, with grouped pull requests and repository labelling.
  - Configured scheduled updates to run every Monday morning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->