### PR TITLE
feat(ui): add Surface, Card, Chip, Avatar and Divider

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -77,7 +77,20 @@ export default {
       rootDir: '.',
       testEnvironment: 'jsdom',
       testMatch: ['<rootDir>/packages/*/src/**/*.dom.test.tsx'],
-      moduleNameMapper: { ...moduleNameMapper, '^react-native$': 'react-native-web' },
+      /*
+       * `react-native` becomes its web build; the two Expo packages become stubs.
+       *
+       * Not a transform of the real ones: they reach for the Expo runtime and the native module
+       * registry, which a jsdom test has no use for, and pulling all of it in makes the suite
+       * slow and its failures unreadable — the first attempt reported a syntax error inside a
+       * doc comment. See test/stubs for what the substitution gives up.
+       */
+      moduleNameMapper: {
+        ...moduleNameMapper,
+        '^react-native$': 'react-native-web',
+        '^expo-image$': '<rootDir>/test/stubs/expo-image.tsx',
+        '^expo-linear-gradient$': '<rootDir>/test/stubs/expo-linear-gradient.tsx',
+      },
       /*
        * `.web` first, so the platform split resolves the way Metro resolves it for web.
        *

--- a/packages/theme/src/color.ts
+++ b/packages/theme/src/color.ts
@@ -168,3 +168,12 @@ export const hueOf = (color: string): number => toOklch(color).h;
 
 /** Chroma, used to tell the admin when their seed was pulled into a usable range. */
 export const chromaOf = (color: string): number => toOklch(color).c;
+
+/**
+ * Perceptual lightness, 0 to 1.
+ *
+ * Signed comparisons need this because `contrast` is symmetric: `contrast(a, b)` cannot say
+ * which of the two is lighter, so a test built on it alone will accept a pair whose roles have
+ * been swapped, and accept a hover that darkens beside a press that lightens.
+ */
+export const lightnessOf = (color: string): number => toOklch(color).l;

--- a/packages/theme/src/index.ts
+++ b/packages/theme/src/index.ts
@@ -2,6 +2,7 @@ export {
   buildNeutralRamp,
   buildRamp,
   chromaOf,
+  lightnessOf,
   contrast,
   ensureContrast,
   hueOf,

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -12,6 +12,6 @@
     "expo-image": ">=57",
     "expo-linear-gradient": ">=57",
     "react": "^19.0.0",
-    "react-native": ">=0.77"
+    "react-native": ">=0.78"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -12,6 +12,6 @@
     "expo-image": ">=57",
     "expo-linear-gradient": ">=57",
     "react": "^19.0.0",
-    "react-native": ">=0.76"
+    "react-native": ">=0.77"
   }
 }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -55,4 +55,27 @@ export {
   type ScrimPlacement,
 } from './media/imageFrame';
 
