### PR TITLE
feat(ui): add Skeleton, SkeletonText and EmptyState

### DIFF
--- a/packages/ui/src/feedback/EmptyState.tsx
+++ b/packages/ui/src/feedback/EmptyState.tsx
@@ -1,0 +1,69 @@
+import { type ReactNode } from 'react';
+import { Text, View, type StyleProp, type ViewStyle } from 'react-native';
+import { createStyles } from '../theme/createStyles';
+
+/**
+ * What a list says when it is empty on purpose.
+ *
+ * Distinct from a skeleton, which says "not yet", and from the error fallback, which says
+ * "something broke". This one says "nothing here, and here is what to do about it" — and the
+ * last clause is the part that gets skipped. An empty gossips board that only reads "No posts
+ * yet" is a dead end at an event where the whole point is that an attendee can post one.
+ *
+ * The illustration and the action are slots rather than typed props: what fills them is an
+ * image for one event and an icon for another, and a button here, a link there. Taking a
+ * `ReactNode` keeps this component from owning either decision, and keeps this file from
+ * depending on the button component to render an empty list.
+ */
+
+type Props = {
+  /**
+   * Decorative only — it is hidden from screen readers, because the title and message already
+   * carry the meaning and a described picture of nothing is noise. Anything load-bearing
+   * belongs in `title` or `message`.
+   */
+  readonly illustration?: ReactNode;
+  /** The state, in the attendee's words: "No photos yet", not "Empty". */
+  readonly title: string;
+  /** Why it is empty, or what fills it. One sentence. */
+  readonly message?: string | undefined;
+  /** The one thing to do about it. Omitted when there genuinely is nothing to do. */
+  readonly action?: ReactNode;
+  readonly style?: StyleProp<ViewStyle> | undefined;
+};
+
+const useStyles = createStyles((t) => ({
+  root: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: t.space(12),
+    paddingHorizontal: t.space(6),
+    gap: t.space(3),
+  },
+  title: { ...t.type.title2, color: t.color.text, textAlign: 'center' },
+  /* Capped rather than left to the container: an empty state is one sentence, and one sentence
+     across the full width of a tablet is a line nobody's eye can track back from. */
+  message: { ...t.type.body, color: t.color.textMuted, textAlign: 'center', maxWidth: t.space(80) },
+  action: { marginTop: t.space(2) },
+}));
+
+export function EmptyState({ illustration, title, message, action, style }: Props) {
+  const styles = useStyles();
+
+  return (
+    <View style={[styles.root, style]}>
+      {illustration === undefined ? null : (
+        <View accessibilityElementsHidden importantForAccessibility="no-hide-descendants">
+          {illustration}
+        </View>
+      )}
+      {/* `header` rather than nothing: it is how a screen reader user skims to "what is this
+          screen showing me", which for an empty list is the only content there is. */}
+      <Text accessibilityRole="header" style={styles.title}>
+        {title}
+      </Text>
+      {message === undefined ? null : <Text style={styles.message}>{message}</Text>}
+      {action === undefined ? null : <View style={styles.action}>{action}</View>}
+    </View>
+  );
+}

