### PR TITLE
feat(ui): add Text and Button with real interaction states

### DIFF
--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -1,7 +1,14 @@
 import { useCallback, useRef, useState } from 'react';
-import { Pressable, View, type StyleProp, type TextStyle, type ViewStyle } from 'react-native';
+import {
+  Pressable,
+  Text,
+  View,
+  type StyleProp,
+  type TextStyle,
+  type ViewStyle,
+} from 'react-native';
 import { createStyles } from '../theme/createStyles';
-import { Text } from './Text';
+import type { LayoutViewStyle } from './layoutStyle';
 import {
   buttonPalette,
   resolveButtonState,
@@ -50,7 +57,11 @@ const useButtonStyles = createStyles((theme) => {
       /* Present on every variant and every state, so nothing reflows when the state changes. */
       borderWidth: theme.border.hairline,
     },
-    label: { textAlign: 'center' },
+    /* React Native's Text rather than this package's, because the label colour is a per-state
+       palette value and the public Text API deliberately cannot express one — a `color` escape
+       there is exactly the hole that keeps a design system honest. The type role is still a
+       token, so the label follows the tenant's scale and font set. */
+    label: { ...theme.type.bodyStrong, textAlign: 'center' },
     ring: {
       position: 'absolute',
       top: -ringGap,
@@ -92,8 +103,8 @@ export type ButtonProps = {
   /** Defaults to `label`; set it when the visible label is not the whole story. */
   readonly accessibilityLabel?: string | undefined;
   readonly testID?: string | undefined;
-  /** Layout only — colour and size come from the theme. */
-  readonly style?: StyleProp<ViewStyle> | undefined;
+  /** Layout only — colour, size, radius and spacing come from the theme. */
+  readonly style?: StyleProp<LayoutViewStyle> | undefined;
 };
 
 export function Button({
@@ -158,9 +169,7 @@ export function Button({
       {showsFocusRing(focusOrigin, disabled) ? (
         <View pointerEvents="none" style={styles.ring} />
       ) : null}
-      <Text style={[styles.label, styles[`${variant}_${state}_label`]]} variant="bodyStrong">
-        {label}
-      </Text>
+      <Text style={[styles.label, styles[`${variant}_${state}_label`]]}>{label}</Text>
     </Pressable>
   );
 }

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -12,6 +12,7 @@ import type { LayoutViewStyle } from './layoutStyle';
 import {
   buttonPalette,
   resolveButtonState,
+  focusOriginAfterPointerDown,
   showsFocusRing,
   type ButtonTone,
   type ButtonVariant,
@@ -140,6 +141,14 @@ export function Button({
   const handleHoverOut = useCallback(() => {
     setHovered(false);
   }, []);
+  /* Not `onPressIn`, which keyboard activation fires too — demoting the origin there would
+     take the ring away from the keyboard user at the moment they press Enter. `onPointerDown`
+     is raised only by a real pointer: React Native declares it on ViewProps, which Pressable
+     extends, and react-native-web forwards it to the DOM event of the same name. */
+  const handlePointerDown = useCallback(() => {
+    pointerDown.current = true;
+    setFocusOrigin(focusOriginAfterPointerDown);
+  }, []);
   const handleFocus = useCallback(() => {
     setFocusOrigin(pointerDown.current ? 'pointer' : 'keyboard');
   }, []);
@@ -161,6 +170,7 @@ export function Button({
       onHoverIn={handleHoverIn}
       onHoverOut={handleHoverOut}
       onPress={onPress}
+      onPointerDown={handlePointerDown}
       onPressIn={handlePressIn}
       onPressOut={handlePressOut}
       style={[styles.base, styles[`${variant}_${state}`], style]}

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -1,0 +1,166 @@
+import { useCallback, useRef, useState } from 'react';
+import { Pressable, View, type StyleProp, type TextStyle, type ViewStyle } from 'react-native';
+import { createStyles } from '../theme/createStyles';
+import { Text } from './Text';
+import {
+  buttonPalette,
+  resolveButtonState,
+  showsFocusRing,
+  type ButtonTone,
+  type ButtonVariant,
+  type FocusOrigin,
+} from './buttonTokens';
+
+/**
+ * A button with the four states a pointer and a keyboard can actually produce.
+ *
+ * Web is the primary surface (D30), and on the web a control with no hover and no focus ring
+ * reads as decoration: nothing acknowledges the pointer, and a keyboard user cannot see where
+ * they are. So hover, pressed, disabled and focus are all painted, all from theme tokens.
+ *
+ * The colour decisions live in buttonTokens.ts, which is testable without a renderer — component
+ * rendering is not available yet (#110), and a palette whose only proof is a screenshot is a
+ * palette nobody has checked.
+ */
+
+const useButtonStyles = createStyles((theme) => {
+  const palette = buttonPalette(theme);
+  const surface = (tone: ButtonTone): ViewStyle => ({
+    backgroundColor: tone.background,
+    borderColor: tone.border,
+  });
+  const label = (tone: ButtonTone): TextStyle => ({ color: tone.label });
+
+  /* The ring is drawn in a gap *outside* the control. It has to be: interactive.focusRing is
+     the brand solid, which is also the primary fill — inside the button it would be invisible.
+     Outside, it is measured against the page background, where the resolver guarantees 3:1. */
+  const ringGap = theme.space(1);
+
+  return {
+    base: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'center',
+      /* Hug the label rather than stretching to the parent's cross axis; a caller that wants a
+         full-width button says so in `style`. */
+      alignSelf: 'flex-start',
+      paddingVertical: theme.space(3),
+      paddingHorizontal: theme.space(5),
+      borderRadius: theme.radius.md,
+      /* Present on every variant and every state, so nothing reflows when the state changes. */
+      borderWidth: theme.border.hairline,
+    },
+    label: { textAlign: 'center' },
+    ring: {
+      position: 'absolute',
+      top: -ringGap,
+      right: -ringGap,
+      bottom: -ringGap,
+      left: -ringGap,
+      borderWidth: theme.border.standard,
+      borderColor: theme.color.interactive.focusRing,
+      borderRadius: theme.radius.md + ringGap,
+    },
+
+    /* Keyed `<variant>_<state>` so the component indexes the sheet straight from the resolved
+       state, with the template literal checked against these keys at compile time. */
+    primary_rest: surface(palette.primary.rest),
+    primary_hover: surface(palette.primary.hover),
+    primary_pressed: surface(palette.primary.pressed),
+    primary_disabled: surface(palette.primary.disabled),
+    primary_rest_label: label(palette.primary.rest),
+    primary_hover_label: label(palette.primary.hover),
+    primary_pressed_label: label(palette.primary.pressed),
+    primary_disabled_label: label(palette.primary.disabled),
+
+    secondary_rest: surface(palette.secondary.rest),
+    secondary_hover: surface(palette.secondary.hover),
+    secondary_pressed: surface(palette.secondary.pressed),
+    secondary_disabled: surface(palette.secondary.disabled),
+    secondary_rest_label: label(palette.secondary.rest),
+    secondary_hover_label: label(palette.secondary.hover),
+    secondary_pressed_label: label(palette.secondary.pressed),
+    secondary_disabled_label: label(palette.secondary.disabled),
+  };
+});
+
+export type ButtonProps = {
+  readonly label: string;
+  readonly onPress?: (() => void) | undefined;
+  readonly variant?: ButtonVariant | undefined;
+  readonly disabled?: boolean | undefined;
+  /** Defaults to `label`; set it when the visible label is not the whole story. */
+  readonly accessibilityLabel?: string | undefined;
+  readonly testID?: string | undefined;
+  /** Layout only — colour and size come from the theme. */
+  readonly style?: StyleProp<ViewStyle> | undefined;
+};
+
+export function Button({
+  label,
+  onPress,
+  variant = 'primary',
+  disabled = false,
+  accessibilityLabel,
+  testID,
+  style,
+}: ButtonProps) {
+  const styles = useButtonStyles();
+  const [hovered, setHovered] = useState(false);
+  const [pressed, setPressed] = useState(false);
+  const [focusOrigin, setFocusOrigin] = useState<FocusOrigin>('blurred');
+
+  /* A ref rather than state: on the web the pointer is already down when the focus event
+     arrives, and a `setPressed(true)` scheduled by onPressIn has not been applied yet — so
+     reading `pressed` in the focus handler would report the previous render's value. */
+  const pointerDown = useRef(false);
+
+  const handlePressIn = useCallback(() => {
+    pointerDown.current = true;
+    setPressed(true);
+  }, []);
+  const handlePressOut = useCallback(() => {
+    pointerDown.current = false;
+    setPressed(false);
+  }, []);
+  const handleHoverIn = useCallback(() => {
+    setHovered(true);
+  }, []);
+  const handleHoverOut = useCallback(() => {
+    setHovered(false);
+  }, []);
+  const handleFocus = useCallback(() => {
+    setFocusOrigin(pointerDown.current ? 'pointer' : 'keyboard');
+  }, []);
+  const handleBlur = useCallback(() => {
+    pointerDown.current = false;
+    setFocusOrigin('blurred');
+  }, []);
+
+  const state = resolveButtonState({ disabled, hovered, pressed });
+
+  return (
+    <Pressable
+      accessibilityLabel={accessibilityLabel ?? label}
+      accessibilityRole="button"
+      accessibilityState={{ disabled }}
+      disabled={disabled}
+      onBlur={handleBlur}
+      onFocus={handleFocus}
+      onHoverIn={handleHoverIn}
+      onHoverOut={handleHoverOut}
+      onPress={onPress}
+      onPressIn={handlePressIn}
+      onPressOut={handlePressOut}
+      style={[styles.base, styles[`${variant}_${state}`], style]}
+      testID={testID}
+    >
+      {showsFocusRing(focusOrigin, disabled) ? (
+        <View pointerEvents="none" style={styles.ring} />
+      ) : null}
+      <Text style={[styles.label, styles[`${variant}_${state}_label`]]} variant="bodyStrong">
+        {label}
+      </Text>
+    </Pressable>
+  );
+}

--- a/packages/ui/src/components/Text.tsx
+++ b/packages/ui/src/components/Text.tsx
@@ -1,6 +1,13 @@
-import { Text as RNText, type TextProps as RNTextProps } from 'react-native';
+import { Text as RNText, type StyleProp, type TextProps as RNTextProps } from 'react-native';
 import { createStyles } from '../theme/createStyles';
-import { textPalette, type TextTone, type TextVariant } from './textTokens';
+import type { LayoutTextStyle } from './layoutStyle';
+import {
+  textPalette,
+  type BodyTextTone,
+  type LargeTextVariant,
+  type SmallTextVariant,
+  type TextTone,
+} from './textTokens';
 
 /**
  * Every piece of text in the app.
@@ -10,8 +17,8 @@ import { textPalette, type TextTone, type TextVariant } from './textTokens';
  * theme's typography scale, density and font set therefore reach every string for free.
  *
  * Anything React Native's Text accepts still works (`numberOfLines`, `onPress`, `selectable`,
- * accessibility props), and `style` is applied last so a caller can override — layout, not
- * colour or size, is the intended use.
+ * accessibility props). `style` is narrowed to layout: a component whose contrast is proved
+ * cannot also let the caller repaint it.
  */
 
 const useTextStyles = createStyles((theme) => {
@@ -39,10 +46,17 @@ const useTextStyles = createStyles((theme) => {
   };
 });
 
-export type TextProps = RNTextProps & {
-  readonly variant?: TextVariant | undefined;
-  readonly tone?: TextTone | undefined;
-};
+/**
+ * The variant and tone are a pair, not two independent props: `faint` is only legal on a variant
+ * that reaches WCAG's large-text threshold, so the union makes an inaccessible combination fail
+ * to compile. Everything else is the same for both arms.
+ */
+export type TextProps = Omit<RNTextProps, 'style'> & {
+  readonly style?: StyleProp<LayoutTextStyle> | undefined;
+} & (
+    | { readonly variant: LargeTextVariant; readonly tone?: TextTone | undefined }
+    | { readonly variant?: SmallTextVariant | undefined; readonly tone?: BodyTextTone | undefined }
+  );
 
 export function Text({ variant = 'body', tone = 'default', style, ...rest }: TextProps) {
   const styles = useTextStyles();

--- a/packages/ui/src/components/Text.tsx
+++ b/packages/ui/src/components/Text.tsx
@@ -1,0 +1,50 @@
+import { Text as RNText, type TextProps as RNTextProps } from 'react-native';
+import { createStyles } from '../theme/createStyles';
+import { textPalette, type TextTone, type TextVariant } from './textTokens';
+
+/**
+ * Every piece of text in the app.
+ *
+ * `variant` names a type role the resolver already produced — there is no size prop, because a
+ * size prop is how a design system acquires a 17px heading that exists on one screen. The
+ * theme's typography scale, density and font set therefore reach every string for free.
+ *
+ * Anything React Native's Text accepts still works (`numberOfLines`, `onPress`, `selectable`,
+ * accessibility props), and `style` is applied last so a caller can override — layout, not
+ * colour or size, is the intended use.
+ */
+
+const useTextStyles = createStyles((theme) => {
+  const tone = textPalette(theme);
+
+  return {
+    /* Spread rather than referenced: StyleSheet.create takes ownership of what it is given,
+       and these token objects belong to the theme. */
+    display1: { ...theme.type.display1 },
+    display2: { ...theme.type.display2 },
+    title1: { ...theme.type.title1 },
+    title2: { ...theme.type.title2 },
+    body: { ...theme.type.body },
+    bodyStrong: { ...theme.type.bodyStrong },
+    caption: { ...theme.type.caption },
+    overline: { ...theme.type.overline },
+
+    /* Tone names never collide with variant names, so one flat sheet indexes both. */
+    default: { color: tone.default },
+    muted: { color: tone.muted },
+    faint: { color: tone.faint },
+    inverse: { color: tone.inverse },
+    onBrand: { color: tone.onBrand },
+    onAccent: { color: tone.onAccent },
+  };
+});
+
+export type TextProps = RNTextProps & {
+  readonly variant?: TextVariant | undefined;
+  readonly tone?: TextTone | undefined;
+};
+
+export function Text({ variant = 'body', tone = 'default', style, ...rest }: TextProps) {
+  const styles = useTextStyles();
+  return <RNText {...rest} style={[styles[variant], styles[tone], style]} />;
+}

--- a/packages/ui/src/components/buttonTokens.test.ts
+++ b/packages/ui/src/components/buttonTokens.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from '@jest/globals';
+import { contrast, resolveTheme, themeInputFromPreset } from '@occasio/theme';
+import {
+  BUTTON_STATES,
+  BUTTON_VARIANTS,
+  buttonPalette,
+  resolveButtonState,
+  showsFocusRing,
+} from './buttonTokens';
+import { everyTheme } from './themeMatrix.fixture';
+
+describe('resolveButtonState', () => {
+  it('paints rest when nothing is happening', () => {
+    expect(resolveButtonState({ disabled: false, hovered: false, pressed: false })).toBe('rest');
+  });
+
+  it('paints hover for a pointer that is over but not down', () => {
+    expect(resolveButtonState({ disabled: false, hovered: true, pressed: false })).toBe('hover');
+  });
+
+  it('lets pressed win over hover, because a press is always also a hover', () => {
+    expect(resolveButtonState({ disabled: false, hovered: true, pressed: true })).toBe('pressed');
+  });
+
+  it('lets disabled win over everything', () => {
+    /* A disabled button still receives hover on the web — the pointer really is over it. If
+       hover won, an unusable control would light up as though it could be clicked. */
+    expect(resolveButtonState({ disabled: true, hovered: true, pressed: true })).toBe('disabled');
+  });
+});
+
+describe('showsFocusRing', () => {
+  it('shows the ring for keyboard focus', () => {
+    expect(showsFocusRing('keyboard', false)).toBe(true);
+  });
+
+  it('stays hidden for focus that came from a click', () => {
+    /* mousedown focuses the element on the web, so a ring on every focus flashes up after an
+       ordinary click. This is the `:focus-visible` behaviour Pressable does not expose. */
+    expect(showsFocusRing('pointer', false)).toBe(false);
+  });
+
+  it('stays hidden when blurred', () => {
+    expect(showsFocusRing('blurred', false)).toBe(false);
+  });
+
+  it('stays hidden on a disabled button that somehow holds focus', () => {
+    expect(showsFocusRing('keyboard', true)).toBe(false);
+  });
+});
+
+describe('buttonPalette', () => {
+  it('defines every state of every variant', () => {
+    const palette = buttonPalette(resolveTheme(themeInputFromPreset('editorial', '#7C3A5A')));
+
+    for (const variant of BUTTON_VARIANTS) {
+      expect(Object.keys(palette[variant]).sort()).toEqual([...BUTTON_STATES].sort());
+    }
+  });
+
+  it.each(BUTTON_VARIANTS.flatMap((v) => BUTTON_STATES.map((s) => [v, s] as const)))(
+    'keeps the %s button legible in its %s state, in every theme',
+    (variant, state) => {
+      /* The regression this exists for: the primary hover and pressed fills are further along
+         the brand ramp than `color.brand`, so the paired `onBrand` label falls to 2.97:1 on the
+         pressed fill — an AA failure on the exact state a user is looking at while they click.
+         The palette derives the label from the fill instead; this is what holds it there. */
+      const failures = everyTheme()
+        .map(({ label, theme }) => {
+          const tone = buttonPalette(theme)[variant][state];
+          return { label, ratio: contrast(tone.label, tone.background) };
+        })
+        .filter(({ ratio }) => ratio < 4.5)
+        .map(({ label, ratio }) => `${label} ${ratio.toFixed(2)}:1`);
+
+      expect(failures).toEqual([]);
+    },
+  );
+});
+
+describe('focus ring', () => {
+  it('stays visible against the page it is drawn on', () => {
+    /* The ring is drawn in a gap outside the control, so the background it must separate from
+       is the page, not the button — inside a primary button the ring colour *is* the fill. */
+    const failures = everyTheme()
+      .map(({ label, theme }) => ({
+        label,
+        ratio: contrast(theme.color.interactive.focusRing, theme.color.bg),
+      }))
+      .filter(({ ratio }) => ratio < 3)
+      .map(({ label, ratio }) => `${label} ${ratio.toFixed(2)}:1`);
+
+    expect(failures).toEqual([]);
+  });
+});

--- a/packages/ui/src/components/buttonTokens.test.ts
+++ b/packages/ui/src/components/buttonTokens.test.ts
@@ -4,6 +4,7 @@ import {
   BUTTON_STATES,
   BUTTON_VARIANTS,
   buttonPalette,
+  focusOriginAfterPointerDown,
   resolveButtonState,
   showsFocusRing,
 } from './buttonTokens';
@@ -91,5 +92,25 @@ describe('focus ring', () => {
       .map(({ label, ratio }) => `${label} ${ratio.toFixed(2)}:1`);
 
     expect(failures).toEqual([]);
+  });
+});
+
+describe('focusOriginAfterPointerDown', () => {
+  it('takes the ring away from a button that was tabbed to and then clicked', () => {
+    /* The case the function exists for. Focus does not move, so no second `onFocus` fires, and
+       without this transition the ring raised by the tab would still be up under the pointer. */
+    expect(focusOriginAfterPointerDown('keyboard')).toBe('pointer');
+  });
+
+  it('leaves the other two origins alone', () => {
+    expect(focusOriginAfterPointerDown('pointer')).toBe('pointer');
+    /* Not promoted to `pointer`: the focus event that follows the press is what decides, and it
+       reads the pointer flag rather than this value. */
+    expect(focusOriginAfterPointerDown('blurred')).toBe('blurred');
+  });
+
+  it('never shows a ring for the origin it produces', () => {
+    /* The two functions have to agree, since one feeds the other. */
+    expect(showsFocusRing(focusOriginAfterPointerDown('keyboard'), false)).toBe(false);
   });
 });

--- a/packages/ui/src/components/buttonTokens.ts
+++ b/packages/ui/src/components/buttonTokens.ts
@@ -53,6 +53,21 @@ export type FocusOrigin = 'blurred' | 'pointer' | 'keyboard';
 export const showsFocusRing = (origin: FocusOrigin, disabled: boolean): boolean =>
   origin === 'keyboard' && !disabled;
 
+/**
+ * What the focus origin becomes when a pointer goes down on the button.
+ *
+ * Focus events do not repeat: tab to a button and then click it and no second `onFocus` fires,
+ * because focus never moved. Without this the ring raised by the tab stays up through the click
+ * and after it — a focus ring on a mouse user, which is the single thing `focus-visible`
+ * exists to prevent. Browsers demote their own `:focus-visible` on pointer input for exactly
+ * this case.
+ *
+ * `blurred` is left alone rather than promoted to `pointer`: the focus event that follows the
+ * press is what decides, and it reads the same pointer flag this transition sets.
+ */
+export const focusOriginAfterPointerDown = (origin: FocusOrigin): FocusOrigin =>
+  origin === 'keyboard' ? 'pointer' : origin;
+
 export type ButtonTone = {
   readonly background: string;
   readonly border: string;

--- a/packages/ui/src/components/buttonTokens.ts
+++ b/packages/ui/src/components/buttonTokens.ts
@@ -1,0 +1,119 @@
+import { onColorFor, type ResolvedTheme } from '@occasio/theme';
+
+/**
+ * Button's interaction model and its palette, kept free of React and React Native.
+ *
+ * Both are the parts of a button that can go wrong invisibly: a state that wins over the wrong
+ * one, and a hover fill whose label stops being readable. Neither needs a renderer to check, and
+ * component rendering is not available yet (#110) — so they live here and are unit-tested.
+ */
+
+/** WCAG AA for body-sized text. A button label is body-sized. */
+const AA_TEXT = 4.5;
+
+export const BUTTON_VARIANTS = ['primary', 'secondary'] as const;
+export type ButtonVariant = (typeof BUTTON_VARIANTS)[number];
+
+export const BUTTON_STATES = ['rest', 'hover', 'pressed', 'disabled'] as const;
+export type ButtonState = (typeof BUTTON_STATES)[number];
+
+/** The three signals a pointer can raise. They overlap freely — a button can be hovered *and*
+ *  pressed — which is exactly why the winner is decided in one place. */
+export type ButtonInteraction = {
+  readonly disabled: boolean;
+  readonly hovered: boolean;
+  readonly pressed: boolean;
+};
+
+/**
+ * Collapses the signals to the single state that paints.
+ *
+ * Precedence matters more than it looks: a disabled button still receives hover events on the
+ * web (the pointer is over it), so "hovered wins" would light up a control that cannot be used.
+ */
+export const resolveButtonState = (interaction: ButtonInteraction): ButtonState => {
+  if (interaction.disabled) return 'disabled';
+  if (interaction.pressed) return 'pressed';
+  if (interaction.hovered) return 'hover';
+  return 'rest';
+};
+
+/**
+ * Where focus came from.
+ *
+ * Modelled as a union rather than two booleans because `focused` and `focusedByPointer` can
+ * contradict each other, and the contradiction is silent.
+ *
+ * Why it is tracked at all: on the web, mousedown focuses the element, so a ring drawn on every
+ * focus flashes up after an ordinary click. Only keyboard focus should show a ring — that is
+ * what `:focus-visible` does in CSS, and React Native's Pressable does not expose it.
+ */
+export type FocusOrigin = 'blurred' | 'pointer' | 'keyboard';
+
+export const showsFocusRing = (origin: FocusOrigin, disabled: boolean): boolean =>
+  origin === 'keyboard' && !disabled;
+
+export type ButtonTone = {
+  readonly background: string;
+  readonly border: string;
+  readonly label: string;
+};
+
+export type ButtonPalette = Readonly<
+  Record<ButtonVariant, Readonly<Record<ButtonState, ButtonTone>>>
+>;
+
+/**
+ * Every colour a button can paint, for one resolved theme.
+ *
+ * Two things here are load-bearing and were measured, not guessed:
+ *
+ * 1. The primary label is derived per state instead of always being `color.onBrand`. `onBrand`
+ *    is paired with `color.brand` (ramp step 9); the hover and pressed fills are steps 10 and 11.
+ *    Across every preset, seed and scheme, `onBrand` on the pressed fill bottoms out at 2.97:1 —
+ *    a plain AA failure on the state a user is looking at while they click. `onColorFor` picks
+ *    the readable end of the neutral ramp for the fill actually being painted, which is the same
+ *    thing the resolver does for its own `on*` tokens, and lifts the floor to 4.5:1.
+ *
+ * 2. Secondary reads the neutral ramp's component-background steps (indices 2-4) rather than
+ *    `surface`/`surfaceRaised`/`surfaceSunken`. `surfaceSunken` resolves to the page background,
+ *    so a "pressed" secondary would vanish into the page instead of reacting to the press.
+ */
+export const buttonPalette = (theme: ResolvedTheme): ButtonPalette => {
+  const { color } = theme;
+  const { interactive, ramp } = color;
+
+  /* The two ends of the neutral ramp — the same candidate pair the resolver hands to
+     onColorFor when it derives onBrand, onDanger and the rest. */
+  const labelOn = (fill: string): string =>
+    onColorFor(fill, { light: ramp.neutral[0], dark: ramp.neutral[11] }, AA_TEXT);
+
+  const solid = (fill: string): ButtonTone => ({
+    background: fill,
+    /* Border matches the fill so every variant has identical geometry and no state change
+       moves a pixel of layout. */
+    border: fill,
+    label: labelOn(fill),
+  });
+
+  const disabled: ButtonTone = {
+    background: interactive.disabled,
+    border: interactive.disabled,
+    label: interactive.onDisabled,
+  };
+
+  return {
+    primary: {
+      rest: solid(interactive.rest),
+      hover: solid(interactive.hover),
+      pressed: solid(interactive.pressed),
+      disabled,
+    },
+    secondary: {
+      rest: { background: ramp.neutral[2], border: color.border, label: color.text },
+      hover: { background: ramp.neutral[3], border: color.borderStrong, label: color.text },
+      pressed: { background: ramp.neutral[4], border: color.borderStrong, label: color.text },
+      disabled: { ...disabled, border: color.border },
+    },
+  };
+};

--- a/packages/ui/src/components/layoutStyle.ts
+++ b/packages/ui/src/components/layoutStyle.ts
@@ -13,6 +13,14 @@ import type { TextStyle, ViewStyle } from 'react-native';
  * between components belongs to the parent's `gap`; anything else that looks missing is a
  * variant or a tone, not a style override. The list is deliberately tight — widening it later
  * is a non-breaking change, narrowing it is not.
+ *
+ * `top`, `right`, `bottom` and `left` are absent for the same reason as `margin`, and it is
+ * worth writing down because they read as layout: an inset is a distance, so `left: 13` is a
+ * spacing value off the theme's scale, arriving through the one prop that was narrowed to keep
+ * spacing values out. Where a child genuinely has to be positioned, it is the parent that knows
+ * where — so the parent wraps it in a positioned `View` of its own, which is the same answer
+ * `gap` gives for the space between two components. `position` and `zIndex` stay: they are
+ * enumerations and a layer index, and neither can express a distance.
  */
 
 type LayoutViewKey =
@@ -29,10 +37,6 @@ type LayoutViewKey =
   | 'minHeight'
   | 'maxHeight'
   | 'position'
-  | 'top'
-  | 'right'
-  | 'bottom'
-  | 'left'
   | 'zIndex';
 
 /** Plus the two text properties that shape a block without touching a type token. */

--- a/packages/ui/src/components/layoutStyle.ts
+++ b/packages/ui/src/components/layoutStyle.ts
@@ -1,0 +1,44 @@
+import type { TextStyle, ViewStyle } from 'react-native';
+
+/**
+ * What a caller is allowed to override on a themed component: where it sits, not what it looks
+ * like.
+ *
+ * D17 makes a literal colour or spacing value a lint error, but a `style` prop typed as the full
+ * `ViewStyle` still lets a token be smuggled through a variable or a computed string — and that
+ * is the failure D17 exists to prevent, just harder to see. Narrowing the prop turns the rule
+ * into something the compiler enforces at the call site rather than something lint catches only
+ * when the value happens to be written inline.
+ *
+ * Deliberately absent: colour, radius, border, font, padding, margin and `opacity`. Spacing
+ * between components belongs to the parent's `gap`; anything else that looks missing is a
+ * variant or a tone, not a style override.
+ *
+ * TypeScript's excess-property check makes this bite on object literals, which is every call
+ * site in practice. A value already typed as `ViewStyle` remains structurally assignable —
+ * "these keys and no others" is not expressible without branding every style in the repo.
+ */
+export type LayoutViewStyle = Pick<
+  ViewStyle,
+  | 'alignSelf'
+  | 'display'
+  | 'flex'
+  | 'flexBasis'
+  | 'flexGrow'
+  | 'flexShrink'
+  | 'width'
+  | 'minWidth'
+  | 'maxWidth'
+  | 'height'
+  | 'minHeight'
+  | 'maxHeight'
+  | 'position'
+  | 'top'
+  | 'right'
+  | 'bottom'
+  | 'left'
+  | 'zIndex'
+>;
+
+/** The same, plus the two text properties that shape a block without touching a type token. */
+export type LayoutTextStyle = LayoutViewStyle & Pick<TextStyle, 'textAlign' | 'textTransform'>;

--- a/packages/ui/src/components/layoutStyle.ts
+++ b/packages/ui/src/components/layoutStyle.ts
@@ -7,19 +7,15 @@ import type { TextStyle, ViewStyle } from 'react-native';
  * D17 makes a literal colour or spacing value a lint error, but a `style` prop typed as the full
  * `ViewStyle` still lets a token be smuggled through a variable or a computed string — and that
  * is the failure D17 exists to prevent, just harder to see. Narrowing the prop turns the rule
- * into something the compiler enforces at the call site rather than something lint catches only
- * when the value happens to be written inline.
+ * into something the compiler enforces at the call site.
  *
  * Deliberately absent: colour, radius, border, font, padding, margin and `opacity`. Spacing
  * between components belongs to the parent's `gap`; anything else that looks missing is a
- * variant or a tone, not a style override.
- *
- * TypeScript's excess-property check makes this bite on object literals, which is every call
- * site in practice. A value already typed as `ViewStyle` remains structurally assignable —
- * "these keys and no others" is not expressible without branding every style in the repo.
+ * variant or a tone, not a style override. The list is deliberately tight — widening it later
+ * is a non-breaking change, narrowing it is not.
  */
-export type LayoutViewStyle = Pick<
-  ViewStyle,
+
+type LayoutViewKey =
   | 'alignSelf'
   | 'display'
   | 'flex'
@@ -37,8 +33,24 @@ export type LayoutViewStyle = Pick<
   | 'right'
   | 'bottom'
   | 'left'
-  | 'zIndex'
+  | 'zIndex';
+
+/** Plus the two text properties that shape a block without touching a type token. */
+type LayoutTextKey = LayoutViewKey | 'textAlign' | 'textTransform';
+
+/**
+ * Every key that is *not* allowed, typed `never`.
+ *
+ * `Pick` alone only stops an inline object literal, because that is all TypeScript's
+ * excess-property check covers — a value already typed `ViewStyle` stays structurally
+ * assignable, and `const s: ViewStyle = { backgroundColor: brandFromSomewhere }` would sail
+ * through. Declaring the excluded keys as optional `never` makes such a value fail to assign,
+ * which is what closes the variable-smuggling route the lint rule cannot see.
+ */
+type Forbidden<Style, Allowed extends keyof Style> = Readonly<
+  Partial<Record<Exclude<keyof Style, Allowed>, never>>
 >;
 
-/** The same, plus the two text properties that shape a block without touching a type token. */
-export type LayoutTextStyle = LayoutViewStyle & Pick<TextStyle, 'textAlign' | 'textTransform'>;
+export type LayoutViewStyle = Pick<ViewStyle, LayoutViewKey> & Forbidden<ViewStyle, LayoutViewKey>;
+
+export type LayoutTextStyle = Pick<TextStyle, LayoutTextKey> & Forbidden<TextStyle, LayoutTextKey>;

--- a/packages/ui/src/components/textTokens.test.ts
+++ b/packages/ui/src/components/textTokens.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from '@jest/globals';
+import { contrast, resolveTheme, themeInputFromPreset, type ResolvedTheme } from '@occasio/theme';
+import { TEXT_TONES, TEXT_VARIANTS, textPalette, type TextTone } from './textTokens';
+import { everyTheme } from './themeMatrix.fixture';
+
+describe('text variants', () => {
+  it('covers every type role the resolver produces, and invents none', () => {
+    /* The point of the test: a role added to ThemeTypography stays unreachable from Text until
+       it is listed here, and a variant naming a role that no longer exists is a dead prop.
+       Both are silent failures otherwise. */
+    const { family: _family, ...roles } = resolveTheme(
+      themeInputFromPreset('editorial', '#7C3A5A'),
+    ).type;
+
+    expect([...TEXT_VARIANTS].sort()).toEqual(Object.keys(roles).sort());
+  });
+});
+
+describe('text tones', () => {
+  /* Each tone, the background it is designed to sit on, and its WCAG floor. `faint` is a
+     large-text tone (3:1); the rest carry body copy and owe AA. */
+  const PAIRS: Readonly<
+    Record<TextTone, { readonly on: (theme: ResolvedTheme) => string; readonly min: number }>
+  > = {
+    default: { on: (t) => t.color.surface, min: 4.5 },
+    muted: { on: (t) => t.color.surface, min: 4.5 },
+    faint: { on: (t) => t.color.surface, min: 3 },
+    inverse: { on: (t) => t.color.ramp.neutral[11], min: 4.5 },
+    onBrand: { on: (t) => t.color.brand, min: 4.5 },
+    onAccent: { on: (t) => t.color.accent, min: 4.5 },
+  };
+
+  it('names a background pairing for every tone', () => {
+    expect(Object.keys(PAIRS).sort()).toEqual([...TEXT_TONES].sort());
+  });
+
+  it.each(TEXT_TONES)('keeps %s readable on its own background, in every theme', (tone) => {
+    const pair = PAIRS[tone];
+
+    const failures = everyTheme()
+      .map(({ label, theme }) => ({
+        label,
+        ratio: contrast(textPalette(theme)[tone], pair.on(theme)),
+      }))
+      .filter(({ ratio }) => ratio < pair.min)
+      .map(({ label, ratio }) => `${label} ${ratio.toFixed(2)}:1`);
+
+    expect(failures).toEqual([]);
+  });
+});

--- a/packages/ui/src/components/textTokens.test.ts
+++ b/packages/ui/src/components/textTokens.test.ts
@@ -1,6 +1,22 @@
 import { describe, expect, it } from '@jest/globals';
-import { contrast, resolveTheme, themeInputFromPreset, type ResolvedTheme } from '@occasio/theme';
-import { TEXT_TONES, TEXT_VARIANTS, textPalette, type TextTone } from './textTokens';
+import {
+  PRESET_IDS,
+  TYPE_SET_IDS,
+  contrast,
+  resolveTheme,
+  themeInputFromPreset,
+  type ResolvedTheme,
+  type ThemeInput,
+} from '@occasio/theme';
+import {
+  BODY_TEXT_TONES,
+  LARGE_TEXT_VARIANTS,
+  TEXT_TONES,
+  TEXT_VARIANTS,
+  textPalette,
+  type TextTone,
+  type TextVariant,
+} from './textTokens';
 import { everyTheme } from './themeMatrix.fixture';
 
 describe('text variants', () => {
@@ -13,6 +29,32 @@ describe('text variants', () => {
     ).type;
 
     expect([...TEXT_VARIANTS].sort()).toEqual(Object.keys(roles).sort());
+  });
+
+  it('admits exactly the variants that reach WCAG large text at every type scale', () => {
+    /* 24px, or 18.66px at weight 700 — the threshold that makes a 3:1 contrast floor legal, and
+       therefore the threshold that decides where the `faint` tone may be used. A tenant picks
+       the type set and the scale, so a variant only qualifies if it qualifies in all of them:
+       `title1` is 24px by default and 22px on `compact`, which is precisely the trap. */
+    const isLargeText = (variant: TextVariant, input: ThemeInput): boolean => {
+      const { fontSize, fontWeight } = resolveTheme(input).type[variant];
+      return fontSize >= 24 || (fontSize >= 18.66 && Number(fontWeight) >= 700);
+    };
+
+    const everyTypeInput = PRESET_IDS.flatMap((presetId) =>
+      TYPE_SET_IDS.flatMap((setId) =>
+        (['compact', 'default', 'grand'] as const).map((scale) => ({
+          ...themeInputFromPreset(presetId, '#7C3A5A'),
+          typography: { setId, scale },
+        })),
+      ),
+    );
+
+    const qualifying = TEXT_VARIANTS.filter((variant) =>
+      everyTypeInput.every((input) => isLargeText(variant, input)),
+    );
+
+    expect([...qualifying].sort()).toEqual([...LARGE_TEXT_VARIANTS].sort());
   });
 });
 
@@ -32,6 +74,15 @@ describe('text tones', () => {
 
   it('names a background pairing for every tone', () => {
     expect(Object.keys(PAIRS).sort()).toEqual([...TEXT_TONES].sort());
+  });
+
+  it('admits at body size exactly the tones that owe and clear AA', () => {
+    /* The floors below are what the contrast test actually enforces, so this ties the prop-level
+       restriction to the measured property rather than to a second hand-maintained list: a tone
+       that only reaches 3:1 must not be reachable from a body-sized variant. */
+    const aaTones = TEXT_TONES.filter((tone) => PAIRS[tone].min >= 4.5);
+
+    expect([...BODY_TEXT_TONES].sort()).toEqual([...aaTones].sort());
   });
 
   it.each(TEXT_TONES)('keeps %s readable on its own background, in every theme', (tone) => {

--- a/packages/ui/src/components/textTokens.ts
+++ b/packages/ui/src/components/textTokens.ts
@@ -28,6 +28,22 @@ export const TEXT_VARIANTS = [
 export type TextVariant = (typeof TEXT_VARIANTS)[number];
 
 /**
+ * The variants that reach WCAG's "large scale" threshold — 24px, or 18.66px at weight 700 — at
+ * *every* type scale a tenant can pick, which is what makes the 3:1 contrast floor legal.
+ *
+ * Only the two display roles clear it. `title1` looks like it should and does not: it resolves
+ * to 22px on the `compact` scale. That is why the list is measured by textTokens.test.ts across
+ * every preset, type set and scale rather than chosen by eye.
+ */
+export const LARGE_TEXT_VARIANTS = [
+  'display1',
+  'display2',
+] as const satisfies readonly TextVariant[];
+
+export type LargeTextVariant = (typeof LARGE_TEXT_VARIANTS)[number];
+export type SmallTextVariant = Exclude<TextVariant, LargeTextVariant>;
+
+/**
  * Tones are limited to the content colours the resolver already guarantees a contrast floor for.
  *
  * `brand`, `danger`, `success` and `warning` are deliberately absent. They are solid *fill*
@@ -39,6 +55,23 @@ export type TextVariant = (typeof TEXT_VARIANTS)[number];
 export const TEXT_TONES = ['default', 'muted', 'faint', 'inverse', 'onBrand', 'onAccent'] as const;
 
 export type TextTone = (typeof TEXT_TONES)[number];
+
+/**
+ * The tones that clear AA (4.5:1) and are therefore legal at any size.
+ *
+ * `faint` is the one that is not: `textFaint` is resolved against a 3:1 floor, which WCAG allows
+ * only for large text. Text's props pair it with `LARGE_TEXT_VARIANTS` so `<Text tone="faint">`
+ * on body or caption copy is a compile error rather than an accessibility bug nobody sees.
+ */
+export const BODY_TEXT_TONES = [
+  'default',
+  'muted',
+  'inverse',
+  'onBrand',
+  'onAccent',
+] as const satisfies readonly TextTone[];
+
+export type BodyTextTone = (typeof BODY_TEXT_TONES)[number];
 
 export type TextToneColors = Readonly<Record<TextTone, string>>;
 

--- a/packages/ui/src/components/textTokens.ts
+++ b/packages/ui/src/components/textTokens.ts
@@ -1,0 +1,55 @@
+import type { ResolvedTheme, ThemeTypography } from '@occasio/theme';
+
+/**
+ * The type roles Text can render, and the colour each tone reads.
+ *
+ * Free of React and React Native on purpose: the variant list and the tone palette are the two
+ * things about Text that can be checked without rendering it, and jest-expo cannot be installed
+ * yet (#110). Keeping them here means the checks are real tests rather than a rendered smoke
+ * test nobody can run.
+ */
+
+/**
+ * Every type role the resolver produces, and nothing else — Text does not invent sizes. The
+ * `satisfies` clause makes a typo a compile error; textTokens.test.ts proves the list is also
+ * *complete*, so a role added to the theme cannot stay unreachable from the component.
+ */
+export const TEXT_VARIANTS = [
+  'display1',
+  'display2',
+  'title1',
+  'title2',
+  'body',
+  'bodyStrong',
+  'caption',
+  'overline',
+] as const satisfies readonly Exclude<keyof ThemeTypography, 'family'>[];
+
+export type TextVariant = (typeof TEXT_VARIANTS)[number];
+
+/**
+ * Tones are limited to the content colours the resolver already guarantees a contrast floor for.
+ *
+ * `brand`, `danger`, `success` and `warning` are deliberately absent. They are solid *fill*
+ * colours: measured across every preset, seed and scheme they bottom out around 3.4:1 against
+ * the page background, so offering them as text tones would ship a WCAG AA failure that looks
+ * like a design choice. Text-safe status colours belong in the resolver next to `textMuted`,
+ * not in a cast at the call site.
+ */
+export const TEXT_TONES = ['default', 'muted', 'faint', 'inverse', 'onBrand', 'onAccent'] as const;
+
+export type TextTone = (typeof TEXT_TONES)[number];
+
+export type TextToneColors = Readonly<Record<TextTone, string>>;
+
+/** Resolves each tone to its token. Pure, so the contrast floors are testable directly. */
+export const textPalette = (theme: ResolvedTheme): TextToneColors => ({
+  default: theme.color.text,
+  muted: theme.color.textMuted,
+  faint: theme.color.textFaint,
+  /** For text on the darkest neutral — a scrim or an inverted surface. */
+  inverse: theme.color.textInverse,
+  /** For text sitting on a solid brand or accent fill, such as a primary button label. */
+  onBrand: theme.color.onBrand,
+  onAccent: theme.color.onAccent,
+});

--- a/packages/ui/src/components/themeMatrix.fixture.ts
+++ b/packages/ui/src/components/themeMatrix.fixture.ts
@@ -1,0 +1,31 @@
+import {
+  PRESET_IDS,
+  resolveTheme,
+  themeInputFromPreset,
+  type ResolvedTheme,
+  type Scheme,
+} from '@occasio/theme';
+
+/**
+ * Every theme a token choice has to survive: each preset, a spread of seeds, both schemes.
+ *
+ * Shared by the token tests so that a palette proved readable is proved readable *everywhere*,
+ * not on the one theme whoever wrote the test happened to pick. Each theme carries a label, so
+ * a failure names the combination that broke rather than only the ratio.
+ */
+
+/** A spread of hues, plus the two achromatic extremes, which is where ramps usually break. */
+const SEEDS = ['#7C3A5A', '#1E6F5C', '#C2410C', '#2563EB', '#F59E0B', '#111111', '#FFFFFF'];
+const SCHEMES: readonly Scheme[] = ['light', 'dark'];
+
+export type LabelledTheme = { readonly label: string; readonly theme: ResolvedTheme };
+
+export const everyTheme = (): readonly LabelledTheme[] =>
+  PRESET_IDS.flatMap((presetId) =>
+    SEEDS.flatMap((seed) =>
+      SCHEMES.map((scheme) => ({
+        label: `${presetId}/${seed}/${scheme}`,
+        theme: resolveTheme(themeInputFromPreset(presetId, seed), { forceScheme: scheme }),
+      })),
+    ),
+  );

--- a/packages/ui/src/components/typeContracts.assertions.ts
+++ b/packages/ui/src/components/typeContracts.assertions.ts
@@ -1,0 +1,63 @@
+import type { TextStyle, ViewStyle } from 'react-native';
+import type { LayoutTextStyle, LayoutViewStyle } from './layoutStyle';
+import type { TextProps } from './Text';
+
+/**
+ * Compile-time proof that two type-level rules in this folder actually reject what they claim
+ * to reject.
+ *
+ * Not ceremony: a narrowing type that silently admits everything looks exactly like one that
+ * works, and this repo has already shipped two lint rules that were configured, read correctly
+ * and did nothing. The architectural equivalent lives in tools/enforcement; a *type* contract
+ * cannot be probed from there, so it is proved here instead — `tsc` is the assertion, and every
+ * line below fails to compile the moment its rule stops biting.
+ *
+ * Nothing here runs. It is a source file rather than a test because jest strips types, so a
+ * suite could not fail on any of it.
+ */
+
+/** `true` when `Wide` is NOT assignable to `Narrow` — i.e. the narrowing rejects it. */
+type Rejects<Wide, Narrow> = [Wide] extends [Narrow] ? false : true;
+
+/** `true` when `Value` IS assignable to `Narrow` — i.e. a legitimate call still compiles. */
+type Accepts<Value, Narrow> = [Value] extends [Narrow] ? true : false;
+
+export const TYPE_CONTRACTS: {
+  /* D17 through the type system: a token cannot be smuggled in through `style`. `Pick` alone
+     would stop only object literals; these two lines are what prove the `never` exclusions
+     close the variable route as well. */
+  readonly fullViewStyleIsRejected: Rejects<ViewStyle, LayoutViewStyle>;
+  readonly fullTextStyleIsRejected: Rejects<TextStyle, LayoutTextStyle>;
+  readonly colourIsRejected: Rejects<{ backgroundColor: string }, LayoutViewStyle>;
+  readonly radiusIsRejected: Rejects<{ borderRadius: number }, LayoutViewStyle>;
+  readonly paddingIsRejected: Rejects<{ paddingHorizontal: number }, LayoutViewStyle>;
+  readonly marginIsRejected: Rejects<{ marginTop: number }, LayoutViewStyle>;
+  readonly fontSizeIsRejected: Rejects<{ fontSize: number }, LayoutTextStyle>;
+  readonly textColourIsRejected: Rejects<{ color: string }, LayoutTextStyle>;
+
+  /* …while the layout properties the prop exists for still go through. A contract that rejects
+     everything is not a contract, it is a broken prop. */
+  readonly layoutIsAccepted: Accepts<{ alignSelf: 'stretch'; maxWidth: number }, LayoutViewStyle>;
+  readonly textAlignIsAccepted: Accepts<{ textAlign: 'center' }, LayoutTextStyle>;
+
+  /* The variant/tone pairing: `faint` only clears WCAG at large-text sizes. */
+  readonly faintOnDefaultVariantIsRejected: Rejects<{ tone: 'faint' }, TextProps>;
+  readonly faintOnSmallVariantIsRejected: Rejects<{ variant: 'caption'; tone: 'faint' }, TextProps>;
+  readonly faintOnDisplayIsAccepted: Accepts<{ variant: 'display1'; tone: 'faint' }, TextProps>;
+  readonly mutedOnSmallVariantIsAccepted: Accepts<{ variant: 'caption'; tone: 'muted' }, TextProps>;
+} = {
+  fullViewStyleIsRejected: true,
+  fullTextStyleIsRejected: true,
+  colourIsRejected: true,
+  radiusIsRejected: true,
+  paddingIsRejected: true,
+  marginIsRejected: true,
+  fontSizeIsRejected: true,
+  textColourIsRejected: true,
+  layoutIsAccepted: true,
+  textAlignIsAccepted: true,
+  faintOnDefaultVariantIsRejected: true,
+  faintOnSmallVariantIsRejected: true,
+  faintOnDisplayIsAccepted: true,
+  mutedOnSmallVariantIsAccepted: true,
+};

--- a/packages/ui/src/components/typeContracts.assertions.ts
+++ b/packages/ui/src/components/typeContracts.assertions.ts
@@ -32,12 +32,16 @@ export const TYPE_CONTRACTS: {
   readonly radiusIsRejected: Rejects<{ borderRadius: number }, LayoutViewStyle>;
   readonly paddingIsRejected: Rejects<{ paddingHorizontal: number }, LayoutViewStyle>;
   readonly marginIsRejected: Rejects<{ marginTop: number }, LayoutViewStyle>;
+  /* An inset is a distance, so it is a spacing value arriving through the prop that was
+     narrowed to keep spacing values out. Positioning a child is the parent's job. */
+  readonly insetIsRejected: Rejects<{ left: number }, LayoutViewStyle>;
   readonly fontSizeIsRejected: Rejects<{ fontSize: number }, LayoutTextStyle>;
   readonly textColourIsRejected: Rejects<{ color: string }, LayoutTextStyle>;
 
   /* …while the layout properties the prop exists for still go through. A contract that rejects
      everything is not a contract, it is a broken prop. */
   readonly layoutIsAccepted: Accepts<{ alignSelf: 'stretch'; maxWidth: number }, LayoutViewStyle>;
+  readonly positionIsAccepted: Accepts<{ position: 'absolute'; zIndex: number }, LayoutViewStyle>;
   readonly textAlignIsAccepted: Accepts<{ textAlign: 'center' }, LayoutTextStyle>;
 
   /* The variant/tone pairing: `faint` only clears WCAG at large-text sizes. */
@@ -52,9 +56,11 @@ export const TYPE_CONTRACTS: {
   radiusIsRejected: true,
   paddingIsRejected: true,
   marginIsRejected: true,
+  insetIsRejected: true,
   fontSizeIsRejected: true,
   textColourIsRejected: true,
   layoutIsAccepted: true,
+  positionIsAccepted: true,
   textAlignIsAccepted: true,
   faintOnDefaultVariantIsRejected: true,
   faintOnSmallVariantIsRejected: true,

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -16,13 +16,19 @@ export {
 } from './feedback/skeletonText';
 export { Text, type TextProps } from './components/Text';
 export {
+  BODY_TEXT_TONES,
+  LARGE_TEXT_VARIANTS,
   TEXT_TONES,
   TEXT_VARIANTS,
   textPalette,
+  type BodyTextTone,
+  type LargeTextVariant,
+  type SmallTextVariant,
   type TextTone,
   type TextToneColors,
   type TextVariant,
 } from './components/textTokens';
+export type { LayoutTextStyle, LayoutViewStyle } from './components/layoutStyle';
 
 export { Button, type ButtonProps } from './components/Button';
 export {

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -14,5 +14,29 @@ export {
   skeletonTextRows,
   type SkeletonTextRow,
 } from './feedback/skeletonText';
+export { Text, type TextProps } from './components/Text';
+export {
+  TEXT_TONES,
+  TEXT_VARIANTS,
+  textPalette,
+  type TextTone,
+  type TextToneColors,
+  type TextVariant,
+} from './components/textTokens';
+
+export { Button, type ButtonProps } from './components/Button';
+export {
+  BUTTON_STATES,
+  BUTTON_VARIANTS,
+  buttonPalette,
+  resolveButtonState,
+  showsFocusRing,
+  type ButtonInteraction,
+  type ButtonPalette,
+  type ButtonState,
+  type ButtonTone,
+  type ButtonVariant,
+  type FocusOrigin,
+} from './components/buttonTokens';
 
 export const UI_PACKAGE_VERSION = '0.0.0' as const;


### PR DESCRIPTION
Closes #25

## What changed

`packages/ui` gains its first two components. **Text** takes a `variant` naming a type role the resolver already produced (`display1` … `overline`) and a `tone` naming a content colour — there is no size prop and no colour prop, so the tenant's typography scale, density and font set reach every string for free. **Button** paints all four states a pointer and a keyboard can actually produce — rest, hover, pressed, disabled — plus a keyboard focus ring, every value from `t.color.interactive.*`. Both go through `createStyles`, so a theme builds one `StyleSheet`, not one per render.

## Why this way

**Two colour decisions were measured across every preset × seed × scheme, and both changed the implementation.**

1. *A primary button cannot use `color.onBrand` for its label.* `onBrand` is paired with `color.brand` (brand ramp step 9), but the hover and pressed fills are steps 10 and 11. Measured, `onBrand` on the pressed fill bottoms out at **2.97:1** — a plain AA failure on the exact state a user is looking at while they click. The label is now derived from the fill being painted, using the same `onColorFor` call the resolver uses for its own `on*` tokens. Floor across the whole matrix: 4.50:1.

2. *The focus ring is drawn in a gap outside the control, not inside it.* `interactive.focusRing` resolves to the brand solid — which is also the primary fill, so an inset ring on a primary button is contrast 1.00:1, i.e. invisible. Outside, it sits on the page background, where the resolver guarantees 3:1 (measured floor 3.41:1).

**Focus origin is a union, not two booleans.** `'blurred' | 'pointer' | 'keyboard'`. Mousedown focuses the element on the web, so a ring shown on every focus flashes up after an ordinary click; only keyboard focus shows one. That is what `:focus-visible` does in CSS, and React Native's `Pressable` does not expose it.

**Secondary reads the neutral ramp's component-background steps (2–4), not `surface`/`surfaceRaised`/`surfaceSunken`.** `surfaceSunken` resolves to the page background, so a "pressed" secondary would vanish into the page rather than react to the press.

**No status or brand tones on Text.** `brand`, `danger`, `success` and `warning` are solid *fill* colours; measured, they bottom out around 3.4:1 against the page background. Exposing them as text tones would ship an AA failure that looks like a design choice. Text-safe status colours belong next to `textMuted` in the resolver — a `packages/theme` change, so out of this PR's lane. Happy to raise an issue if you want them.

**Two variants, not five.** `primary` and `secondary`. A tertiary/ghost variant is a real gap but it is a new decision (what does a borderless control use for its rest boundary, given there is no `transparent` token?), and D35 says a PR that outgrows its issue gets split.

### What is tested, and what is not

Component *rendering* cannot be tested here — `jest-expo` cannot be installed (#110). So the parts that can fail invisibly were deliberately factored out of the components into `buttonTokens.ts` and `textTokens.ts`, which are free of React and React Native and are unit-tested directly:

- the state machine's precedence (a disabled button still receives hover on the web; `disabled` must win)
- the focus-ring rule
- every variant × state of the button palette clearing 4.5:1, across every preset × seed × scheme
- every text tone clearing its floor on the background it was designed for
- `TEXT_VARIANTS` matching the resolver's type roles **exactly** — so a role added to the theme cannot stay unreachable, and a variant naming a removed role is caught

**Not verified, and I am not implying otherwise:** that either component renders correctly. Nothing routes to them yet, so the `visual` gate does not exercise them — it passes at 40/40 unchanged. The web export does bundle both files (confirmed by grepping the built bundle), so they compile and their imports resolve on web; that is all it proves. Hover, press and focus behaviour is reasoned from React Native Web's `Pressable` source (it drives `onHoverIn`/`onHoverOut` through `useHover`, forwards `onFocus`/`onBlur`, and sets `tabIndex` to `-1` when disabled), not observed in a browser.

## Checks

- [x] `npm run verify` passes locally
- [x] `npm run test:visual` passes — 40 routes, all clean
- [x] Scoped to one issue — anything else was split out
- [x] Title is in conventional-commit form (it becomes the squashed commit)
- [x] New architectural rules, if any, have a probe in `tools/enforcement/` — none added

---

## After review (2e99866)

Both CodeRabbit findings were real and are fixed.

**`style` is now layout-only.** D17's lint rule fires on a literal in a `style` prop, but a `StyleProp<ViewStyle>` still let a token be smuggled through a variable or a computed string. `LayoutViewStyle` / `LayoutTextStyle` allow position, size, flex, insets, `textAlign` and `textTransform` — no colour, radius, border, font, padding, margin or opacity. Margin is out because spacing between components belongs to the parent's `gap`; opacity because a component whose contrast is proved should not let the caller silently reduce it. Knock-on: Button renders React Native's `Text` for its label, since the label colour is a per-state palette value and a `color` escape on `Text` would reopen the hole.

**`faint` no longer pairs with small text.** `textFaint` is resolved against a 3:1 floor (measured: 4.02:1), which WCAG allows only for large text — so `<Text tone="faint" variant="caption">` rendered 13px copy below AA and compiled cleanly. `variant` and `tone` are now one union.

The qualifying variants were measured, not chosen. At their minimum across every preset × type set × scale: display1 35px, display2 29px, **title1 22px**, title2 18px, body/bodyStrong 16px, caption 13px, overline 11px. `title1` is the trap — 24px on `default`, 22px on `compact`, and the tenant picks the scale. That table is now a test, so a change to the type ramp fails the build rather than quietly widening what `faint` is allowed on. A second test ties the body-size tone list to the contrast floors the palette test already enforces, instead of to a second hand-maintained list.

**Both constraints were checked with a throwaway probe component run through `tsc`** — a type rule that compiles but rejects nothing is the failure mode this repo has already been bitten by twice. All seven bad combinations error (TS2322 on the two `faint` pairings and on an unknown variant, TS2353 on `color`, `fontSize`, `backgroundColor` and `paddingHorizontal` in `style`); the four legitimate ones compile.

One limit stated rather than glossed: the `style` narrowing bites on **object literals**, via TypeScript's excess-property check, which is every call site in practice. A value already typed as `ViewStyle` stays structurally assignable — "these keys and no others" needs branding, which did not seem worth it for this. Easy to tighten if you disagree.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145VPJXGgJA9PWqeNXDr1DG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added themed, accessible Button components with primary and secondary variants, interaction states, keyboard focus indicators, disabled styling, and custom layout styling.
  - Added themed Text components with configurable typography variants, colour tones, and theme-aware styling.
  - Added type-safe layout styling and text variant/tone combinations.
  - Exposed the new components, configuration options, and theme utilities through the UI package.

- **Tests**
  - Added coverage for interaction states, focus visibility, theme palettes, typography mappings, type contracts, and colour contrast across themes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->