+export { Avatar, type AvatarProps, type AvatarSize } from './primitives/Avatar';
+export { Card, type CardProps } from './primitives/Card';
+export { Chip, type ChipProps } from './primitives/Chip';
+export {
+  Divider,
+  type DividerOrientation,
+  type DividerProps,
+  type DividerTone,
+} from './primitives/Divider';
+export { Surface, type SurfaceProps, type SurfaceShape } from './primitives/Surface';
+export { initialsFrom } from './primitives/initials';
+export {
+  SPACE_STEPS,
+  surfaceBackground,
+  tonalPalette,
+  type BorderTone,
+  type RadiusScale,
+  type SpaceScale,
+  type SurfaceTone,
+  type TonalPalette,
+  type TonalTone,
+} from './primitives/tones';
+
 export const UI_PACKAGE_VERSION = '0.0.0' as const;

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -69,6 +69,7 @@ export { initialsFrom } from './primitives/initials';
 export {
   SPACE_STEPS,
   surfaceBackground,
+  surfacePalette,
   tonalPalette,
   type BorderTone,
   type RadiusScale,

--- a/packages/ui/src/primitives/Avatar.dom.test.tsx
+++ b/packages/ui/src/primitives/Avatar.dom.test.tsx
@@ -1,0 +1,73 @@
+import { themeInputFromPreset } from '@occasio/theme';
+import { afterAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import { Text } from 'react-native';
+import { Image } from '../media/Image';
+import { ThemeProvider } from '../theme/ThemeProvider';
+import { Avatar, type AvatarProps } from './Avatar';
+
+/**
+ * The half of Avatar's contract that only exists at runtime.
+ *
+ * `children` is typed as an element taking `ImageProps`, which constrains the props and not the
+ * component — `ReactElement<ImageProps, typeof Image>` does not help, because JSX produces
+ * `React.JSX.Element` and that is assignable to anything. So the identity check is a runtime
+ * one, and a runtime check with no test is the thing this repo keeps being caught by.
+ */
+
+const THEME = themeInputFromPreset('romantic', '#7C3A5A');
+
+/**
+ * No cast needed to pass a `<Text>` here, which is the finding restated: `JSX.Element` is
+ * `ReactElement<any, any>`, so it satisfies `ReactElement<ImageProps>` — and would satisfy
+ * `ReactElement<ImageProps, typeof Image>` just as happily. The prop type cannot reject this
+ * child, which is why the component checks at runtime and why this file exists.
+ */
+const renderAvatar = (children?: AvatarProps['children']) =>
+  render(
+    <ThemeProvider input={THEME} forceScheme="light">
+      <Avatar name="Riya Kapoor">{children}</Avatar>
+    </ThemeProvider>,
+  );
+
+describe('Avatar', () => {
+  const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+  beforeEach(() => {
+    warn.mockClear();
+  });
+
+  afterAll(() => {
+    warn.mockRestore();
+  });
+
+  it('falls back to initials when there is no photograph', () => {
+    renderAvatar();
+
+    /* Most guests never upload one, so this is the common case rather than the fallback. */
+    expect(screen.getByText('RK')).toBeTruthy();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('accepts the package Image without complaint', () => {
+    renderAvatar(<Image source="https://example.test/riya.jpg" alt="Riya Kapoor" />);
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('warns when the child is some other element', () => {
+    /* What the prop type cannot catch: anything satisfies `ReactElement<ImageProps>`, including
+       a component of one's own that renders react-native's `Image` — a spinner and no
+       alternative text, inside a circle that is meant to guarantee neither. */
+    renderAvatar(<Text>not an image</Text>);
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0]?.[0])).toContain('Image');
+  });
+
+  it('names the avatar for a screen reader whether or not there is a photo', () => {
+    renderAvatar();
+
+    expect(screen.getByLabelText('Riya Kapoor')).toBeTruthy();
+  });
+});

--- a/packages/ui/src/primitives/Avatar.tsx
+++ b/packages/ui/src/primitives/Avatar.tsx
@@ -1,5 +1,6 @@
-import type { ReactNode } from 'react';
+import type { ReactElement } from 'react';
 import { Text, View, type StyleProp, type ViewStyle } from 'react-native';
+import type { ImageProps } from '../media/Image';
 import { createStyles } from '../theme/createStyles';
 import { useTheme } from '../theme/useTheme';
 import { initialsFrom } from './initials';
@@ -70,8 +71,15 @@ export type AvatarProps = {
   readonly name: string;
   readonly size?: AvatarSize | undefined;
   readonly tone?: TonalTone | undefined;
-  /** An image element, clipped to the circle. Nothing is rendered behind it. */
-  readonly children?: ReactNode;
+  /**
+   * The avatar's photograph, clipped to the circle. Nothing is rendered behind it.
+   *
+   * Typed as an `<Image>` element rather than a bare `ReactNode`, because `ReactNode` accepted
+   * react-native's `Image` — the one this package bans — and with it a photograph that shows a
+   * spinner instead of a blurhash and has no alternative text. The wrapper already requires
+   * both; this is what makes a caller go through it.
+   */
+  readonly children?: ReactElement<ImageProps> | undefined;
   readonly style?: StyleProp<ViewStyle> | undefined;
   readonly testID?: string | undefined;
 };

--- a/packages/ui/src/primitives/Avatar.tsx
+++ b/packages/ui/src/primitives/Avatar.tsx
@@ -90,8 +90,10 @@ export function Avatar({
 
   return (
     <View
-      accessibilityRole="image"
-      accessibilityLabel={name}
+      /* ARIA spellings: react-native-web 0.21 marks the `accessibility*` ones deprecated, and
+         React Native maps these back to the native roles. `img` is the ARIA name for it. */
+      role="img"
+      aria-label={name}
       testID={testID}
       style={[
         styles.box,
@@ -101,7 +103,10 @@ export function Avatar({
       ]}
     >
       {children ?? (
+        /* Hidden from assistive technology: the circle already carries the full name, and
+           without this a screen reader reads "Ada Lovelace, A L". */
         <Text
+          aria-hidden
           numberOfLines={1}
           maxFontSizeMultiplier={MAX_FONT_SCALE}
           style={[styles[LABEL_STYLE[size]], { color: palette.content }]}

--- a/packages/ui/src/primitives/Avatar.tsx
+++ b/packages/ui/src/primitives/Avatar.tsx
@@ -1,6 +1,6 @@
-import type { ReactElement } from 'react';
+import { isValidElement, type ReactElement } from 'react';
 import { Text, View, type StyleProp, type ViewStyle } from 'react-native';
-import type { ImageProps } from '../media/Image';
+import { Image, type ImageProps } from '../media/Image';
 import { createStyles } from '../theme/createStyles';
 import { useTheme } from '../theme/useTheme';
 import { initialsFrom } from './initials';
@@ -74,14 +74,29 @@ export type AvatarProps = {
   /**
    * The avatar's photograph, clipped to the circle. Nothing is rendered behind it.
    *
-   * Typed as an `<Image>` element rather than a bare `ReactNode`, because `ReactNode` accepted
+   * Typed as an element taking `ImageProps` rather than a bare `ReactNode`, which had accepted
    * react-native's `Image` — the one this package bans — and with it a photograph that shows a
-   * spinner instead of a blurhash and has no alternative text. The wrapper already requires
-   * both; this is what makes a caller go through it.
+   * spinner instead of a blurhash and has no alternative text.
+   *
+   * The type constrains the props and not the component. `ReactElement<ImageProps, typeof
+   * Image>` looks like it would fix that and does not: JSX produces `React.JSX.Element`, which
+   * is `ReactElement<any, any>` and assignable to anything — I checked, and `<Text>` satisfies
+   * it. Rather than keep a type parameter that reads as an enforcement and is not one, the
+   * identity is checked at runtime below.
    */
   readonly children?: ReactElement<ImageProps> | undefined;
   readonly style?: StyleProp<ViewStyle> | undefined;
   readonly testID?: string | undefined;
+};
+
+/**
+ * Complains in development and stays silent in a shipped build. Metro replaces
+ * `process.env.NODE_ENV` at build time, so the branch leaves the production bundle entirely.
+ */
+const warnInDevelopment = (message: string): void => {
+  if (process.env.NODE_ENV !== 'production') {
+    console.warn(`<Avatar>: ${message}`);
+  }
 };
 
 export function Avatar({
@@ -95,6 +110,20 @@ export function Avatar({
   const theme = useTheme();
   const styles = useAvatarStyles();
   const palette = tonalPalette(theme, tone);
+
+  /*
+   * The check the prop type cannot make. Anything can satisfy `ReactElement<ImageProps>` — a
+   * component of one's own taking the same props and rendering react-native's `Image` reaches
+   * here happily, which puts a spinner and no alternative text inside the circle.
+   *
+   * A warning rather than a refusal: a wrong image element is a defect, not a reason to blank
+   * a guest's face, and this is exactly the shape of mistake that gets made once and copied.
+   */
+  if (children !== undefined && isValidElement(children) && children.type !== Image) {
+    warnInDevelopment(
+      'children should be the `Image` from @occasio/ui, which is what guarantees a blurhash placeholder and alternative text.',
+    );
+  }
 
   return (
     <View

--- a/packages/ui/src/primitives/Avatar.tsx
+++ b/packages/ui/src/primitives/Avatar.tsx
@@ -1,0 +1,114 @@
+import type { ReactNode } from 'react';
+import { Text, View, type StyleProp, type ViewStyle } from 'react-native';
+import { createStyles } from '../theme/createStyles';
+import { useTheme } from '../theme/useTheme';
+import { initialsFrom } from './initials';
+import { tonalPalette, type TonalTone } from './tones';
+
+/**
+ * A guest's face, or their initials when there is no photo.
+ *
+ * **The image is a child, not a prop.** `<Avatar name="…"><Image …/></Avatar>` rather than
+ * `source={…}`, for two reasons: the avatar never has to grow props for blurhash, priority,
+ * caching and transition as the image component gains them, and it stays free of any image
+ * dependency, so it renders in a plain React tree. The circle clips whatever it is given.
+ *
+ * Nothing a name can contain is allowed to change the size of the circle — see initials.ts.
+ * Sizes come from the space scale, so an avatar tracks the tenant's density like everything
+ * else, and the initials are capped against OS font scaling so a 200% accessibility setting
+ * cannot burst the circle. The full name always reaches a screen reader.
+ */
+
+const useAvatarStyles = createStyles((t) => ({
+  box: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: t.border.hairline,
+    borderRadius: t.radius.pill,
+    /* Clips a child image to the circle. */
+    overflow: 'hidden',
+  },
+
+  sizeXs: { width: t.space(6), height: t.space(6) },
+  sizeSm: { width: t.space(8), height: t.space(8) },
+  sizeMd: { width: t.space(10), height: t.space(10) },
+  sizeLg: { width: t.space(14), height: t.space(14) },
+
+  labelXs: { ...t.type.overline },
+  labelSm: { ...t.type.caption },
+  labelMd: { ...t.type.bodyStrong },
+  labelLg: { ...t.type.title2 },
+}));
+
+type AvatarStyles = ReturnType<typeof useAvatarStyles>;
+
+export type AvatarSize = 'xs' | 'sm' | 'md' | 'lg';
+
+const SIZE_STYLE = {
+  xs: 'sizeXs',
+  sm: 'sizeSm',
+  md: 'sizeMd',
+  lg: 'sizeLg',
+} as const satisfies Record<AvatarSize, keyof AvatarStyles>;
+
+const LABEL_STYLE = {
+  xs: 'labelXs',
+  sm: 'labelSm',
+  md: 'labelMd',
+  lg: 'labelLg',
+} as const satisfies Record<AvatarSize, keyof AvatarStyles>;
+
+/**
+ * The circle is a fixed size, so unbounded OS font scaling would push the initials outside it.
+ * Capped rather than disabled: a reader who scales text still gets larger initials, up to a
+ * point the circle can hold.
+ */
+const MAX_FONT_SCALE = 1.3;
+
+export type AvatarProps = {
+  /** Used for the initials fallback and as the accessible name. Required for both reasons. */
+  readonly name: string;
+  readonly size?: AvatarSize | undefined;
+  readonly tone?: TonalTone | undefined;
+  /** An image element, clipped to the circle. Nothing is rendered behind it. */
+  readonly children?: ReactNode;
+  readonly style?: StyleProp<ViewStyle> | undefined;
+  readonly testID?: string | undefined;
+};
+
+export function Avatar({
+  name,
+  size = 'md',
+  tone = 'neutral',
+  children,
+  style,
+  testID,
+}: AvatarProps) {
+  const theme = useTheme();
+  const styles = useAvatarStyles();
+  const palette = tonalPalette(theme, tone);
+
+  return (
+    <View
+      accessibilityRole="image"
+      accessibilityLabel={name}
+      testID={testID}
+      style={[
+        styles.box,
+        styles[SIZE_STYLE[size]],
+        { backgroundColor: palette.background, borderColor: palette.border },
+        style,
+      ]}
+    >
+      {children ?? (
+        <Text
+          numberOfLines={1}
+          maxFontSizeMultiplier={MAX_FONT_SCALE}
+          style={[styles[LABEL_STYLE[size]], { color: palette.content }]}
+        >
+          {initialsFrom(name)}
+        </Text>
+      )}
+    </View>
+  );
+}

--- a/packages/ui/src/primitives/Card.tsx
+++ b/packages/ui/src/primitives/Card.tsx
@@ -1,0 +1,27 @@
+import { Surface, type SurfaceProps } from './Surface';
+
+export type CardProps = SurfaceProps;
+
+/**
+ * A Surface with the card defaults named once.
+ *
+ * It adds no props and no behaviour, and that is the point: "card" is a set of decisions —
+ * raised tone, hairline, large radius, comfortable padding — not a second implementation of a
+ * box. Every one of them stays overridable, so a compact list card is `<Card padding="sm">`
+ * rather than a `variant` enum that grows a case per screen.
+ *
+ * Passing `onPress` makes it a pressable card, with hover, press, focus and disabled handled by
+ * the same code that handles them for Chip.
+ */
+export function Card({
+  tone = 'raised',
+  border = 'hairline',
+  radius = 'lg',
+  padding = 'md',
+  gap = 'sm',
+  ...rest
+}: CardProps) {
+  return (
+    <Surface tone={tone} border={border} radius={radius} padding={padding} gap={gap} {...rest} />
+  );
+}

--- a/packages/ui/src/primitives/Chip.tsx
+++ b/packages/ui/src/primitives/Chip.tsx
@@ -38,15 +38,8 @@ const useChipStyles = createStyles((t) => ({
   label: { ...t.type.caption, flexShrink: 1 },
 }));
 
-export type ChipProps = {
+type ChipBase = {
   readonly tone?: TonalTone | undefined;
-  /**
-   * Present only on a chip that toggles. Left out — not set to `false` — on a plain tag, which
-   * is what tells the chip whether it is a checkbox or a button, and stops every filter chip
-   * announcing "not selected".
-   */
-  readonly selected?: boolean | undefined;
-  readonly onPress?: (() => void) | undefined;
   readonly disabled?: boolean | undefined;
   readonly leading?: ReactNode;
   readonly trailing?: ReactNode;
@@ -55,6 +48,30 @@ export type ChipProps = {
   /** The label. Screen readers get it in full even when it is visually truncated. */
   readonly children: string;
 };
+
+/**
+ * A chip is one of two things, and the type makes you say which.
+ *
+ * `selected` on its own used to compile, and painted the selected palette while rendering
+ * without `role="checkbox"` or `aria-checked` — the state visible to anyone who can see the
+ * colour and invisible to anyone who cannot. A selected state nobody can toggle is also not a
+ * state, it is a colour, and a tag wanting the brand colour should ask for the tone.
+ */
+export type ChipProps =
+  | (ChipBase & {
+      /**
+       * Present only on a chip that toggles, which is why it brings `onPress` with it. Left out
+       * — not set to `false` — on a plain tag, so that every filter chip does not announce
+       * "not selected".
+       */
+      readonly selected: boolean;
+      readonly onPress: () => void;
+    })
+  | (ChipBase & {
+      readonly selected?: undefined;
+      /** A chip that acts without toggling: a dismissable filter, a link. */
+      readonly onPress?: (() => void) | undefined;
+    });
 
 export function Chip({
   tone = 'neutral',
@@ -73,8 +90,12 @@ export function Chip({
 
   /* A chip that toggles is a checkbox, not a button: `aria-selected` is only valid on options
      and tabs, so a screen reader would ignore it on a button. `aria-checked` is valid here, is
-     forwarded by react-native-web, and React Native maps it to the native checked state. */
-  const togglable = onPress !== undefined && selected !== undefined;
+     forwarded by react-native-web, and React Native maps it to the native checked state.
+
+     `selected` is enough on its own now — the prop types will not let it arrive without an
+     `onPress`, so this no longer has to defend against the combination that produced a
+     silently unannounced selected state. */
+  const togglable = selected !== undefined;
 
   return (
     <InteractiveBox

--- a/packages/ui/src/primitives/Chip.tsx
+++ b/packages/ui/src/primitives/Chip.tsx
@@ -40,6 +40,11 @@ const useChipStyles = createStyles((t) => ({
 
 export type ChipProps = {
   readonly tone?: TonalTone | undefined;
+  /**
+   * Present only on a chip that toggles. Left out — not set to `false` — on a plain tag, which
+   * is what tells the chip whether it is a checkbox or a button, and stops every filter chip
+   * announcing "not selected".
+   */
   readonly selected?: boolean | undefined;
   readonly onPress?: (() => void) | undefined;
   readonly disabled?: boolean | undefined;
@@ -53,7 +58,7 @@ export type ChipProps = {
 
 export function Chip({
   tone = 'neutral',
-  selected = false,
+  selected,
   onPress,
   disabled = false,
   leading,
@@ -64,7 +69,12 @@ export function Chip({
 }: ChipProps) {
   const theme = useTheme();
   const styles = useChipStyles();
-  const palette = tonalPalette(theme, selected ? 'brandSolid' : tone);
+  const palette = tonalPalette(theme, selected === true ? 'brandSolid' : tone);
+
+  /* A chip that toggles is a checkbox, not a button: `aria-selected` is only valid on options
+     and tabs, so a screen reader would ignore it on a button. `aria-checked` is valid here, is
+     forwarded by react-native-web, and React Native maps it to the native checked state. */
+  const togglable = onPress !== undefined && selected !== undefined;
 
   return (
     <InteractiveBox
@@ -72,11 +82,9 @@ export function Chip({
       boxStyle={styles.box}
       onPress={onPress}
       disabled={disabled}
-      accessibilityRole={onPress === undefined ? 'text' : 'button'}
-      /* Only a chip you can act on has a selection state; announcing "not selected" on a
-         read-only tag is noise. */
-      accessibilityState={onPress === undefined ? undefined : { selected }}
-      accessibilityLabel={children}
+      role={togglable ? 'checkbox' : undefined}
+      aria-checked={togglable ? selected : undefined}
+      aria-label={children}
       testID={testID}
       style={style}
     >

--- a/packages/ui/src/primitives/Chip.tsx
+++ b/packages/ui/src/primitives/Chip.tsx
@@ -1,0 +1,94 @@
+import type { ReactNode } from 'react';
+import { Text, View, type StyleProp, type ViewStyle } from 'react-native';
+import { createStyles } from '../theme/createStyles';
+import { useTheme } from '../theme/useTheme';
+import { InteractiveBox } from './InteractiveBox';
+import { tonalPalette, type TonalTone } from './tones';
+
+/**
+ * A pill carrying one short label: a dietary tag, an RSVP state, a filter.
+ *
+ * **Label is a string, not children.** A chip that accepts arbitrary children cannot promise to
+ * stay one line, and "Partners welcome" next to "Veg" in a wrapping row is exactly where that
+ * promise breaks. Being a string lets the chip guarantee the two things that keep a chip row
+ * readable: the label truncates with an ellipsis instead of wrapping, and the chip shrinks
+ * instead of pushing its neighbours off the screen. Icons go in `leading`/`trailing`, which are
+ * pinned at their natural size so they never get squeezed to nothing.
+ *
+ * Selection is one visual state rather than a variant of every tone — a filter row where each
+ * chip is selected in its own colour is unreadable at a glance.
+ */
+
+const useChipStyles = createStyles((t) => ({
+  box: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    /* Sizes to its label, and shrinks rather than overflowing when the row runs out of room. */
+    alignSelf: 'flex-start',
+    flexShrink: 1,
+    maxWidth: '100%',
+    borderWidth: t.border.hairline,
+    borderRadius: t.radius.pill,
+    paddingHorizontal: t.space(3),
+    paddingVertical: t.space(1),
+    gap: t.space(1),
+  },
+  /* Icons keep their size; only the label gives ground. */
+  slot: { flexShrink: 0 },
+  label: { ...t.type.caption, flexShrink: 1 },
+}));
+
+export type ChipProps = {
+  readonly tone?: TonalTone | undefined;
+  readonly selected?: boolean | undefined;
+  readonly onPress?: (() => void) | undefined;
+  readonly disabled?: boolean | undefined;
+  readonly leading?: ReactNode;
+  readonly trailing?: ReactNode;
+  readonly style?: StyleProp<ViewStyle> | undefined;
+  readonly testID?: string | undefined;
+  /** The label. Screen readers get it in full even when it is visually truncated. */
+  readonly children: string;
+};
+
+export function Chip({
+  tone = 'neutral',
+  selected = false,
+  onPress,
+  disabled = false,
+  leading,
+  trailing,
+  style,
+  testID,
+  children,
+}: ChipProps) {
+  const theme = useTheme();
+  const styles = useChipStyles();
+  const palette = tonalPalette(theme, selected ? 'brandSolid' : tone);
+
+  return (
+    <InteractiveBox
+      palette={palette}
+      boxStyle={styles.box}
+      onPress={onPress}
+      disabled={disabled}
+      accessibilityRole={onPress === undefined ? 'text' : 'button'}
+      /* Only a chip you can act on has a selection state; announcing "not selected" on a
+         read-only tag is noise. */
+      accessibilityState={onPress === undefined ? undefined : { selected }}
+      accessibilityLabel={children}
+      testID={testID}
+      style={style}
+    >
+      {leading === undefined ? null : <View style={styles.slot}>{leading}</View>}
+      <Text
+        numberOfLines={1}
+        ellipsizeMode="tail"
+        style={[styles.label, { color: palette.content }]}
+      >
+        {children}
+      </Text>
+      {trailing === undefined ? null : <View style={styles.slot}>{trailing}</View>}
+    </InteractiveBox>
+  );
+}

--- a/packages/ui/src/primitives/Divider.tsx
+++ b/packages/ui/src/primitives/Divider.tsx
@@ -1,0 +1,93 @@
+import { View, type StyleProp, type ViewStyle } from 'react-native';
+import { createStyles } from '../theme/createStyles';
+import { SPACE_STEPS, type SpaceScale } from './tones';
+
+/**
+ * A hairline rule.
+ *
+ * Drawn as a filled box of `border.hairline` rather than as a border, so a divider between two
+ * rows cannot be mistaken for one of those rows having a border — and so its colour comes from
+ * `divider`, the token the resolver keeps deliberately fainter than `border`.
+ *
+ * Decorative by default: it is hidden from assistive technology, because a separator announced
+ * between every list item is noise. Structure that a screen reader needs belongs in headings.
+ */
+
+const useDividerStyles = createStyles((t) => ({
+  horizontal: { alignSelf: 'stretch', height: t.border.hairline },
+  vertical: { alignSelf: 'stretch', width: t.border.hairline },
+
+  toneDivider: { backgroundColor: t.color.divider },
+  toneBorder: { backgroundColor: t.color.border },
+
+  insetHorizontalNone: { marginHorizontal: t.space(SPACE_STEPS.none) },
+  insetHorizontalXs: { marginHorizontal: t.space(SPACE_STEPS.xs) },
+  insetHorizontalSm: { marginHorizontal: t.space(SPACE_STEPS.sm) },
+  insetHorizontalMd: { marginHorizontal: t.space(SPACE_STEPS.md) },
+  insetHorizontalLg: { marginHorizontal: t.space(SPACE_STEPS.lg) },
+
+  insetVerticalNone: { marginVertical: t.space(SPACE_STEPS.none) },
+  insetVerticalXs: { marginVertical: t.space(SPACE_STEPS.xs) },
+  insetVerticalSm: { marginVertical: t.space(SPACE_STEPS.sm) },
+  insetVerticalMd: { marginVertical: t.space(SPACE_STEPS.md) },
+  insetVerticalLg: { marginVertical: t.space(SPACE_STEPS.lg) },
+}));
+
+type DividerStyles = ReturnType<typeof useDividerStyles>;
+
+export type DividerOrientation = 'horizontal' | 'vertical';
+export type DividerTone = 'divider' | 'border';
+
+const TONE_STYLE = {
+  divider: 'toneDivider',
+  border: 'toneBorder',
+} as const satisfies Record<DividerTone, keyof DividerStyles>;
+
+/** Inset runs along the line, so a horizontal rule insets left and right. */
+const INSET_STYLE = {
+  horizontal: {
+    none: 'insetHorizontalNone',
+    xs: 'insetHorizontalXs',
+    sm: 'insetHorizontalSm',
+    md: 'insetHorizontalMd',
+    lg: 'insetHorizontalLg',
+  },
+  vertical: {
+    none: 'insetVerticalNone',
+    xs: 'insetVerticalXs',
+    sm: 'insetVerticalSm',
+    md: 'insetVerticalMd',
+    lg: 'insetVerticalLg',
+  },
+} as const satisfies Record<DividerOrientation, Record<SpaceScale, keyof DividerStyles>>;
+
+export type DividerProps = {
+  readonly orientation?: DividerOrientation | undefined;
+  readonly tone?: DividerTone | undefined;
+  readonly inset?: SpaceScale | undefined;
+  readonly style?: StyleProp<ViewStyle> | undefined;
+  readonly testID?: string | undefined;
+};
+
+export function Divider({
+  orientation = 'horizontal',
+  tone = 'divider',
+  inset = 'none',
+  style,
+  testID,
+}: DividerProps) {
+  const styles = useDividerStyles();
+
+  return (
+    <View
+      aria-hidden
+      testID={testID}
+      style={[
+        styles[orientation],
+        styles[TONE_STYLE[tone]],
+        styles[INSET_STYLE[orientation][inset]],
+        style,
+      ]}
+    />
+  );
+}

--- a/packages/ui/src/primitives/InteractiveBox.tsx
+++ b/packages/ui/src/primitives/InteractiveBox.tsx
@@ -1,0 +1,119 @@
+import type { ReactNode } from 'react';
+import {
+  Pressable,
+  View,
+  type AccessibilityRole,
+  type AccessibilityState,
+  type StyleProp,
+  type ViewStyle,
+} from 'react-native';
+import { createStyles } from '../theme/createStyles';
+import { useTheme } from '../theme/useTheme';
+import { DISABLED_OPACITY, interactiveFill } from './interaction';
+import type { TonalPalette } from './tones';
+import { usePressState } from './usePressState';
+
+/**
+ * The one place a box becomes pressable.
+ *
+ * Internal on purpose — it is not exported from the package. Surface, Card and Chip differ in
+ * shape and palette, not in what "pressed" means, so the four states live here once. Adding a
+ * sixth primitive should not mean writing a fifth hover implementation.
+ *
+ * `palette` carries resolved colour strings rather than token names. That is the one deliberate
+ * exception to "components read tokens directly": the caller has already chosen its palette from
+ * the theme (see tones.ts), and threading token names through would just move the switch
+ * statement one level down. Nothing here invents a colour.
+ */
+
+const useStyles = createStyles((t) => ({
+  /* An outline rather than a border, so focus does not resize the box. */
+  focusRing: {
+    outlineColor: t.color.interactive.focusRing,
+    outlineStyle: 'solid',
+    outlineWidth: t.border.standard,
+    outlineOffset: t.border.standard,
+  },
+  disabled: { opacity: DISABLED_OPACITY },
+}));
+
+export type InteractiveBoxProps = {
+  readonly palette: TonalPalette;
+  /** The primitive's own computed styles. Caller overrides go in `style`, which lands last. */
+  readonly boxStyle: StyleProp<ViewStyle>;
+  readonly onPress?: (() => void) | undefined;
+  readonly disabled?: boolean | undefined;
+  readonly accessibilityRole?: AccessibilityRole | undefined;
+  readonly accessibilityState?: AccessibilityState | undefined;
+  readonly accessibilityLabel?: string | undefined;
+  readonly testID?: string | undefined;
+  readonly style?: StyleProp<ViewStyle> | undefined;
+  readonly children?: ReactNode;
+};
+
+export function InteractiveBox({
+  palette,
+  boxStyle,
+  onPress,
+  disabled = false,
+  accessibilityRole,
+  accessibilityState,
+  accessibilityLabel,
+  testID,
+  style,
+  children,
+}: InteractiveBoxProps) {
+  const theme = useTheme();
+  const styles = useStyles();
+  const { hovered, focused, handlers } = usePressState();
+
+  const fill = { backgroundColor: palette.background, borderColor: palette.border };
+
+  if (onPress === undefined) {
+    return (
+      <View
+        accessibilityRole={accessibilityRole}
+        accessibilityState={accessibilityState}
+        accessibilityLabel={accessibilityLabel}
+        testID={testID}
+        /* A box with no onPress still honours `disabled`: a chip that reads as available but
+           silently does nothing is worse than one that looks switched off. */
+        style={[boxStyle, fill, disabled ? styles.disabled : null, style]}
+      >
+        {children}
+      </View>
+    );
+  }
+
+  return (
+    <Pressable
+      accessibilityRole={accessibilityRole ?? 'button'}
+      accessibilityState={{ ...accessibilityState, disabled }}
+      accessibilityLabel={accessibilityLabel}
+      testID={testID}
+      onPress={onPress}
+      disabled={disabled}
+      onHoverIn={handlers.onHoverIn}
+      onHoverOut={handlers.onHoverOut}
+      onFocus={handlers.onFocus}
+      onBlur={handlers.onBlur}
+      style={({ pressed }) => [
+        boxStyle,
+        {
+          backgroundColor: interactiveFill(theme, palette, {
+            hovered,
+            pressed,
+            focused,
+            disabled,
+          }),
+          borderColor: palette.border,
+        },
+        focused && !disabled ? styles.focusRing : null,
+        disabled ? styles.disabled : null,
+        style,
+      ]}
+    >
+      {children}
+    </Pressable>
+  );
+}

--- a/packages/ui/src/primitives/InteractiveBox.tsx
+++ b/packages/ui/src/primitives/InteractiveBox.tsx
@@ -1,12 +1,5 @@
 import type { ReactNode } from 'react';
-import {
-  Pressable,
-  View,
-  type AccessibilityRole,
-  type AccessibilityState,
-  type StyleProp,
-  type ViewStyle,
-} from 'react-native';
+import { Pressable, View, type Role, type StyleProp, type ViewStyle } from 'react-native';
 import { createStyles } from '../theme/createStyles';
 import { useTheme } from '../theme/useTheme';
 import { DISABLED_OPACITY, interactiveFill } from './interaction';
@@ -22,8 +15,16 @@ import { usePressState } from './usePressState';
  *
  * `palette` carries resolved colour strings rather than token names. That is the one deliberate
  * exception to "components read tokens directly": the caller has already chosen its palette from
- * the theme (see tones.ts), and threading token names through would just move the switch
+ * the theme (see tones.ts), and threading token names through would only move the switch
  * statement one level down. Nothing here invents a colour.
+ *
+ * Accessibility uses the ARIA spellings throughout, for the reason #127 established for the
+ * feedback components: react-native-web 0.21's forwarded-prop table
+ * (`dist/modules/forwardedProps/index.js`) does not contain `accessibilityState` at all, and
+ * marks `accessibilityRole` and `accessibilityLabel` deprecated. A chip's selected state written
+ * the `accessibility*` way is dropped silently on web. React Native maps `role`, `aria-label`,
+ * `aria-checked` and `aria-disabled` back to the native equivalents, so nothing is lost on iOS
+ * or Android — and web, which ships first (D30), gets props it actually reads.
  */
 
 const useStyles = createStyles((t) => ({
@@ -37,15 +38,20 @@ const useStyles = createStyles((t) => ({
   disabled: { opacity: DISABLED_OPACITY },
 }));
 
-export type InteractiveBoxProps = {
+/** The accessibility props a primitive forwards. ARIA spellings — see the note above. */
+export type BoxAccessibilityProps = {
+  readonly role?: Role | undefined;
+  readonly 'aria-label'?: string | undefined;
+  /** For a chip that toggles. Left undefined by anything that is not a toggle. */
+  readonly 'aria-checked'?: boolean | undefined;
+};
+
+export type InteractiveBoxProps = BoxAccessibilityProps & {
   readonly palette: TonalPalette;
   /** The primitive's own computed styles. Caller overrides go in `style`, which lands last. */
   readonly boxStyle: StyleProp<ViewStyle>;
   readonly onPress?: (() => void) | undefined;
   readonly disabled?: boolean | undefined;
-  readonly accessibilityRole?: AccessibilityRole | undefined;
-  readonly accessibilityState?: AccessibilityState | undefined;
-  readonly accessibilityLabel?: string | undefined;
   readonly testID?: string | undefined;
   readonly style?: StyleProp<ViewStyle> | undefined;
   readonly children?: ReactNode;
@@ -56,9 +62,9 @@ export function InteractiveBox({
   boxStyle,
   onPress,
   disabled = false,
-  accessibilityRole,
-  accessibilityState,
-  accessibilityLabel,
+  role,
+  'aria-label': ariaLabel,
+  'aria-checked': ariaChecked,
   testID,
   style,
   children,
@@ -67,14 +73,17 @@ export function InteractiveBox({
   const styles = useStyles();
   const { hovered, focused, handlers } = usePressState();
 
+  /* Omitted rather than false: "not disabled" on every box is noise a screen reader reads out. */
+  const ariaDisabled = disabled ? true : undefined;
   const fill = { backgroundColor: palette.background, borderColor: palette.border };
 
   if (onPress === undefined) {
     return (
       <View
-        accessibilityRole={accessibilityRole}
-        accessibilityState={accessibilityState}
-        accessibilityLabel={accessibilityLabel}
+        role={role}
+        aria-label={ariaLabel}
+        aria-checked={ariaChecked}
+        aria-disabled={ariaDisabled}
         testID={testID}
         /* A box with no onPress still honours `disabled`: a chip that reads as available but
            silently does nothing is worse than one that looks switched off. */
@@ -87,9 +96,10 @@ export function InteractiveBox({
 
   return (
     <Pressable
-      accessibilityRole={accessibilityRole ?? 'button'}
-      accessibilityState={{ ...accessibilityState, disabled }}
-      accessibilityLabel={accessibilityLabel}
+      role={role ?? 'button'}
+      aria-label={ariaLabel}
+      aria-checked={ariaChecked}
+      aria-disabled={ariaDisabled}
       testID={testID}
       onPress={onPress}
       disabled={disabled}

--- a/packages/ui/src/primitives/Surface.tsx
+++ b/packages/ui/src/primitives/Surface.tsx
@@ -1,0 +1,142 @@
+import type { ReactNode } from 'react';
+import type { AccessibilityRole, StyleProp, ViewStyle } from 'react-native';
+import { createStyles } from '../theme/createStyles';
+import { useTheme } from '../theme/useTheme';
+import { InteractiveBox } from './InteractiveBox';
+import {
+  SPACE_STEPS,
+  surfaceBackground,
+  type BorderTone,
+  type RadiusScale,
+  type SpaceScale,
+  type SurfaceTone,
+  type TonalPalette,
+} from './tones';
+
+/**
+ * The tonal box every other surface primitive is made of.
+ *
+ * Depth is two steps of the neutral ramp plus a hairline — never a shadow. Shadows date a
+ * product instantly, render differently on each platform, and on web they smear over a
+ * background image. `bg -> surface -> surfaceRaised` is the whole elevation model; genuinely
+ * floating UI (a sheet, a menu) owns its own elevation rather than every box on the screen
+ * carrying a shadow prop it almost never sets.
+ *
+ * Every size is an enumerated token, so the entire variant matrix is one cached StyleSheet per
+ * theme rather than a fresh object per render.
+ */
+
+const useSurfaceStyles = createStyles((t) => ({
+  /* Clips children to the corner radius — the reason a card can hold a photo. */
+  box: { overflow: 'hidden' },
+
+  borderNone: { borderWidth: 0 },
+  borderHairline: { borderWidth: t.border.hairline },
+  borderStrong: { borderWidth: t.border.standard },
+
+  radiusNone: { borderRadius: 0 },
+  radiusXs: { borderRadius: t.radius.xs },
+  radiusSm: { borderRadius: t.radius.sm },
+  radiusMd: { borderRadius: t.radius.md },
+  radiusLg: { borderRadius: t.radius.lg },
+  radiusPill: { borderRadius: t.radius.pill },
+  radiusHero: { borderRadius: t.radius.hero },
+
+  paddingNone: { padding: t.space(SPACE_STEPS.none) },
+  paddingXs: { padding: t.space(SPACE_STEPS.xs) },
+  paddingSm: { padding: t.space(SPACE_STEPS.sm) },
+  paddingMd: { padding: t.space(SPACE_STEPS.md) },
+  paddingLg: { padding: t.space(SPACE_STEPS.lg) },
+
+  gapNone: { gap: t.space(SPACE_STEPS.none) },
+  gapXs: { gap: t.space(SPACE_STEPS.xs) },
+  gapSm: { gap: t.space(SPACE_STEPS.sm) },
+  gapMd: { gap: t.space(SPACE_STEPS.md) },
+  gapLg: { gap: t.space(SPACE_STEPS.lg) },
+}));
+
+type SurfaceStyles = ReturnType<typeof useSurfaceStyles>;
+
+const BORDER_STYLE = {
+  none: 'borderNone',
+  hairline: 'borderHairline',
+  strong: 'borderStrong',
+} as const satisfies Record<BorderTone, keyof SurfaceStyles>;
+
+const RADIUS_STYLE = {
+  none: 'radiusNone',
+  xs: 'radiusXs',
+  sm: 'radiusSm',
+  md: 'radiusMd',
+  lg: 'radiusLg',
+  pill: 'radiusPill',
+  hero: 'radiusHero',
+} as const satisfies Record<RadiusScale, keyof SurfaceStyles>;
+
+const PADDING_STYLE = {
+  none: 'paddingNone',
+  xs: 'paddingXs',
+  sm: 'paddingSm',
+  md: 'paddingMd',
+  lg: 'paddingLg',
+} as const satisfies Record<SpaceScale, keyof SurfaceStyles>;
+
+const GAP_STYLE = {
+  none: 'gapNone',
+  xs: 'gapXs',
+  sm: 'gapSm',
+  md: 'gapMd',
+  lg: 'gapLg',
+} as const satisfies Record<SpaceScale, keyof SurfaceStyles>;
+
+export type SurfaceShape = {
+  readonly tone?: SurfaceTone | undefined;
+  readonly border?: BorderTone | undefined;
+  readonly radius?: RadiusScale | undefined;
+  readonly padding?: SpaceScale | undefined;
+  readonly gap?: SpaceScale | undefined;
+};
+
+export type SurfaceProps = SurfaceShape & {
+  /** Supplying this turns the surface into a Pressable with hover, press and focus states. */
+  readonly onPress?: (() => void) | undefined;
+  readonly disabled?: boolean | undefined;
+  readonly accessibilityRole?: AccessibilityRole | undefined;
+  readonly accessibilityLabel?: string | undefined;
+  readonly testID?: string | undefined;
+  readonly style?: StyleProp<ViewStyle> | undefined;
+  readonly children?: ReactNode;
+};
+
+export function Surface({
+  tone = 'base',
+  border = 'hairline',
+  radius = 'md',
+  padding = 'none',
+  gap = 'none',
+  ...rest
+}: SurfaceProps) {
+  const theme = useTheme();
+  const styles = useSurfaceStyles();
+
+  const palette: TonalPalette = {
+    background: surfaceBackground(theme, tone),
+    border: border === 'strong' ? theme.color.borderStrong : theme.color.border,
+    /* Body text is what will sit on this box, so it is the pair the hover fill must protect. */
+    content: theme.color.text,
+  };
+
+  return (
+    <InteractiveBox
+      {...rest}
+      palette={palette}
+      boxStyle={[
+        styles.box,
+        styles[BORDER_STYLE[border]],
+        styles[RADIUS_STYLE[radius]],
+        styles[PADDING_STYLE[padding]],
+        styles[GAP_STYLE[gap]],
+      ]}
+    />
+  );
+}

--- a/packages/ui/src/primitives/Surface.tsx
+++ b/packages/ui/src/primitives/Surface.tsx
@@ -1,8 +1,8 @@
 import type { ReactNode } from 'react';
-import type { AccessibilityRole, StyleProp, ViewStyle } from 'react-native';
+import type { StyleProp, ViewStyle } from 'react-native';
 import { createStyles } from '../theme/createStyles';
 import { useTheme } from '../theme/useTheme';
-import { InteractiveBox } from './InteractiveBox';
+import { InteractiveBox, type BoxAccessibilityProps } from './InteractiveBox';
 import {
   SPACE_STEPS,
   surfacePalette,
@@ -20,6 +20,12 @@ import {
  * background image. `bg -> surface -> surfaceRaised` is the whole elevation model; genuinely
  * floating UI (a sheet, a menu) owns its own elevation rather than every box on the screen
  * carrying a shadow prop it almost never sets.
+ *
+ * There is deliberately no `elevation` prop, even though `theme.elevation` and
+ * `toElevationStyle()` exist. A shadow drawn on this box would be clipped by the `overflow:
+ * hidden` that makes the corner radius work, so a floating container composes the two instead:
+ * an outer View carrying `toElevationStyle(theme.elevation.md)` around a Surface. That keeps the
+ * shadow where it belongs — on the handful of things that genuinely float.
  *
  * Every size is an enumerated token, so the entire variant matrix is one cached StyleSheet per
  * theme rather than a fresh object per render.
@@ -96,16 +102,15 @@ export type SurfaceShape = {
   readonly gap?: SpaceScale | undefined;
 };
 
-export type SurfaceProps = SurfaceShape & {
-  /** Supplying this turns the surface into a Pressable with hover, press and focus states. */
-  readonly onPress?: (() => void) | undefined;
-  readonly disabled?: boolean | undefined;
-  readonly accessibilityRole?: AccessibilityRole | undefined;
-  readonly accessibilityLabel?: string | undefined;
-  readonly testID?: string | undefined;
-  readonly style?: StyleProp<ViewStyle> | undefined;
-  readonly children?: ReactNode;
-};
+export type SurfaceProps = SurfaceShape &
+  BoxAccessibilityProps & {
+    /** Supplying this turns the surface into a Pressable with hover, press and focus states. */
+    readonly onPress?: (() => void) | undefined;
+    readonly disabled?: boolean | undefined;
+    readonly testID?: string | undefined;
+    readonly style?: StyleProp<ViewStyle> | undefined;
+    readonly children?: ReactNode;
+  };
 
 export function Surface({
   tone = 'base',

--- a/packages/ui/src/primitives/Surface.tsx
+++ b/packages/ui/src/primitives/Surface.tsx
@@ -5,12 +5,11 @@ import { useTheme } from '../theme/useTheme';
 import { InteractiveBox } from './InteractiveBox';
 import {
   SPACE_STEPS,
-  surfaceBackground,
+  surfacePalette,
   type BorderTone,
   type RadiusScale,
   type SpaceScale,
   type SurfaceTone,
-  type TonalPalette,
 } from './tones';
 
 /**
@@ -119,17 +118,10 @@ export function Surface({
   const theme = useTheme();
   const styles = useSurfaceStyles();
 
-  const palette: TonalPalette = {
-    background: surfaceBackground(theme, tone),
-    border: border === 'strong' ? theme.color.borderStrong : theme.color.border,
-    /* Body text is what will sit on this box, so it is the pair the hover fill must protect. */
-    content: theme.color.text,
-  };
-
   return (
     <InteractiveBox
       {...rest}
-      palette={palette}
+      palette={surfacePalette(theme, tone, border)}
       boxStyle={[
         styles.box,
         styles[BORDER_STYLE[border]],

--- a/packages/ui/src/primitives/initials.test.ts
+++ b/packages/ui/src/primitives/initials.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from '@jest/globals';
+import { initialsFrom } from './initials';
+
+/** Code points, not UTF-16 units: an astral character must count as the one glyph it draws. */
+const codePointsOf = (value: string): readonly string[] => value.match(/./gu) ?? [];
+
+/**
+ * The property that matters is length: an avatar is a fixed-size circle, so no name may ever
+ * produce more than two characters. Everything else here is a case from a real guest list.
+ */
+describe('initialsFrom', () => {
+  it.each([
+    ['Ada Lovelace', 'AL'],
+    /* One long word gives one letter. "AN" would read like two different people. */
+    ['Anantharamakrishnan', 'A'],
+    ['Anantharamakrishnan Venkatasubramanian', 'AV'],
+    /* Middle names are noise — first and last. */
+    ['Mary Jane Watson', 'MW'],
+    ['Jean-Luc Picard', 'JP'],
+    ['  ada   lovelace  ', 'AL'],
+    ['ólafur eliasson', 'ÓE'],
+    ['李 明', '李明'],
+    ['007 Bond', '0B'],
+    /* Punctuation is skipped rather than shown. */
+    ['(Ana) Ruiz', 'AR'],
+  ])('turns %p into %p', (name, expected) => {
+    expect(initialsFrom(name)).toBe(expected);
+  });
+
+  it('falls back to the first character when a name has no letters or digits', () => {
+    /* Emoji-only display names exist, and an empty circle looks like a loading state. */
+    expect(initialsFrom('🎉')).toBe('🎉');
+    expect(initialsFrom('  🎉  ')).toBe('🎉');
+  });
+
+  it('skips a word that contributes nothing rather than emitting a blank initial', () => {
+    expect(initialsFrom('🎉 party')).toBe('P');
+  });
+
+  it('returns nothing it cannot render', () => {
+    expect(initialsFrom('')).toBe('');
+    expect(initialsFrom('   ')).toBe('');
+  });
+
+  it('never returns more than two characters, for any name in a plausible guest list', () => {
+    const names = [
+      'Ada Lovelace',
+      'Anantharamakrishnan Venkatasubramanian Iyer',
+      'María del Carmen García Fernández',
+      'Jean-Luc Picard',
+      'ß',
+      '🎉 🎊 🎈',
+      'a b c d e f g h i j k',
+      '李 明 華',
+    ];
+
+    const lengths = names.map((name) => codePointsOf(initialsFrom(name)).length);
+
+    /* Every one of these names has something to show, and none of them may show more than two. */
+    expect(lengths.filter((length) => length < 1 || length > 2)).toEqual([]);
+  });
+
+  it('uppercases, including where uppercasing lengthens the letter', () => {
+    /* 'ß'.toUpperCase() is 'SS' — the second character must not leak into the circle. */
+    expect(initialsFrom('ßingen')).toBe('S');
+    expect(initialsFrom('ada')).toBe('A');
+  });
+
+  it('does not split an astral character in half', () => {
+    /* A name starting with an ideograph outside the BMP is one code point, two UTF-16 units. */
+    expect(initialsFrom('\u{20BB7} Tanaka')).toBe('\u{20BB7}T');
+  });
+});

--- a/packages/ui/src/primitives/initials.ts
+++ b/packages/ui/src/primitives/initials.ts
@@ -1,0 +1,54 @@
+/**
+ * Initials for an avatar that has no photo.
+ *
+ * The requirement is not "shorten a name" — it is "never let a name change the size of the
+ * circle". A guest list contains `Anantharamakrishnan`, `Ada`, `李 明`, `007 Bond` and the
+ * occasional emoji-only display name, and every one of them has to come out as at most two
+ * characters.
+ */
+
+const MAX_INITIALS = 2;
+
+/* Skips punctuation, so `(Ana)` gives `A` rather than `(`. */
+const LETTER_OR_DIGIT = /[\p{L}\p{N}]/u;
+
+/**
+ * Iterating a string yields code points, so an astral character (an emoji, or a rarer CJK
+ * ideograph) survives intact instead of being cut in half at a surrogate. Combining marks are
+ * *not* grouped — a decomposed `é` would lose its accent. Intl.Segmenter would fix that but is
+ * not reliably present in Hermes, and the cost of getting it wrong is a missing accent on one
+ * letter rather than a broken glyph.
+ */
+const firstInitialOf = (word: string): string => {
+  for (const character of word) {
+    if (LETTER_OR_DIGIT.test(character)) {
+      const [upper] = character.toLocaleUpperCase();
+      return upper ?? '';
+    }
+  }
+  return '';
+};
+
+/**
+ * First and last word, because middle names are noise: `Mary Jane Watson` is `MW`.
+ * A single word gives a single letter — `AN` for `Anantharamakrishnan` reads like two people.
+ *
+ * Returns an empty string for a name with nothing to show, which the avatar renders as a plain
+ * tinted circle rather than a box with stray punctuation in it.
+ */
+export const initialsFrom = (name: string): string => {
+  const initials = name
+    .split(/\s+/u)
+    .map(firstInitialOf)
+    .filter((initial) => initial !== '');
+
+  if (initials.length === 0) {
+    /* Nothing alphanumeric anywhere: an emoji-only display name still deserves its glyph. */
+    const [first] = name.trim();
+    return first ?? '';
+  }
+
+  const chosen =
+    initials.length <= MAX_INITIALS ? initials : [initials[0] ?? '', initials.at(-1) ?? ''];
+  return chosen.join('');
+};

--- a/packages/ui/src/primitives/interaction.ts
+++ b/packages/ui/src/primitives/interaction.ts
@@ -1,0 +1,70 @@
+import { contrast, mix, type ResolvedTheme } from '@occasio/theme';
+import type { TonalPalette } from './tones';
+
+/**
+ * What a pressable box looks like in each of its four states, as a pure function of the theme.
+ *
+ * Kept free of React and React Native so the property that matters — content still meets AA on
+ * the *hovered* and *pressed* fills, not merely on the resting one — is testable without
+ * rendering anything.
+ */
+
+export type PressState = {
+  readonly hovered: boolean;
+  readonly pressed: boolean;
+  readonly focused: boolean;
+  readonly disabled: boolean;
+};
+
+/** How far the fill travels along the neutral ramp. Small: this is a tint, not a colour change. */
+const HOVER_MIX = 0.06;
+const PRESSED_MIX = 0.12;
+
+const AA_TEXT = 4.5;
+
+export const DISABLED_OPACITY = 0.45;
+
+/**
+ * Which way the fill moves when the box is hovered or pressed.
+ *
+ * The default is toward `ramp.neutral[11]`, the high-contrast end — one formula that works in
+ * both schemes without a branch, because neutral[11] is near-black in light and near-white in
+ * dark. So hover darkens a light card and lightens a dark one.
+ *
+ * The default is wrong for a filled chip whose content already sits near that end: darkening a
+ * yellow `warning` chip that carries dark text pushes the pair below AA, and it was measured
+ * doing exactly that (4.50 resting to 3.84 pressed across the preset x seed sweep). When the
+ * strongest state would break AA, the fill moves the other way instead.
+ *
+ * The direction is decided once, from the *pressed* mix, so hover and press never travel in
+ * opposite directions — a box that darkens on hover and lightens on press looks broken.
+ */
+const fillDirection = (theme: ResolvedTheme, palette: TonalPalette): string => {
+  const toward = theme.color.ramp.neutral[11];
+  const away = theme.color.ramp.neutral[0];
+
+  const strongest = mix(palette.background, toward, PRESSED_MIX);
+  if (contrast(palette.content, strongest) >= AA_TEXT) return toward;
+
+  const flipped = mix(palette.background, away, PRESSED_MIX);
+  return contrast(palette.content, flipped) >= contrast(palette.content, strongest) ? away : toward;
+};
+
+/**
+ * The fill for an interactive box in a given state.
+ *
+ * A disabled box does not react — it keeps its resting fill and is dimmed by
+ * `DISABLED_OPACITY` instead, so "nothing happened" reads as "this is off" rather than as a
+ * dropped tap.
+ */
+export const interactiveFill = (
+  theme: ResolvedTheme,
+  palette: TonalPalette,
+  state: PressState,
+): string => {
+  if (state.disabled) return palette.background;
+  if (!state.pressed && !state.hovered) return palette.background;
+
+  const target = fillDirection(theme, palette);
+  return mix(palette.background, target, state.pressed ? PRESSED_MIX : HOVER_MIX);
+};

--- a/packages/ui/src/primitives/tones.test.ts
+++ b/packages/ui/src/primitives/tones.test.ts
@@ -1,0 +1,239 @@
+import { PRESET_IDS, contrast, resolveTheme, themeInputFromPreset } from '@occasio/theme';
+import type { ResolvedTheme, Scheme } from '@occasio/theme';
+import { describe, expect, it } from '@jest/globals';
+import { interactiveFill, type PressState } from './interaction';
+import { SPACE_STEPS, SURFACE_TONES, TONAL_TONES, surfaceBackground, tonalPalette } from './tones';
+
+/**
+ * The primitives promise two things the theme package cannot check on its own: that every
+ * palette a component is able to select is readable, and that "tonal surfaces, not shadows"
+ * produces a step you can actually see.
+ *
+ * Both are pure functions of the resolved theme, so they are swept across every preset, both
+ * schemes and a deterministic spread of seeds — including the neon and near-black ones an admin
+ * will eventually try. No rendering is involved, which is why this can run at all before
+ * jest-expo exists (#110).
+ *
+ * Each sweep collects the themes that failed rather than stopping at the first, so a failure
+ * says which preset, scheme, seed and tone broke and by how much.
+ */
+
+const SEED_COUNT = 120;
+const SCHEMES: readonly Scheme[] = ['light', 'dark'];
+
+const AA_TEXT = 4.5;
+const AAA_TEXT = 7;
+/* Around where a flat fill stops reading as the same colour as the one next to it. */
+const PERCEPTIBLE = 1.03;
+
+/** Deterministic PRNG so a failure reproduces rather than flakes. */
+const mulberry32 = (seed: number): (() => number) => {
+  let state = seed;
+  return () => {
+    state += 0x6d2b79f5;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+};
+
+const randomHex = (random: () => number): string =>
+  `#${Math.floor(random() * 0xffffff)
+    .toString(16)
+    .padStart(6, '0')}`;
+
+const random = mulberry32(0x0cca5107);
+
+const SEEDS: readonly string[] = [
+  /* Adversarial cases first: a neon, a near-black, a near-white and a pure grey. */
+  '#00ff00',
+  '#050505',
+  '#fafafa',
+  '#808080',
+  ...Array.from({ length: SEED_COUNT }, () => randomHex(random)),
+];
+
+type Case = { readonly theme: ResolvedTheme; readonly label: string };
+
+const CASES: readonly Case[] = PRESET_IDS.flatMap((presetId) =>
+  SCHEMES.flatMap((scheme) =>
+    SEEDS.map((seed) => ({
+      theme: resolveTheme(themeInputFromPreset(presetId, seed), { forceScheme: scheme }),
+      label: `${presetId}/${scheme}/${seed}`,
+    })),
+  ),
+);
+
+/** Runs `check` over every theme and returns one line per failure. */
+const sweep = (check: (theme: ResolvedTheme) => readonly string[]): readonly string[] =>
+  CASES.flatMap(({ theme, label }) => check(theme).map((failure) => `${label} — ${failure}`));
+
+const state = (overrides: Partial<PressState> = {}): PressState => ({
+  hovered: false,
+  pressed: false,
+  focused: false,
+  disabled: false,
+  ...overrides,
+});
+
+describe('the sweep itself', () => {
+  it('covers every preset, both schemes and the adversarial seeds', () => {
+    expect(CASES).toHaveLength(PRESET_IDS.length * SCHEMES.length * SEEDS.length);
+    expect(CASES.length).toBeGreaterThan(1000);
+  });
+});
+
+describe('space scale', () => {
+  it('starts at nothing and only ever increases', () => {
+    const steps = Object.values(SPACE_STEPS);
+    expect(steps[0]).toBe(0);
+    expect([...steps].sort((a, b) => a - b)).toEqual(steps);
+  });
+});
+
+describe('surface tones', () => {
+  it('separate by lightness, with no shadow to fall back on', () => {
+    const failures = sweep((theme) => {
+      const sunken = surfaceBackground(theme, 'sunken');
+      const base = surfaceBackground(theme, 'base');
+      const raised = surfaceBackground(theme, 'raised');
+
+      const problems: string[] = [];
+      if (contrast(base, sunken) <= 1) {
+        problems.push(`base is not above sunken (${base} on ${sunken})`);
+      }
+      const step = contrast(raised, base);
+      if (step < PERCEPTIBLE) problems.push(`raised/base step only ${step.toFixed(3)}`);
+      return problems;
+    });
+
+    expect(failures).toEqual([]);
+  });
+
+  it('keep body text at AAA whichever tone a box uses', () => {
+    const failures = sweep((theme) =>
+      SURFACE_TONES.flatMap((tone) => {
+        const ratio = contrast(theme.color.text, surfaceBackground(theme, tone));
+        return ratio >= AAA_TEXT ? [] : [`text on ${tone} is ${ratio.toFixed(2)}`];
+      }),
+    );
+
+    expect(failures).toEqual([]);
+  });
+});
+
+describe('tonal palettes', () => {
+  it('keep their content at AA on their own background', () => {
+    const failures = sweep((theme) =>
+      TONAL_TONES.flatMap((tone) => {
+        const palette = tonalPalette(theme, tone);
+        const ratio = contrast(palette.content, palette.background);
+        return ratio >= AA_TEXT ? [] : [`${tone} content is ${ratio.toFixed(2)}`];
+      }),
+    );
+
+    expect(failures).toEqual([]);
+  });
+
+  it('stay visible against the surface they sit on', () => {
+    /* A chip is either filled differently from the page or outlined against it — a neutral chip
+       relies on its hairline, a status chip on its fill. Either is fine; neither is not. */
+    const failures = sweep((theme) =>
+      TONAL_TONES.flatMap((tone) => {
+        const palette = tonalPalette(theme, tone);
+        const visible = Math.max(
+          contrast(palette.background, theme.color.surface),
+          contrast(palette.border, theme.color.surface),
+        );
+        return visible >= 1.3
+          ? []
+          : [`${tone} disappears into the surface (${visible.toFixed(2)})`];
+      }),
+    );
+
+    expect(failures).toEqual([]);
+  });
+});
+
+describe('interactive fill', () => {
+  it('does not move a disabled box', () => {
+    const failures = sweep((theme) =>
+      TONAL_TONES.flatMap((tone) => {
+        const palette = tonalPalette(theme, tone);
+        const hovered = interactiveFill(theme, palette, state({ disabled: true, hovered: true }));
+        const pressed = interactiveFill(theme, palette, state({ disabled: true, pressed: true }));
+        return hovered === palette.background && pressed === palette.background
+          ? []
+          : [`${tone} reacted while disabled`];
+      }),
+    );
+
+    expect(failures).toEqual([]);
+  });
+
+  it('leaves a resting box exactly as it was', () => {
+    const failures = sweep((theme) =>
+      TONAL_TONES.flatMap((tone) => {
+        const palette = tonalPalette(theme, tone);
+        return interactiveFill(theme, palette, state()) === palette.background
+          ? []
+          : [`${tone} moved at rest`];
+      }),
+    );
+
+    expect(failures).toEqual([]);
+  });
+
+  it('shifts perceptibly on hover and further on press, in one direction', () => {
+    const failures = sweep((theme) =>
+      TONAL_TONES.flatMap((tone) => {
+        const palette = tonalPalette(theme, tone);
+        const hoverShift = contrast(
+          interactiveFill(theme, palette, state({ hovered: true })),
+          palette.background,
+        );
+        const pressShift = contrast(
+          interactiveFill(theme, palette, state({ pressed: true })),
+          palette.background,
+        );
+
+        const problems: string[] = [];
+        if (hoverShift <= 1.02)
+          problems.push(`${tone} hover is invisible (${hoverShift.toFixed(3)})`);
+        /* Same direction, further along it. Choosing the direction per state is how a box ends
+           up darkening on hover and lightening on press. */
+        if (pressShift <= hoverShift) {
+          problems.push(
+            `${tone} press (${pressShift.toFixed(3)}) does not go beyond hover (${hoverShift.toFixed(3)})`,
+          );
+        }
+        return problems;
+      }),
+    );
+
+    expect(failures).toEqual([]);
+  });
+
+  it('never drops its content below AA in any state', () => {
+    /* This is why interaction.ts picks a direction instead of always mixing toward the
+       high-contrast end. Measured before the flip existed: a filled warning chip with dark text
+       fell to 3.84 when pressed. */
+    const failures = sweep((theme) =>
+      TONAL_TONES.flatMap((tone) => {
+        const palette = tonalPalette(theme, tone);
+        const states = [
+          ['hovered', state({ hovered: true })],
+          ['pressed', state({ pressed: true })],
+        ] as const;
+
+        return states.flatMap(([name, pressState]) => {
+          const ratio = contrast(palette.content, interactiveFill(theme, palette, pressState));
+          return ratio >= AA_TEXT ? [] : [`${tone} content when ${name} is ${ratio.toFixed(2)}`];
+        });
+      }),
+    );
+
+    expect(failures).toEqual([]);
+  });
+});

--- a/packages/ui/src/primitives/tones.test.ts
+++ b/packages/ui/src/primitives/tones.test.ts
@@ -2,7 +2,15 @@ import { PRESET_IDS, contrast, resolveTheme, themeInputFromPreset } from '@occas
 import type { ResolvedTheme, Scheme } from '@occasio/theme';
 import { describe, expect, it } from '@jest/globals';
 import { interactiveFill, type PressState } from './interaction';
-import { SPACE_STEPS, SURFACE_TONES, TONAL_TONES, surfaceBackground, tonalPalette } from './tones';
+import {
+  BORDER_TONES,
+  SPACE_STEPS,
+  SURFACE_TONES,
+  TONAL_TONES,
+  surfaceBackground,
+  surfacePalette,
+  tonalPalette,
+} from './tones';
 
 /**
  * The primitives promise two things the theme package cannot check on its own: that every
@@ -117,6 +125,31 @@ describe('surface tones', () => {
         const ratio = contrast(theme.color.text, surfaceBackground(theme, tone));
         return ratio >= AAA_TEXT ? [] : [`text on ${tone} is ${ratio.toFixed(2)}`];
       }),
+    );
+
+    expect(failures).toEqual([]);
+  });
+
+  it('keep body text at AAA on a pressable card, hovered and pressed', () => {
+    /* A pressable Card tints its own fill, so the AAA promise has to survive the tint — this is
+       the pair a card actually renders, which the tonal-palette sweep below does not cover. */
+    const failures = sweep((theme) =>
+      SURFACE_TONES.flatMap((tone) =>
+        BORDER_TONES.flatMap((border) => {
+          const palette = surfacePalette(theme, tone, border);
+          const states = [
+            ['hovered', state({ hovered: true })],
+            ['pressed', state({ pressed: true })],
+          ] as const;
+
+          return states.flatMap(([name, pressState]) => {
+            const ratio = contrast(palette.content, interactiveFill(theme, palette, pressState));
+            return ratio >= AAA_TEXT
+              ? []
+              : [`text on ${tone}/${border} when ${name} is ${ratio.toFixed(2)}`];
+          });
+        }),
+      ),
     );
 
     expect(failures).toEqual([]);

--- a/packages/ui/src/primitives/tones.test.ts
+++ b/packages/ui/src/primitives/tones.test.ts
@@ -1,4 +1,10 @@
-import { PRESET_IDS, contrast, resolveTheme, themeInputFromPreset } from '@occasio/theme';
+import {
+  PRESET_IDS,
+  contrast,
+  lightnessOf,
+  resolveTheme,
+  themeInputFromPreset,
+} from '@occasio/theme';
 import type { ResolvedTheme, Scheme } from '@occasio/theme';
 import { describe, expect, it } from '@jest/globals';
 import { interactiveFill, type PressState } from './interaction';
@@ -10,6 +16,7 @@ import {
   surfaceBackground,
   surfacePalette,
   tonalPalette,
+  type SurfaceTone,
 } from './tones';
 
 /**
@@ -101,19 +108,59 @@ describe('space scale', () => {
 });
 
 describe('surface tones', () => {
-  it('separate by lightness, with no shadow to fall back on', () => {
+  it('separate by lightness, in one direction, with no shadow to fall back on', () => {
+    /*
+     * Signed lightness rather than `contrast`, which is symmetric: `contrast(a, b)` cannot say
+     * which of two colours is lighter, so a version of this test built on it alone passed when
+     * `sunken` and `raised` swapped roles. The elevation ramp is an ordering, and an ordering
+     * needs a direction.
+     */
     const failures = sweep((theme) => {
-      const sunken = surfaceBackground(theme, 'sunken');
-      const base = surfaceBackground(theme, 'base');
-      const raised = surfaceBackground(theme, 'raised');
+      const sunken = lightnessOf(surfaceBackground(theme, 'sunken'));
+      const base = lightnessOf(surfaceBackground(theme, 'base'));
+      const raised = lightnessOf(surfaceBackground(theme, 'raised'));
 
       const problems: string[] = [];
-      if (contrast(base, sunken) <= 1) {
-        problems.push(`base is not above sunken (${base} on ${sunken})`);
+      /* Raised is further from the page than base, and base further than sunken — measured
+         along whichever direction this scheme elevates in, which is up in light and up in dark
+         but is not assumed either way. */
+      const direction = Math.sign(raised - sunken);
+      if (direction === 0) problems.push('sunken and raised are the same lightness');
+      if (Math.sign(base - sunken) !== direction) {
+        problems.push(
+          `base is not between sunken and raised (${String(sunken)} / ${String(base)} / ${String(raised)})`,
+        );
       }
-      const step = contrast(raised, base);
+      if (Math.sign(raised - base) !== direction) {
+        problems.push(`raised does not continue past base (${String(base)} / ${String(raised)})`);
+      }
+
+      const step = contrast(surfaceBackground(theme, 'raised'), surfaceBackground(theme, 'base'));
       if (step < PERCEPTIBLE) problems.push(`raised/base step only ${step.toFixed(3)}`);
       return problems;
+    });
+
+    expect(failures).toEqual([]);
+  });
+
+  it('elevates away from the page, whichever way that is for the scheme', () => {
+    /*
+     * The direction is not the same in both schemes and should not be: light elevates darker
+     * (0.989 sunken to 0.951 raised) and dark elevates lighter (0.170 to 0.245). Asserting one
+     * fixed direction fails on half the themes — I tried, and the measurement is what corrected
+     * it. What holds everywhere is the reason behind both: elevation moves *away* from the page
+     * background, so a raised card separates from it more than a sunken well does.
+     */
+    const failures = sweep((theme) => {
+      const page = lightnessOf(theme.color.bg);
+      const from = (tone: SurfaceTone): number =>
+        Math.abs(lightnessOf(surfaceBackground(theme, tone)) - page);
+
+      return from('raised') > from('base') && from('base') >= from('sunken')
+        ? []
+        : [
+            `elevation does not move away from the page (sunken ${from('sunken').toFixed(4)}, base ${from('base').toFixed(4)}, raised ${from('raised').toFixed(4)})`,
+          ];
     });
 
     expect(failures).toEqual([]);
@@ -222,23 +269,34 @@ describe('interactive fill', () => {
     const failures = sweep((theme) =>
       TONAL_TONES.flatMap((tone) => {
         const palette = tonalPalette(theme, tone);
+        const resting = lightnessOf(palette.background);
+        /*
+         * Signed deltas, not `contrast`. Contrast is symmetric, so measuring the shift with it
+         * says how far the fill moved and not which way — and "the same direction" was the
+         * whole claim. A box darkening on hover and lightening on press passed the previous
+         * version of this test, which is precisely the thing `fillDirection` exists to prevent.
+         */
+        const hoverDelta =
+          lightnessOf(interactiveFill(theme, palette, state({ hovered: true }))) - resting;
+        const pressDelta =
+          lightnessOf(interactiveFill(theme, palette, state({ pressed: true }))) - resting;
+
+        const problems: string[] = [];
         const hoverShift = contrast(
           interactiveFill(theme, palette, state({ hovered: true })),
           palette.background,
         );
-        const pressShift = contrast(
-          interactiveFill(theme, palette, state({ pressed: true })),
-          palette.background,
-        );
-
-        const problems: string[] = [];
         if (hoverShift <= 1.02)
           problems.push(`${tone} hover is invisible (${hoverShift.toFixed(3)})`);
-        /* Same direction, further along it. Choosing the direction per state is how a box ends
-           up darkening on hover and lightening on press. */
-        if (pressShift <= hoverShift) {
+        if (Math.sign(hoverDelta) !== Math.sign(pressDelta)) {
           problems.push(
-            `${tone} press (${pressShift.toFixed(3)}) does not go beyond hover (${hoverShift.toFixed(3)})`,
+            `${tone} hover (${hoverDelta.toFixed(4)}) and press (${pressDelta.toFixed(4)}) move in opposite directions`,
+          );
+        }
+        /* Same direction, further along it. */
+        if (Math.abs(pressDelta) <= Math.abs(hoverDelta)) {
+          problems.push(
+            `${tone} press (${pressDelta.toFixed(4)}) does not go beyond hover (${hoverDelta.toFixed(4)})`,
           );
         }
         return problems;

--- a/packages/ui/src/primitives/tones.ts
+++ b/packages/ui/src/primitives/tones.ts
@@ -89,6 +89,21 @@ export const tonalPalette = (theme: ResolvedTheme, tone: TonalTone): TonalPalett
   }
 };
 
+/**
+ * The palette a Surface uses. Its content colour is body text, because that is what will sit on
+ * the box and therefore the pair a hover fill has to keep readable — the component does not get
+ * to guess at that, and stating it here is what lets the sweep in tones.test.ts check it.
+ */
+export const surfacePalette = (
+  theme: ResolvedTheme,
+  tone: SurfaceTone,
+  border: BorderTone,
+): TonalPalette => ({
+  background: surfaceBackground(theme, tone),
+  border: border === 'strong' ? theme.color.borderStrong : theme.color.border,
+  content: theme.color.text,
+});
+
 export const TONAL_TONES: readonly TonalTone[] = [
   'neutral',
   'brand',
@@ -100,3 +115,5 @@ export const TONAL_TONES: readonly TonalTone[] = [
 ];
 
 export const SURFACE_TONES: readonly SurfaceTone[] = ['sunken', 'base', 'raised'];
+
+export const BORDER_TONES: readonly BorderTone[] = ['none', 'hairline', 'strong'];

--- a/packages/ui/src/primitives/tones.ts
+++ b/packages/ui/src/primitives/tones.ts
@@ -1,0 +1,102 @@
+import type { ResolvedTheme } from '@occasio/theme';
+
+/**
+ * The vocabulary the surface primitives are built from. Deliberately free of React Native so it
+ * stays unit-testable: every value below is a pure function of the resolved theme, which is what
+ * lets the contrast properties in tones.test.ts run against every preset and hundreds of seeds
+ * without rendering anything.
+ *
+ * Sizes are enumerated, never free numbers — the same guardrail the theme editor uses (density is
+ * cozy/comfortable/airy, not a px field). A caller cannot write `padding={13}`, so a stylesheet
+ * covering the whole matrix can be built once per theme and cached.
+ */
+
+/** Padding and gap steps, in `theme.space()` units. */
+export const SPACE_STEPS = { none: 0, xs: 1, sm: 2, md: 4, lg: 6 } as const;
+
+export type SpaceScale = keyof typeof SPACE_STEPS;
+
+/** Corner sizes: the theme's radii, plus square. */
+export type RadiusScale = 'none' | keyof ResolvedTheme['radius'];
+
+/**
+ * Hairline is the default and `strong` is rare. There is no shadow option: tonal separation plus
+ * a hairline is the house style, because drop shadows date a product instantly and render
+ * differently on every platform. Genuinely floating UI — a sheet, a menu — gets its elevation
+ * from the component that owns it, not from every box on the screen.
+ */
+export type BorderTone = 'none' | 'hairline' | 'strong';
+
+/**
+ * Depth is expressed as two steps of the neutral ramp, not as elevation. `bg` is the page,
+ * `surface` sits on it, `raised` sits on that.
+ */
+export type SurfaceTone = 'sunken' | 'base' | 'raised';
+
+export const surfaceBackground = (theme: ResolvedTheme, tone: SurfaceTone): string => {
+  switch (tone) {
+    case 'sunken':
+      return theme.color.surfaceSunken;
+    case 'base':
+      return theme.color.surface;
+    case 'raised':
+      return theme.color.surfaceRaised;
+  }
+};
+
+/**
+ * A background, its hairline and the content that sits on it, always taken as a set.
+ *
+ * They travel together because the resolver only guarantees contrast for specific pairs
+ * (`onBrandSubtle` on `brandSubtle`, `onSuccess` on `success`). Letting a caller pick a
+ * background and a text colour independently is exactly how a theme-safe palette becomes an
+ * unreadable one.
+ */
+export type TonalPalette = {
+  readonly background: string;
+  readonly border: string;
+  readonly content: string;
+};
+
+/**
+ * `brand` is the tinted form and `brandSolid` the filled one — selection is a single visual
+ * state rather than a variant of every tone, so a row of chips stays readable when one is on.
+ *
+ * Status tones are filled rather than tinted because the theme guarantees contrast for the
+ * `on*` pairs only; a tinted `dangerSubtle` would need a new role in the resolver, and inventing
+ * one here is how a colour ends up unchecked.
+ */
+export type TonalTone =
+  'neutral' | 'brand' | 'brandSolid' | 'success' | 'warning' | 'danger' | 'info';
+
+export const tonalPalette = (theme: ResolvedTheme, tone: TonalTone): TonalPalette => {
+  const c = theme.color;
+  switch (tone) {
+    case 'neutral':
+      return { background: c.surfaceRaised, border: c.border, content: c.text };
+    case 'brand':
+      return { background: c.brandSubtle, border: c.brandBorder, content: c.onBrandSubtle };
+    case 'brandSolid':
+      return { background: c.brand, border: c.brand, content: c.onBrand };
+    case 'success':
+      return { background: c.success, border: c.success, content: c.onSuccess };
+    case 'warning':
+      return { background: c.warning, border: c.warning, content: c.onWarning };
+    case 'danger':
+      return { background: c.danger, border: c.danger, content: c.onDanger };
+    case 'info':
+      return { background: c.info, border: c.info, content: c.onInfo };
+  }
+};
+
+export const TONAL_TONES: readonly TonalTone[] = [
+  'neutral',
+  'brand',
+  'brandSolid',
+  'success',
+  'warning',
+  'danger',
+  'info',
+];
+
+export const SURFACE_TONES: readonly SurfaceTone[] = ['sunken', 'base', 'raised'];

--- a/packages/ui/src/primitives/typeContracts.assertions.ts
+++ b/packages/ui/src/primitives/typeContracts.assertions.ts
@@ -1,0 +1,43 @@
+import type { ChipProps } from './Chip';
+
+/**
+ * Compile-time proof that the primitive prop types reject what they claim to reject.
+ *
+ * Same reasoning as the file of this name under `components/`: a union that silently admits
+ * everything looks exactly like one that works, and `tsc` is the only assertion available for a
+ * type. Nothing here runs; it is a source file rather than a test because Jest strips types.
+ */
+
+/** `true` when `Value` is NOT assignable to `Shape` — i.e. the type rejects it. */
+type Rejects<Value, Shape> = [Value] extends [Shape] ? false : true;
+
+/** `true` when `Value` IS assignable — a legitimate call still compiles. */
+type Accepts<Value, Shape> = [Value] extends [Shape] ? true : false;
+
+export const PRIMITIVE_TYPE_CONTRACTS: {
+  /* A selected chip is a checkbox, so it needs something to toggle. Without this, `selected`
+     alone compiled and painted the selected palette while rendering no `role="checkbox"` and no
+     `aria-checked` — visible to anyone who can see the colour, invisible to anyone who cannot. */
+  readonly selectedWithoutOnPressIsRejected: Rejects<
+    { children: 'Vegetarian'; selected: true },
+    ChipProps
+  >;
+  readonly selectedFalseWithoutOnPressIsRejected: Rejects<
+    { children: 'Vegetarian'; selected: false },
+    ChipProps
+  >;
+
+  /* …while the two shapes a chip is actually allowed to have still compile. */
+  readonly toggleChipIsAccepted: Accepts<
+    { children: 'Vegetarian'; selected: true; onPress: () => void },
+    ChipProps
+  >;
+  readonly plainTagIsAccepted: Accepts<{ children: 'Vegetarian' }, ChipProps>;
+  readonly actionChipIsAccepted: Accepts<{ children: 'Clear'; onPress: () => void }, ChipProps>;
+} = {
+  selectedWithoutOnPressIsRejected: true,
+  selectedFalseWithoutOnPressIsRejected: true,
+  toggleChipIsAccepted: true,
+  plainTagIsAccepted: true,
+  actionChipIsAccepted: true,
+};

--- a/packages/ui/src/primitives/usePressState.ts
+++ b/packages/ui/src/primitives/usePressState.ts
@@ -1,0 +1,47 @@
+import { useMemo, useState } from 'react';
+
+export type PressHandlers = {
+  readonly onHoverIn: () => void;
+  readonly onHoverOut: () => void;
+  readonly onFocus: () => void;
+  readonly onBlur: () => void;
+};
+
+/**
+ * Hover and focus, which React Native does not hand back the way it hands back `pressed`.
+ *
+ * `pressed` arrives through Pressable's style callback, so it is deliberately absent here — two
+ * sources of truth for the same state is how a box gets stuck looking pressed.
+ *
+ * Hover matters more than it looks: web is the first platform to ship (D30), and a card that
+ * does not respond to the cursor reads as static content rather than as something you can open.
+ */
+export const usePressState = (): {
+  readonly hovered: boolean;
+  readonly focused: boolean;
+  readonly handlers: PressHandlers;
+} => {
+  const [hovered, setHovered] = useState(false);
+  const [focused, setFocused] = useState(false);
+
+  /* State setters are stable, so these handlers are built once and never re-render a child. */
+  const handlers = useMemo<PressHandlers>(
+    () => ({
+      onHoverIn: () => {
+        setHovered(true);
+      },
+      onHoverOut: () => {
+        setHovered(false);
+      },
+      onFocus: () => {
+        setFocused(true);
+      },
+      onBlur: () => {
+        setFocused(false);
+      },
+    }),
+    [],
+  );
+
+  return { hovered, focused, handlers };
+};

--- a/test/stubs/expo-image.tsx
+++ b/test/stubs/expo-image.tsx
@@ -1,0 +1,18 @@
+import { View, type ViewProps } from 'react-native';
+
+/**
+ * Stands in for `expo-image` in the jsdom component project.
+ *
+ * The real package reaches for the Expo runtime, which pulls in the native module registry and
+ * a great deal else that a component test has no use for — and transforming all of it makes the
+ * suite slow and the failures unreadable.
+ *
+ * What is given up is real: this renders nothing of expo-image's own behaviour, so the caching,
+ * the blurhash decode and the transition are not covered here. They belong to the visual gate
+ * and to a device. What component tests are for is the layer above — that `Image` requires
+ * alternative text, that `Avatar` rejects a child that is not it — and that layer is untouched
+ * by the substitution.
+ */
+export const Image = (props: ViewProps) => <View {...props} />;
+
+export type ImageSource = { readonly uri?: string };

--- a/test/stubs/expo-linear-gradient.tsx
+++ b/test/stubs/expo-linear-gradient.tsx
@@ -1,0 +1,4 @@
+import { View, type ViewProps } from 'react-native';
+
+/** See expo-image.tsx: the gradient's pixels are the visual gate's job, not a unit test's. */
+export const LinearGradient = (props: ViewProps) => <View {...props} />;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,9 @@
     "apps/*/src/**/*",
     "apps/*/app/**/*",
     "apps/*/*.d.ts",
-    "tools/**/*.ts"
+    "tools/**/*.ts",
+    "tools/**/*.d.mts",
+    "test/**/*"
   ],
   "exclude": [".claude", "node_modules"]
 }


### PR DESCRIPTION
Closes #26

## What changed

Five surface primitives in `packages/ui/src/primitives/` — `Surface`, `Card`, `Chip`, `Avatar`, `Divider` — plus the pure helpers they are built from. Before this the UI package could resolve a theme but had nothing to render with it: a screen wrote its own box, its own hairline and its own hover state. Depth is two steps of the neutral ramp plus a hairline (`bg → surface → surfaceRaised`); no primitive has an elevation prop.

## Why this way

**No shadows, by construction rather than by convention.** Shadows date a product instantly, render differently on every platform, and on web they smear over the background photography this product is built around. Rather than adding an option nobody should reach for, the elevation model *is* the tonal ramp.

This is not the same as saying elevation should not exist — #122's tokens landed while this was open, and they are right for what they are for. `Surface` still has no `elevation` prop for a concrete reason: a shadow drawn on this box would be clipped by the `overflow: hidden` that makes the corner radius work on child content. A floating container composes the two instead — an outer `View` carrying `toElevationStyle(theme.elevation.md)` around a `Surface` — which keeps the shadow on the handful of things that genuinely float. The reasoning is in `Surface.tsx` rather than only here. Happy to be overruled if a sheet turns out to want it inline.

**Composition rather than accumulation.** `Card` is `Surface` with the card defaults named and nothing else — "card" is a set of decisions (raised tone, hairline, `lg` radius, `md` padding, `sm` gap), not a second implementation of a box, and every one stays overridable, so a compact list card is `<Card padding="sm">` rather than a `variant` enum that grows a case per screen. `Chip` and `Surface` share one pressable implementation (`InteractiveBox`), so hover, press, focus and disabled exist once; a sixth primitive should not mean a fifth hover implementation. `Avatar` takes its image as a *child* rather than a `source` prop, which keeps it free of any image dependency and stops it growing props for blurhash, priority and caching as the image component does.

**Enumerated sizes, never free numbers** — the same guardrail the theme editor uses on density. Not only taste: a finite variant matrix is what lets `createStyles` build one cached StyleSheet per theme instead of a fresh style object per render. A caller cannot write `padding={13}`.

**Two things measurement changed:**

1. Mixing the hover fill toward the ramp's high-contrast end (`neutral[11]`) is a neat trick — near-black in light, near-white in dark, so one formula darkens a light card and lightens a dark one with no branch. It also breaks filled chips: a yellow `warning` chip carrying dark text measured **4.50 at rest and 3.84 pressed** — below AA. `interaction.ts` now picks the direction that preserves contrast, and picks it once from the *pressed* mix so hover and press never travel opposite ways.
2. Status chips are filled, not tinted. The resolver guarantees contrast for the `on*` pairs only; a tinted `dangerSubtle` would need a new role in `packages/theme`, and inventing one in the UI package is exactly how a colour ends up unchecked. **Worth an issue** if tinted status chips are wanted — it belongs in the resolver with a `contrast.test.ts` requirement, not here.

Both are held by a property sweep in `tones.test.ts` over every preset × both schemes × 124 seeds (neon, near-black, near-white and pure grey pinned; the rest seeded pseudo-random so a failure reproduces). **The sweep was confirmed to fail:** forcing the old single-direction rule reproduces the 3.84 readings above. It also asserts the tonal-separation promise — that `raised` is a visible step from `base` — because with shadows removed there is nothing else holding a card apart from the page.

**Overflow and long text** are what `Chip` and `Avatar` are shaped around. A chip's label is a `string`, not `children`, because a chip accepting arbitrary children cannot promise to stay one line — as a string it truncates with an ellipsis and shrinks rather than pushing its neighbours off a wrapping row, while `leading`/`trailing` icons are pinned at their natural size. `Avatar` reduces any name to at most two code points: `Anantharamakrishnan` → `A` (one long word gives one letter — `AN` reads like two different people), `Mary Jane Watson` → `MW`, `(Ana) Ruiz` → `AR`, `🎉` → `🎉`, and an astral character is never cut in half at a surrogate. Font scaling is capped at 1.3× so a 200% accessibility setting cannot burst the circle.

**ARIA spellings, not `accessibility*`.** #127's finding applies here and was re-checked against `react-native-web` 0.21 in this worktree: `accessibilityState` is absent from `dist/modules/forwardedProps/index.js`, so a selected chip's state was being dropped on the platform that ships first (D30). Two things changed beyond a rename: `selected` no longer defaults to `false`, because only the *absence* of the prop distinguishes a plain tag from an unselected filter chip (otherwise every chip announces "not selected"); and a chip that toggles is `role="checkbox"` with `aria-checked` rather than a button with `aria-selected`, since `aria-selected` is only valid on options and tabs. `Avatar`'s initials are `aria-hidden` — the circle already carries the full name, so without it a reader says "Ada Lovelace, A L".

## What is **not** verified

`jest-expo` cannot be installed yet (#110), so **nothing here has been rendered in a test**. The pure halves were deliberately factored out — `tones.ts`, `interaction.ts`, `initials.ts` — and those are covered by 30 assertions including the sweep. What is not:

- that Chip's label actually ellipsises, that the chip shrinks rather than overflowing its row, and that `leading`/`trailing` hold their size
- that Avatar's initials stay inside the circle at every size and font scale, and that a child image is clipped to it
- that `overflow: 'hidden'` on Surface does not clip something a caller needs
- that hover, press and focus fire on web, and that the focus outline is visible — `outlineWidth`/`outlineOffset` are RN ≥0.79 and web, argued from the type definitions, not seen on a device
- that any of the ARIA props produce the intended announcement on a real screen reader. The narrower, checkable claim is the one made above: the props now written are in RNW's forwarded table and the ones removed were not.

The `visual` gate renders app routes, and no route uses these components yet, so it does not cover them either — its green tick means nothing regressed, not that these look right.

## Checks

- [x] `npm run verify` passes locally (164 tests, 8 enforcement probes)
- [x] `npm run test:visual` run locally: 40 screenshots, every route clean
- [x] Scoped to one issue — anything else was split out
- [x] Title is in conventional-commit form (it becomes the squashed commit)
- [x] New architectural rules, if any, have a probe in `tools/enforcement/` — none added. The `ELEV` probe that arrived with #122 passes over this code, which is the mechanical half of "no shadows" already being enforced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145VPJXGgJA9PWqeNXDr1DG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added themed UI primitives including avatars, cards, chips, dividers, and surfaces.
  * Added accessible interactions, press states, focus handling, disabled styling, and customisation options.
  * Added automatic avatar initials generation with Unicode and multilingual support.
  * Added surface, tonal, spacing, radius, and border design tokens.
  * Added colour lightness utilities for improved theme and contrast handling.
* **Tests**
  * Added comprehensive coverage for initials, tones, contrast, spacing, and interaction behaviour.
  * Added compile-time checks for chip interaction requirements.
  * Added rendering coverage for avatar fallbacks, accessibility, and image content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->