--- a/packages/ui/src/feedback/Skeleton.tsx
+++ b/packages/ui/src/feedback/Skeleton.tsx
@@ -1,0 +1,105 @@
+import type { ResolvedTheme } from '@occasio/theme';
+import { useMemo } from 'react';
+import { Animated, View, type DimensionValue, type StyleProp, type ViewStyle } from 'react-native';
+import { useTheme } from '../theme/useTheme';
+import { useSkeletonPulse } from './SkeletonGroup';
+import { skeletonTextRows } from './skeletonText';
+
+/**
+ * The two pieces a loading placeholder is built from.
+ *
+ * The point of the whole file, and of #28: **a skeleton is the screen with its content
+ * removed, not a spinner where the screen will be.** The mock adapter carries deliberate
+ * latency (D4) so this gets designed alongside each layout rather than retrofitted onto it.
+ * A spinner tells someone that something is happening; a skeleton tells them what is about to
+ * be there, and then does not move the page when it arrives.
+ *
+ * Which is why these are primitives rather than a `<LoadingSchedule>` per screen. A screen's
+ * skeleton is a copy of that screen's box model, so it belongs next to the layout it mirrors
+ * and lands in that screen's PR — written anywhere else, it starts drifting from the layout the
+ * day after it is merged. What lives here is the vocabulary that makes such a copy exact: bars
+ * measured in the same theme units the real components read, and text blocks measured from the
+ * very type token the real text will use.
+ */
+
+/** The `t.type.*` keys that are text styles; `family` is the font stack, not a style. */
+type TypeVariant = Exclude<keyof ResolvedTheme['type'], 'family'>;
+
+type SkeletonProps = {
+  /** Defaults to filling its parent, which is what a bar inside a laid-out row usually wants. */
+  readonly width?: DimensionValue | undefined;
+  /** In points, from `t.space(n)` or a `t.type.*` metric — never a number typed by hand. */
+  readonly height?: number | undefined;
+  readonly radius?: keyof ResolvedTheme['radius'] | undefined;
+  readonly style?: StyleProp<ViewStyle> | undefined;
+};
+
+/**
+ * One placeholder block: an avatar, a thumbnail, a button, a line of a heading.
+ *
+ * Size it from the same tokens the real element uses — `<Skeleton width={t.space(12)}
+ * height={t.space(12)} radius="pill" />` for an avatar that will be `t.space(12)` across — and
+ * the swap to real content moves nothing.
+ */
+export function Skeleton({ width = '100%', height, radius = 'sm', style }: SkeletonProps) {
+  const theme = useTheme();
+  const opacity = useSkeletonPulse();
+
+  return (
+    <Animated.View
+      /* Ramp step 4 is a component background: present against both `bg` and `surface` in
+         either scheme, without reading as a filled control that failed to load. */
+      style={[
+        {
+          width,
+          height: height ?? theme.space(3),
+          borderRadius: theme.radius[radius],
+          backgroundColor: theme.color.ramp.neutral[3],
+          opacity,
+        },
+        style,
+      ]}
+    />
+  );
+}
+
+type SkeletonTextProps = {
+  readonly lines?: number | undefined;
+  /** The `t.type.*` style the real text will be rendered in. */
+  readonly variant?: TypeVariant | undefined;
+  /** Percentage width of the closing line. Ignored when there is only one line. */
+  readonly lastLineWidth?: number | undefined;
+  readonly style?: StyleProp<ViewStyle> | undefined;
+};
+
+/**
+ * A block of placeholder text that occupies exactly the space the real text will.
+ *
+ * Each row is a full line box of the chosen type token with the bar centred inside it, so
+ * `lines` lines here and `lines` lines of loaded text are the same height and nothing below
+ * jumps. The arithmetic is in skeletonText.ts, where it can be tested.
+ */
+export function SkeletonText({
+  lines = 3,
+  variant = 'body',
+  lastLineWidth,
+  style,
+}: SkeletonTextProps) {
+  const theme = useTheme();
+  const rows = useMemo(
+    () => skeletonTextRows(theme.type[variant], lines, lastLineWidth),
+    [theme, variant, lines, lastLineWidth],
+  );
+
+  return (
+    <View style={style}>
+      {rows.map((row, index) => (
+        /* Index keys: the rows are positional, homogeneous and never reordered or removed —
+           there is no identity here for a key to carry. */
+        <View key={index} style={{ height: row.lineHeight, justifyContent: 'center' }}>
+          <Skeleton width={row.width} height={row.barHeight} radius="xs" />
+        </View>
+      ))}
+    </View>
+  );
+}

