### PR TITLE
fix(ui): use the ARIA prop spellings, which are the ones web reads

### DIFF
--- a/packages/ui/src/feedback/EmptyState.tsx
+++ b/packages/ui/src/feedback/EmptyState.tsx
@@ -29,6 +29,15 @@ type Props = {
   readonly message?: string | undefined;
   /** The one thing to do about it. Omitted when there genuinely is nothing to do. */
   readonly action?: ReactNode;
+  /**
+   * Where the title sits in the page's heading outline.
+   *
+   * Defaults to 2, because an empty state is the state of one section of a screen that already
+   * has a heading of its own. It has to be written down rather than left off: react-native-web
+   * renders `role="heading"` with no level as an `<h1>`, so the default of doing nothing is a
+   * second top-level heading on the page and an outline that reads as two documents.
+   */
+  readonly headingLevel?: 2 | 3 | 4;
   readonly style?: StyleProp<ViewStyle> | undefined;
 };
 
@@ -47,7 +56,14 @@ const useStyles = createStyles((t) => ({
   action: { marginTop: t.space(2) },
 }));
 
-export function EmptyState({ illustration, title, message, action, style }: Props) {
+export function EmptyState({
+  illustration,
+  title,
+  message,
+  action,
+  headingLevel = 2,
+  style,
+}: Props) {
   const styles = useStyles();
 
   return (
@@ -55,15 +71,19 @@ export function EmptyState({ illustration, title, message, action, style }: Prop
       {illustration === undefined ? null : (
         /* `aria-hidden` covers all three platforms on its own: React Native expands it to
            `accessibilityElementsHidden` for iOS and `importantForAccessibility` for Android,
-           and react-native-web forwards it to the DOM attribute — which the
-           `accessibility*` spellings never reach. */
+           and react-native-web forwards it to the DOM attribute. The `accessibility*` spellings
+           still reach the DOM in react-native-web 0.21.2, but only through a deprecated
+           fallback that warns once per prop — this is the spelling that is not on its way out. */
         <View aria-hidden>{illustration}</View>
       )}
       {/* A heading rather than plain text: it is how a screen reader user skims to "what is
           this screen showing me", which for an empty list is the only content there is.
           `role="heading"` for the same reason as `aria-hidden` above — React Native maps it to
-          the `header` role, react-native-web forwards it, and neither warns. */}
-      <Text role="heading" style={styles.title}>
+          the `header` role, react-native-web forwards it, and neither warns.
+
+          The level is never left implicit: react-native-web picks the element from it
+          (`propsToAccessibilityComponent`), and with no level at all it picks `<h1>`. */}
+      <Text role="heading" aria-level={headingLevel} style={styles.title}>
         {title}
       </Text>
       {message === undefined ? null : <Text style={styles.message}>{message}</Text>}

--- a/packages/ui/src/feedback/EmptyState.tsx
+++ b/packages/ui/src/feedback/EmptyState.tsx
@@ -53,13 +53,17 @@ export function EmptyState({ illustration, title, message, action, style }: Prop
   return (
     <View style={[styles.root, style]}>
       {illustration === undefined ? null : (
-        <View accessibilityElementsHidden importantForAccessibility="no-hide-descendants">
-          {illustration}
-        </View>
+        /* `aria-hidden` covers all three platforms on its own: React Native expands it to
+           `accessibilityElementsHidden` for iOS and `importantForAccessibility` for Android,
+           and react-native-web forwards it to the DOM attribute — which the
+           `accessibility*` spellings never reach. */
+        <View aria-hidden>{illustration}</View>
       )}
-      {/* `header` rather than nothing: it is how a screen reader user skims to "what is this
-          screen showing me", which for an empty list is the only content there is. */}
-      <Text accessibilityRole="header" style={styles.title}>
+      {/* A heading rather than plain text: it is how a screen reader user skims to "what is
+          this screen showing me", which for an empty list is the only content there is.
+          `role="heading"` for the same reason as `aria-hidden` above — React Native maps it to
+          the `header` role, react-native-web forwards it, and neither warns. */}
+      <Text role="heading" style={styles.title}>
         {title}
       </Text>
       {message === undefined ? null : <Text style={styles.message}>{message}</Text>}

--- a/packages/ui/src/feedback/SkeletonGroup.tsx
+++ b/packages/ui/src/feedback/SkeletonGroup.tsx
@@ -100,15 +100,15 @@ export function SkeletonGroup({ label, children, style }: Props) {
 
   return (
     <SkeletonPulseContext.Provider value={pulse}>
-      {/* `accessible` collapses the subtree into this one node, so the bars inside are never
-          reached individually. */}
-      <View
-        style={style}
-        accessible
-        accessibilityRole="progressbar"
-        accessibilityLabel={label}
-        accessibilityState={{ busy: true }}
-      >
+      {/* ARIA prop names rather than the `accessibility*` ones. react-native-web 0.21 forwards
+          `role`, `aria-label` and `aria-busy` directly; it warns on the `accessibility*`
+          spellings and does not read `accessibilityState` at all, so the busy flag would have
+          been dropped on the platform this ships to first (D30). React Native maps all three
+          back to the native equivalents.
+
+          `accessible` has no web spelling and is kept for native, where it is what collapses
+          the subtree into this one node so the bars are never reached individually. */}
+      <View style={style} accessible role="progressbar" aria-label={label} aria-busy>
         {children}
       </View>
     </SkeletonPulseContext.Provider>


### PR DESCRIPTION
Follow-up to #121, which merged before this fix reached it. Same commit, same reasoning — it was
pushed to `feat/28-skeleton-empty` a few minutes after the squash-merge took `71abecf`, so it is
not in `main`.

## What changed

The accessibility props on `SkeletonGroup` and `EmptyState` move to their ARIA spellings.

## Why this way

Found by reading `react-native-web` 0.21 in `node_modules`, not by testing — these components
still cannot be rendered in a test (#110).

`accessibilityState` is **not in RNW's forwarded-prop table at all**
(`dist/modules/forwardedProps/index.js`); it takes flat `aria-busy` instead. So
`accessibilityState={{ busy: true }}` on `<SkeletonGroup>` was being dropped silently on the
platform this ships to first (D30) — the group announced itself as a progressbar that was never
busy. `accessibilityRole` and `accessibilityLabel` do still work there, but only through a
deprecation path that logs a warning on every mount.

All three become `role`, `aria-label` and `aria-busy`. React Native maps each back to the native
equivalent, so nothing is lost on iOS or Android. `accessible` stays as it was: it has no ARIA
spelling, RNW ignores it, and on native it is what collapses the group into the single node the
label belongs to.

The same reading shrinks `EmptyState`'s illustration wrapper from three props to one. React
Native expands `aria-hidden` into `accessibilityElementsHidden` for iOS **and**
`importantForAccessibility="no-hide-descendants"` for Android
(`Libraries/Components/View/View.js:71-76`), and RNW forwards it to the DOM attribute — so
spelling all three out was redundant on native and still wrong on web, which reads none of them.

## Checks

- [x] `npm run verify` passes locally
- [x] Scoped to one issue — anything else was split out
- [x] Title is in conventional-commit form (it becomes the squashed commit)
- [x] New architectural rules, if any, have a probe in `tools/enforcement/` — n/a, no new rule

`npm run test:visual` also run locally on this branch: 40 screenshots, every route clean. No route
renders these components yet, so that confirms nothing regressed rather than confirming the
announcement is right.

## What is not verified

That any of these props produce the intended announcement on a real screen reader, on any
platform. The claim here is narrower and checkable: the props that were being written are ones
react-native-web does not read, and the ones now written are in its forwarded list.

Also still open from #121, and outside this diff: nothing supplies `reducedMotion` to
`<ThemeProvider>` in `apps/mobile/app/_layout.tsx`, so the OS "reduce motion" setting never
reaches `theme.motion.enabled`. `tools/visual/capture.mjs` already launches Playwright with
`reducedMotion: 'reduce'` and currently has no effect on the theme — the first screen that
renders a skeleton will produce a non-deterministic screenshot. That deserves its own issue
against `apps/mobile` before a screen adopts these.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Improved cross-platform accessibility for empty states and loading indicators.
  * Empty state headings now support configurable levels for clearer document structure.
  * Updated semantic roles and labels for better support across web and native interfaces.
  * Marked illustrations as hidden from assistive technologies where appropriate.
  * Loading indicators now expose their busy state more consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->