--- a/packages/ui/src/feedback/SkeletonGroup.tsx
+++ b/packages/ui/src/feedback/SkeletonGroup.tsx
@@ -1,0 +1,116 @@
+import { createContext, useContext, useEffect, useMemo, useRef, type ReactNode } from 'react';
+import { Animated, Easing, Platform, View, type StyleProp, type ViewStyle } from 'react-native';
+import { useTheme } from '../theme/useTheme';
+
+/**
+ * The wrapper every skeleton lives inside. It does two things a lone bar cannot.
+ *
+ * **One pulse for the whole placeholder.** If each bar drove its own loop, bars mounted a frame
+ * apart — a list that appends a footer placeholder, a section that reveals late — would drift
+ * out of phase, and a screen of placeholders shimmering independently reads as broken rather
+ * than as loading. One Animated.Value per group also means one driver node instead of thirty.
+ *
+ * **One thing said to a screen reader.** A skeleton is twenty meaningless rectangles; announced
+ * individually they are twenty meaningless rectangles. Announced as one busy `progressbar` with
+ * a label, they are "loading the schedule".
+ *
+ * Both are why <Skeleton> throws outside a group rather than quietly rendering a static bar,
+ * the same reasoning as useTheme(): a placeholder that silently loses its animation and its
+ * accessible name still looks fine in the simulator.
+ */
+
+/** The pulsing opacity, shared by every bar in the group. */
+export const SkeletonPulseContext = createContext<Animated.AnimatedInterpolation<number> | null>(
+  null,
+);
+
+/** Fully opaque at rest, so a reduced-motion group is a plain, legible placeholder. */
+const OPACITY_REST = 1;
+/** Far enough to be unmistakably alive, short of the flicker that makes people look away. */
+const OPACITY_FADED = 0.45;
+
+export const useSkeletonPulse = (): Animated.AnimatedInterpolation<number> => {
+  const pulse = useContext(SkeletonPulseContext);
+  if (pulse === null) {
+    throw new Error(
+      '<Skeleton> was rendered outside a <SkeletonGroup>. The group owns the shared pulse and the "loading" announcement, so a skeleton without one is silently unanimated and silently unlabelled.',
+    );
+  }
+  return pulse;
+};
+
+type Props = {
+  /**
+   * What is loading, in the words an attendee would use — this is the whole announcement, so
+   * "Loading the schedule" beats "Loading".
+   */
+  readonly label: string;
+  readonly children: ReactNode;
+  readonly style?: StyleProp<ViewStyle> | undefined;
+};
+
+export function SkeletonGroup({ label, children, style }: Props) {
+  const theme = useTheme();
+  const progress = useRef(new Animated.Value(0)).current;
+
+  const { enabled, slow } = theme.motion;
+
+  useEffect(() => {
+    /* D11 — the reduced-motion path is a first-class path, not a degraded one. A static bar at
+       full opacity still says "content is coming", and it is what the theme asks for when the
+       tenant picked motion: none or the OS asked for less. */
+    if (!enabled) return undefined;
+
+    const loop = Animated.loop(
+      Animated.sequence([
+        Animated.timing(progress, {
+          toValue: 1,
+          duration: slow * 2,
+          easing: Easing.inOut(Easing.quad),
+          /* react-native-web has no native driver, and asking for one there logs a warning on
+             every mount. Web is the platform this ships on first (D30). */
+          useNativeDriver: Platform.OS !== 'web',
+        }),
+        Animated.timing(progress, {
+          toValue: 0,
+          duration: slow * 2,
+          easing: Easing.inOut(Easing.quad),
+          useNativeDriver: Platform.OS !== 'web',
+        }),
+      ]),
+    );
+    loop.start();
+
+    return () => {
+      loop.stop();
+      /* Leaving it mid-fade would freeze the next group that reuses this value at whatever
+         opacity this one happened to unmount at. */
+      progress.setValue(0);
+    };
+  }, [enabled, slow, progress]);
+
+  const pulse = useMemo(
+    () =>
+      progress.interpolate({
+        inputRange: [0, 1],
+        outputRange: [OPACITY_REST, OPACITY_FADED],
+      }),
+    [progress],
+  );
+
+  return (
+    <SkeletonPulseContext.Provider value={pulse}>
+      {/* `accessible` collapses the subtree into this one node, so the bars inside are never
+          reached individually. */}
+      <View
+        style={style}
+        accessible
+        accessibilityRole="progressbar"
+        accessibilityLabel={label}
+        accessibilityState={{ busy: true }}
+      >
+        {children}
+      </View>
+    </SkeletonPulseContext.Provider>
+  );
+}

--- a/packages/ui/src/feedback/skeletonText.test.ts
+++ b/packages/ui/src/feedback/skeletonText.test.ts
@@ -1,0 +1,67 @@
+import { resolveTheme, themeInputFromPreset } from '@occasio/theme';
+import { describe, expect, it } from '@jest/globals';
+import { DEFAULT_LAST_LINE_WIDTH, skeletonTextRows } from './skeletonText';
+
+/* Real resolved tokens rather than a hand-written fixture. A fixture would have to state a
+   fontSize and a lineHeight as literals — which D17 rightly rejects — and would also let this
+   suite keep passing against metrics the resolver no longer produces. */
+const { type } = resolveTheme(themeInputFromPreset('conference', '#2B6CB0'), {
+  forceScheme: 'light',
+});
+
+describe('skeletonTextRows', () => {
+  it('occupies exactly the height of the text it stands in for', () => {
+    const total = skeletonTextRows(type.body, 4).reduce((sum, row) => sum + row.lineHeight, 0);
+
+    expect(total).toBe(4 * type.body.lineHeight);
+  });
+
+  it('measures each variant from its own token, not from a shared guess', () => {
+    const [heading] = skeletonTextRows(type.display1, 1);
+    const [caption] = skeletonTextRows(type.caption, 1);
+
+    expect(heading?.lineHeight).toBe(type.display1.lineHeight);
+    expect(caption?.lineHeight).toBe(type.caption.lineHeight);
+    expect(heading?.barHeight).toBeGreaterThan(caption?.barHeight ?? 0);
+  });
+
+  it('draws the bar at ink height, not at the height of the line box', () => {
+    const [row] = skeletonTextRows(type.body, 1);
+
+    /* The gap between the two is the point: a bar as tall as the line box leaves no space
+       between lines and reads as one solid slab. */
+    expect(row?.barHeight).toBeLessThan(type.body.lineHeight);
+    expect(row?.barHeight).toBeGreaterThan(0);
+    expect(row?.barHeight).toBe(Math.round(row?.barHeight ?? 0));
+  });
+
+  it('shortens the last line of a paragraph', () => {
+    const rows = skeletonTextRows(type.body, 3);
+
+    expect(rows.map((row) => row.width)).toEqual([
+      '100%',
+      '100%',
+      `${String(DEFAULT_LAST_LINE_WIDTH)}%`,
+    ]);
+  });
+
+  it('leaves a single line full width, because one short line reads as a broken heading', () => {
+    expect(skeletonTextRows(type.body, 1).map((row) => row.width)).toEqual(['100%']);
+  });
+
+  it('honours an explicit last-line width', () => {
+    expect(skeletonTextRows(type.body, 2, 40).map((row) => row.width)).toEqual(['100%', '40%']);
+  });
+
+  it('rejects line counts that cannot describe a layout', () => {
+    expect(() => skeletonTextRows(type.body, 0)).toThrow(RangeError);
+    expect(() => skeletonTextRows(type.body, -1)).toThrow(RangeError);
+    expect(() => skeletonTextRows(type.body, 1.5)).toThrow(RangeError);
+  });
+
+  it('rejects a last-line width that is not a percentage', () => {
+    expect(() => skeletonTextRows(type.body, 2, 0)).toThrow(RangeError);
+    expect(() => skeletonTextRows(type.body, 2, 140)).toThrow(RangeError);
+    expect(() => skeletonTextRows(type.body, 2, Number.NaN)).toThrow(RangeError);
+  });
+});

--- a/packages/ui/src/feedback/skeletonText.ts
+++ b/packages/ui/src/feedback/skeletonText.ts
@@ -1,0 +1,71 @@
+import type { TextStyleToken } from '@occasio/theme';
+
+/**
+ * The geometry behind <SkeletonText>, kept here as plain arithmetic.
+ *
+ * Free of React and React Native on purpose, exactly like styleCache: the one property that
+ * makes a text skeleton worth having — that it occupies the same vertical space as the text it
+ * stands in for — is arithmetic, and arithmetic that can only be exercised through a rendered
+ * component is arithmetic nobody checks. Component render tests are not possible yet (#110), so
+ * this is the half of the behaviour that can be proven now.
+ */
+
+/**
+ * A bar drawn at the full font size reads as a solid slab, because a font's em box is mostly
+ * the space above the cap and below the baseline. Real ink is roughly cap height, so the bar is
+ * drawn at that fraction and centred in the line box.
+ */
+const INK_RATIO = 0.72;
+
+/** A last line that reached the margin would read as a paragraph that got cut off. */
+export const DEFAULT_LAST_LINE_WIDTH = 62;
+
+export type SkeletonTextRow = {
+  /**
+   * The row's box, equal to one rendered line of this text style. Rows sit flush against each
+   * other with no gap — line spacing already lives inside `lineHeight`, and adding a gap on top
+   * is what makes a skeleton taller than the text that replaces it.
+   */
+  readonly lineHeight: number;
+  /** The bar inside the box, vertically centred. */
+  readonly barHeight: number;
+  readonly width: `${number}%`;
+};
+
+/**
+ * Rows for `lines` lines of text rendered in `token`.
+ *
+ * Total height is exactly `lines * token.lineHeight`, so swapping the skeleton for the loaded
+ * text moves nothing below it.
+ *
+ * A single line is never shortened: the shortened last line is what makes a paragraph read as a
+ * paragraph, and applied to a one-line heading it just reads as a heading rendered wrong.
+ */
+export const skeletonTextRows = (
+  token: TextStyleToken,
+  lines: number,
+  lastLineWidth: number = DEFAULT_LAST_LINE_WIDTH,
+): readonly SkeletonTextRow[] => {
+  if (!Number.isInteger(lines) || lines < 1) {
+    throw new RangeError(
+      `A text skeleton needs a whole number of lines, at least one; got ${String(lines)}`,
+    );
+  }
+  if (!(lastLineWidth > 0 && lastLineWidth <= 100)) {
+    throw new RangeError(`lastLineWidth is a percentage in (0, 100]; got ${String(lastLineWidth)}`);
+  }
+
+  /* Rounded so the bar lands on whole pixels — a fractional height blurs the top and bottom
+     edges on web, which on a two-pixel-tall element is most of it. */
+  const barHeight = Math.max(1, Math.round(token.fontSize * INK_RATIO));
+
+  return Array.from({ length: lines }, (_unused, index): SkeletonTextRow => {
+    const percent = lines > 1 && index === lines - 1 ? lastLineWidth : 100;
+    /* eslint-disable-next-line @typescript-eslint/restrict-template-expressions --
+       The template literal *type* is the point: React Native's DimensionValue accepts
+       `${number}%` and nothing wider, so String(percent) would widen this to `string` and stop
+       it fitting. The interpolated value is a number the guards above have already checked. */
+    const width: `${number}%` = `${percent}%`;
+    return { lineHeight: token.lineHeight, barHeight, width };
+  });
+};

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -3,4 +3,13 @@ export { useTheme } from './theme/useTheme';
 export { createStyles } from './theme/createStyles';
 export { createStyleCache, DEFAULT_MAX_THEMES, type StyleCache } from './theme/styleCache';
 
+export { EmptyState } from './feedback/EmptyState';
+export { Skeleton, SkeletonText } from './feedback/Skeleton';
+export { SkeletonGroup, SkeletonPulseContext, useSkeletonPulse } from './feedback/SkeletonGroup';
+export {
+  DEFAULT_LAST_LINE_WIDTH,
+  skeletonTextRows,
+  type SkeletonTextRow,
+} from './feedback/skeletonText';
+
 export const UI_PACKAGE_VERSION = '0.0.0' as const;


### PR DESCRIPTION
Closes #28

## What changed

`packages/ui` gains the loading and empty vocabulary: `Skeleton`, `SkeletonText`, the
`SkeletonGroup` they live inside, and `EmptyState`. Before this, a screen waiting on the mock
adapter's simulated latency had nothing to render but a spinner.

The measurements are the substance. `SkeletonText` renders one full line box per line of the
exact `t.type.*` token the real text will use, with the bar sat inside the box rather than
between boxes, so the block is exactly `lines × lineHeight` tall and swapping in loaded text
moves nothing below it. The bar is drawn at roughly cap height rather than the full em box —
at the height of the line box it leaves no gap between lines and reads as one solid slab.
`Skeleton` takes width, height and radius so an avatar placeholder is sized from the same
`t.space(12)` the real avatar will be.

## Why this way

**Primitives, not a `<LoadingSchedule>` per screen.** A screen's skeleton is a copy of that
screen's box model. Written next to the layout it mirrors, in that screen's PR, it stays
accurate; written here, ahead of screens that are still placeholders, it would be a guess that
starts drifting the day after it merges. What belongs in `ui` is the vocabulary that makes such
a copy exact — bars measured in theme units, text measured from the token the real text uses.

**`SkeletonGroup` is mandatory, and `Skeleton` throws outside one** — same reasoning as
`useTheme()`. The group owns two things a lone bar cannot: one `Animated.Value` for the whole
placeholder, so bars mounted a frame apart (a list footer, a section that reveals late) cannot
pulse out of phase; and one busy `progressbar` node with a label, so a screen reader hears
"Loading the schedule" instead of twenty anonymous rectangles. A skeleton that silently lost
both would still look right in a simulator, which is exactly the failure the throw prevents.

**`EmptyState` takes the illustration and the action as slots.** What fills them is an image for
one event and an icon for another, a button here and a link there. A `ReactNode` keeps this
component from owning either decision — and keeps an empty list from depending on the button
component in order to render. The illustration is hidden from assistive tech: the title and
message carry the meaning, and a described picture of nothing is noise.

**Motion follows the theme (D11, D30).** `motion.enabled === false` — tenant motion level
`none`, or the OS asking for less — gives static bars at full opacity, a first-class path rather
than a degraded one. The pulse period comes from `motion.slow`, and web asks for no native
driver it does not have.

**D17** — every colour, radius and spacing value comes from a token. The one lint suppression is
narrow and explained inline: `restrict-template-expressions` rejects `` `${percent}%` ``, but the
template literal *type* is the return value, since React Native's `DimensionValue` accepts
`` `${number}%` `` and `String()` would widen it to `string`.

## Checks

- [x] `npm run verify` passes locally
- [x] Scoped to one issue — anything else was split out
- [x] Title is in conventional-commit form (it becomes the squashed commit)
- [x] New architectural rules, if any, have a probe in `tools/enforcement/` — n/a, no new rule

`npm run test:visual` also run locally: 40 screenshots, every route clean. No route renders
these components yet, so it confirms nothing regressed rather than confirming they look right.

## What is not verified

**Nothing here has been rendered.** Component render tests are blocked on #110, so the tested
part is `skeletonTextRows` — the layout arithmetic, driven from real resolved tokens — and
nothing else. Specifically unverified by any test or by eye:

- that the pulse animation runs, stops on unmount, and stays in phase across a group
- that the `progressbar` role and label are announced as one node on iOS, Android and web
- that `accessibilityElementsHidden` / `importantForAccessibility` actually hide the
  illustration
- the chosen ink ratio and pulse opacity range as visual judgements, on any real screen

The first screen to use these is where those get checked.

## One thing for the maintainer, outside this lane

`theme.motion.enabled` is currently driven only by the tenant's `motion.level` — nothing supplies
`reducedMotion` to `<ThemeProvider>` in `apps/mobile/app/_layout.tsx`, so the OS or browser
"reduce motion" setting does not reach the resolver at all. Two consequences, neither of which
this PR can fix without leaving its lane:

1. D11's reduced-motion path is unreachable for a tenant whose motion level is not `none`. That
   is broader than skeletons — it is every animation the app will ever run.
2. `tools/visual/capture.mjs` already launches Playwright with `reducedMotion: 'reduce'`, which
   is exactly the right thing and currently has no effect on the theme. The first screen that
   renders a skeleton will therefore produce a non-deterministic screenshot, because the pulse
   will still be running when the shot is taken.

Worth its own issue against `apps/mobile` before a screen adopts these, rather than being
discovered as a flaky visual gate.
