### PR TITLE
feat(ui): add the Image wrapper with blurhash, scrim and enforced aspect

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -6,7 +6,7 @@
     "version": "0.0.0",
     "orientation": "portrait",
     "userInterfaceStyle": "automatic",
-    "plugins": ["expo-router", "expo-font"],
+    "plugins": ["expo-router", "expo-font", "expo-image"],
     "web": {
       "bundler": "metro",
       "output": "single"

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -25,6 +25,8 @@
     "expo": "^57.0.20",
     "expo-constants": "~57.0.17",
     "expo-font": "~57.0.3",
+    "expo-image": "~57.0.4",
+    "expo-linear-gradient": "~57.0.1",
     "expo-linking": "~57.0.9",
     "expo-router": "~57.0.19",
     "expo-status-bar": "~57.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,8 @@
         "expo": "^57.0.20",
         "expo-constants": "~57.0.17",
         "expo-font": "~57.0.3",
+        "expo-image": "~57.0.4",
+        "expo-linear-gradient": "~57.0.1",
         "expo-linking": "~57.0.9",
         "expo-router": "~57.0.19",
         "expo-status-bar": "~57.0.1",
@@ -8270,6 +8272,26 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-image": {
+      "version": "57.0.4",
+      "resolved": "https://registry.npmjs.org/expo-image/-/expo-image-57.0.4.tgz",
+      "integrity": "sha512-DLVNjqIMLb71wh0F27kRv7nA9i4g80fvkVugiimVgGnO7Iot+gRSv5VhrFJCvX/OlSzbGQqd/3ktlEaPGFqP7g==",
+      "license": "MIT",
+      "dependencies": {
+        "sf-symbols-typescript": "^2.2.0"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*",
+        "react-native-web": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/expo-keep-awake": {
       "version": "57.0.1",
       "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-57.0.1.tgz",
@@ -8278,6 +8300,17 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*"
+      }
+    },
+    "node_modules/expo-linear-gradient": {
+      "version": "57.0.1",
+      "resolved": "https://registry.npmjs.org/expo-linear-gradient/-/expo-linear-gradient-57.0.1.tgz",
+      "integrity": "sha512-CpS8eMqoIWcHVGKV66zbDvzotCw9qYp3f8CuI9N+h1LaO0tMLUzBpkhAKePUsXlpN3yolYlHFSPkfVZ/uSh+iA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-linking": {
@@ -15832,7 +15865,11 @@
     },
     "packages/ui": {
       "name": "@occasio/ui",
-      "version": "0.0.0"
+      "version": "0.0.0",
+      "peerDependencies": {
+        "react": "^19.0.0",
+        "react-native": ">=0.76"
+      }
     },
     "tools/eslint-plugin-occasio": {
       "version": "0.0.0"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -9,6 +9,8 @@
     ".": "./src/index.ts"
   },
   "peerDependencies": {
+    "expo-image": ">=57",
+    "expo-linear-gradient": ">=57",
     "react": "^19.0.0",
     "react-native": ">=0.76"
   }

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -15,4 +15,13 @@ export {
   type SkeletonTextRow,
 } from './feedback/skeletonText';
 
+export { Image, type ImageAspect, type ImageProps, type ImageRadius } from './media/Image';
+export {
+  imageAccessibility,
+  scrimGeometry,
+  type ImageAccessibility,
+  type ScrimGeometry,
+  type ScrimPlacement,
+} from './media/imageFrame';
+
 export const UI_PACKAGE_VERSION = '0.0.0' as const;

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -17,6 +17,7 @@ export {
 
 export { Image, type ImageAspect, type ImageProps, type ImageRadius } from './media/Image';
 export {
+  hasOverlay,
   imageAccessibility,
   scrimGeometry,
   type ImageAccessibility,

--- a/packages/ui/src/media/Image.tsx
+++ b/packages/ui/src/media/Image.tsx
@@ -69,11 +69,13 @@ type ImageFrameProps = {
   /**
    * Margins, width, position — the frame's place in its parent.
    *
-   * `aspectRatio` is deliberately not assignable: the ratio is the token's decision, and an
-   * escape hatch that can quietly reintroduce a mixed set of ratios is not an escape hatch, it
-   * is the rule with an opt-out. Use `aspect` to choose between the ratios the system has.
+   * `aspectRatio`, `borderRadius` and `overflow` are not assignable, and are applied after this
+   * style so that a value smuggled past the type through a variable still loses. The ratio and
+   * the crop are the token's decision; use `aspect` and `radius` to choose between the values
+   * the system has.
    */
-  readonly style?: StyleProp<Omit<ViewStyle, 'aspectRatio'>> | undefined;
+  readonly style?:
+    StyleProp<Omit<ViewStyle, 'aspectRatio' | 'borderRadius' | 'overflow'>> | undefined;
 };
 
 /**
@@ -106,16 +108,19 @@ export type ImageProps = ImageFrameProps & ImageAltProps;
 const FILL = { position: 'absolute', left: 0, right: 0, top: 0, bottom: 0 } as const;
 
 const useStyles = createStyles((t) => ({
-  /* The frame owns the ratio and the clip; the photograph only fills it. `overflow: hidden` is
-     what turns the radius and the crop into one thing rather than two. */
+  /* Defaults, applied BEFORE the caller's style so both can be overridden: a thumbnail in a
+     row may want its own width, and a frame over a photographic background may want no fill. */
   frame: {
     width: '100%',
-    overflow: 'hidden',
     /* Ramp step 4 is a component background — visible against both `bg` and `surface` in either
        scheme. It shows for the moment before a blurhash decodes, and for the whole life of an
        image that has none. Never a spinner. */
     backgroundColor: t.color.ramp.neutral[3],
   },
+  /* `overflow: hidden` is not a default. It is what makes the ratio a crop rather than a
+     suggestion, and what clips the corners — so it goes after the caller's style, with the
+     aspect and the radius. */
+  crop: { overflow: 'hidden' },
   aspectHero: { aspectRatio: t.image.heroAspect },
   aspectSquare: { aspectRatio: 1 },
   radiusHero: { borderRadius: t.image.radius },
@@ -134,10 +139,11 @@ const useStyles = createStyles((t) => ({
 export function Image({
   source,
   blurhash,
-  /* `decorative` is a type-level marker and nothing else — it exists so that omitting `alt`
-     has to be written down. At runtime the absence of `alt` is the whole signal, which is why
-     it is not destructured here. */
   alt,
+  /* Read at runtime, not only at the type level. `imageAccessibility` has to tell a deliberate
+     "there is nothing to describe" apart from a forgotten `alt`, and `decorative` is the only
+     thing that carries the difference once the types are gone. */
+  decorative = false,
   aspect = 'hero',
   radius = 'hero',
   scrim,
@@ -157,11 +163,15 @@ export function Image({
 
   return (
     <View
+      /* Order is the enforcement. The caller's style sits between the defaults it may
+         override and the three properties it may not: an escape hatch that can put back a
+         second aspect ratio is the rule with an opt-out, not an escape hatch. */
       style={[
         styles.frame,
+        style,
+        styles.crop,
         aspect === 'hero' ? styles.aspectHero : styles.aspectSquare,
         radius === 'hero' ? styles.radiusHero : styles.radiusNone,
-        style,
       ]}
     >
       <ExpoImage
@@ -179,7 +189,7 @@ export function Image({
         priority={priority ?? null}
         recyclingKey={recyclingKey ?? null}
         style={styles.image}
-        {...imageAccessibility(alt)}
+        {...imageAccessibility(alt, decorative)}
       />
       {geometry === null ? null : (
         <LinearGradient

--- a/packages/ui/src/media/Image.tsx
+++ b/packages/ui/src/media/Image.tsx
@@ -4,7 +4,7 @@ import { type ReactNode } from 'react';
 import { View, type StyleProp, type ViewStyle } from 'react-native';
 import { createStyles } from '../theme/createStyles';
 import { useTheme } from '../theme/useTheme';
-import { imageAccessibility, scrimGeometry, type ScrimPlacement } from './imageFrame';
+import { hasOverlay, imageAccessibility, scrimGeometry, type ScrimPlacement } from './imageFrame';
 
 /**
  * The only image component in Occasio. Reaching for `react-native`'s `Image` is a bug.
@@ -66,7 +66,14 @@ type ImageFrameProps = {
   readonly recyclingKey?: string | undefined;
   /** Rendered over the scrim, pinned to the bottom of the frame. */
   readonly children?: ReactNode;
-  readonly style?: StyleProp<ViewStyle> | undefined;
+  /**
+   * Margins, width, position — the frame's place in its parent.
+   *
+   * `aspectRatio` is deliberately not assignable: the ratio is the token's decision, and an
+   * escape hatch that can quietly reintroduce a mixed set of ratios is not an escape hatch, it
+   * is the rule with an opt-out. Use `aspect` to choose between the ratios the system has.
+   */
+  readonly style?: StyleProp<Omit<ViewStyle, 'aspectRatio'>> | undefined;
 };
 
 /**
@@ -127,6 +134,9 @@ const useStyles = createStyles((t) => ({
 export function Image({
   source,
   blurhash,
+  /* `decorative` is a type-level marker and nothing else — it exists so that omitting `alt`
+     has to be written down. At runtime the absence of `alt` is the whole signal, which is why
+     it is not destructured here. */
   alt,
   aspect = 'hero',
   radius = 'hero',
@@ -139,9 +149,10 @@ export function Image({
   const theme = useTheme();
   const styles = useStyles();
 
+  const overlaid = hasOverlay(children);
   const geometry = scrimGeometry(
     theme.image.scrimGradient,
-    scrim ?? (children === undefined ? 'none' : 'bottom'),
+    scrim ?? (overlaid ? 'bottom' : 'none'),
   );
 
   return (
@@ -184,7 +195,7 @@ export function Image({
           style={styles.scrim}
         />
       )}
-      {children === undefined ? null : <View style={styles.overlay}>{children}</View>}
+      {overlaid ? <View style={styles.overlay}>{children}</View> : null}
     </View>
   );
 }

--- a/packages/ui/src/media/Image.tsx
+++ b/packages/ui/src/media/Image.tsx
@@ -1,0 +1,190 @@
+import { Image as ExpoImage, type ImageSource } from 'expo-image';
+import { LinearGradient } from 'expo-linear-gradient';
+import { type ReactNode } from 'react';
+import { View, type StyleProp, type ViewStyle } from 'react-native';
+import { createStyles } from '../theme/createStyles';
+import { useTheme } from '../theme/useTheme';
+import { imageAccessibility, scrimGeometry, type ScrimPlacement } from './imageFrame';
+
+/**
+ * The only image component in Occasio. Reaching for `react-native`'s `Image` is a bug.
+ *
+ * Three things are non-negotiable here, and each is a specific way user-generated event sites go
+ * wrong:
+ *
+ *  1. **The ratio comes from the theme, not from the upload.** Mixed aspect ratios are the single
+ *     biggest thing that makes a photo-driven site look amateur, and an admin uploading from a
+ *     phone camera roll will never produce a consistent set. `theme.image.heroAspect` decides the
+ *     frame and `contentFit="cover"` crops the photograph into it — which is why there is no
+ *     `contentFit` prop: `contain` would letterbox, and a letterboxed image is the enforcement
+ *     quietly turned off.
+ *  2. **A blurhash, never a spinner.** A spinner on a hero image is the difference between
+ *     "loading" and "broken", and it costs a layout jump when it goes away. The placeholder is
+ *     the picture's own colours, at the picture's own size, from the first frame.
+ *  3. **Alt text is not optional.** `alt` is required; `decorative` is the only way to omit it,
+ *     and the prop types make writing neither impossible.
+ *
+ * It wraps `expo-image` rather than `Image` for the caching (D20 wants photographs to survive a
+ * cold start on venue wifi) and for the blurhash decoding, neither of which React Native's
+ * component has.
+ */
+
+/** Ratio of the frame. Named, not numeric — a free number is how a design system loses a grid. */
+export type ImageAspect =
+  /** `theme.image.heroAspect`: the tenant's ratio, and the default for anything editorial. */
+  | 'hero'
+  /** For grid cells, avatars and thumbnails, where the square is the layout's, not the photo's. */
+  | 'square';
+
+/** Corner treatment. `hero` is `theme.image.radius`; `none` is for full-bleed. */
+export type ImageRadius = 'hero' | 'none';
+
+type ImageFrameProps = {
+  /** A remote URL, a `require()`d asset, or an expo-image source. */
+  readonly source: string | number | ImageSource;
+  /**
+   * The blurhash stored alongside the image, shown until the real pixels decode.
+   *
+   * Optional only because third-party avatars arrive without one. When it is missing the frame
+   * still shows its tonal fill rather than a spinner — the placeholder is worse, never absent.
+   */
+  readonly blurhash?: string | undefined;
+  readonly aspect?: ImageAspect | undefined;
+  readonly radius?: ImageRadius | undefined;
+  /**
+   * Where the theme's scrim gradient sits. Defaults to `bottom` when there is overlay content
+   * and `none` when there is not, because a scrim exists to make text legible and one over a
+   * bare photograph is just contrast thrown away.
+   */
+  readonly scrim?: ScrimPlacement | undefined;
+  /** Raise it for the one image above the fold; leave it alone for everything in a list. */
+  readonly priority?: 'low' | 'normal' | 'high' | undefined;
+  /**
+   * Blanks the view when it changes, so a recycled row in a long list never shows the previous
+   * row's photograph for a frame. Pass the id of the thing being pictured.
+   */
+  readonly recyclingKey?: string | undefined;
+  /** Rendered over the scrim, pinned to the bottom of the frame. */
+  readonly children?: ReactNode;
+  readonly style?: StyleProp<ViewStyle> | undefined;
+};
+
+/**
+ * Alternative text, or an explicit statement that there is none to give.
+ *
+ * A union rather than an optional string: `<Image source={…} />` does not compile, so the
+ * decision has to be made rather than skipped. `decorative` is for images that repeat what the
+ * adjacent text already says — a section's background photograph, a pattern behind a card.
+ */
+type ImageAltProps =
+  | {
+      /** What the photograph shows, in a sentence someone who cannot see it would want. */
+      readonly alt: string;
+      readonly decorative?: false | undefined;
+    }
+  | {
+      readonly alt?: undefined;
+      /** The image adds nothing the surrounding text does not already say. */
+      readonly decorative: true;
+    };
+
+export type ImageProps = ImageFrameProps & ImageAltProps;
+
+/**
+ * Written out rather than taken from `StyleSheet.absoluteFill`, which is not the same thing on
+ * both platforms: React Native exports a plain frozen object, react-native-web exports a
+ * compiled class handle. Spreading the web one into a style object produces something that
+ * looks right and positions nothing.
+ */
+const FILL = { position: 'absolute', left: 0, right: 0, top: 0, bottom: 0 } as const;
+
+const useStyles = createStyles((t) => ({
+  /* The frame owns the ratio and the clip; the photograph only fills it. `overflow: hidden` is
+     what turns the radius and the crop into one thing rather than two. */
+  frame: {
+    width: '100%',
+    overflow: 'hidden',
+    /* Ramp step 4 is a component background — visible against both `bg` and `surface` in either
+       scheme. It shows for the moment before a blurhash decodes, and for the whole life of an
+       image that has none. Never a spinner. */
+    backgroundColor: t.color.ramp.neutral[3],
+  },
+  aspectHero: { aspectRatio: t.image.heroAspect },
+  aspectSquare: { aspectRatio: 1 },
+  radiusHero: { borderRadius: t.image.radius },
+  radiusNone: { borderRadius: 0 },
+  /* Absolute rather than `flex: 1`: the frame's aspect ratio is the layout, and an image that
+     contributed its own intrinsic size would fight it. */
+  image: { ...FILL },
+  scrim: { ...FILL },
+  overlay: {
+    ...FILL,
+    justifyContent: 'flex-end',
+    padding: t.space(4),
+  },
+}));
+
+export function Image({
+  source,
+  blurhash,
+  alt,
+  aspect = 'hero',
+  radius = 'hero',
+  scrim,
+  priority,
+  recyclingKey,
+  children,
+  style,
+}: ImageProps) {
+  const theme = useTheme();
+  const styles = useStyles();
+
+  const geometry = scrimGeometry(
+    theme.image.scrimGradient,
+    scrim ?? (children === undefined ? 'none' : 'bottom'),
+  );
+
+  return (
+    <View
+      style={[
+        styles.frame,
+        aspect === 'hero' ? styles.aspectHero : styles.aspectSquare,
+        radius === 'hero' ? styles.radiusHero : styles.radiusNone,
+        style,
+      ]}
+    >
+      <ExpoImage
+        source={typeof source === 'string' ? { uri: source } : source}
+        placeholder={blurhash === undefined ? null : { blurhash }}
+        /* Matching the image's own fit: a placeholder scaled differently flickers as it is
+           swapped out, which is the one thing a placeholder must not do. */
+        contentFit="cover"
+        placeholderContentFit="cover"
+        /* From the theme, so the OS "reduce motion" setting turns the cross-fade off rather
+           than leaving one animation nobody asked for. */
+        transition={theme.motion.enabled ? theme.motion.base : 0}
+        /* D20 — read-offline. The disk half is what survives a cold start on venue wifi. */
+        cachePolicy="memory-disk"
+        priority={priority ?? null}
+        recyclingKey={recyclingKey ?? null}
+        style={styles.image}
+        {...imageAccessibility(alt)}
+      />
+      {geometry === null ? null : (
+        <LinearGradient
+          colors={geometry.colors}
+          locations={geometry.locations}
+          start={geometry.start}
+          end={geometry.end}
+          /* Decoration over a picture: it must never eat a tap meant for the card beneath it,
+             and it must never be announced. */
+          pointerEvents="none"
+          accessibilityElementsHidden
+          importantForAccessibility="no-hide-descendants"
+          style={styles.scrim}
+        />
+      )}
+      {children === undefined ? null : <View style={styles.overlay}>{children}</View>}
+    </View>
+  );
+}

--- a/packages/ui/src/media/imageFrame.test.ts
+++ b/packages/ui/src/media/imageFrame.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from '@jest/globals';
-import { imageAccessibility, scrimGeometry } from './imageFrame';
+import { hasOverlay, imageAccessibility, scrimGeometry } from './imageFrame';
 
 describe('imageAccessibility', () => {
   it('announces an image that has alternative text', () => {
@@ -23,6 +23,25 @@ describe('imageAccessibility', () => {
     expect(props.accessibilityElementsHidden).toBe(true);
     expect(props.importantForAccessibility).toBe('no-hide-descendants');
     expect(props.accessibilityRole).toBeUndefined();
+  });
+});
+
+describe('hasOverlay', () => {
+  it('counts anything React will actually paint', () => {
+    expect(hasOverlay('A caption')).toBe(true);
+    expect(hasOverlay(0)).toBe(true);
+    expect(hasOverlay([])).toBe(true);
+  });
+
+  it('does not count the values a JSX conditional collapses to', () => {
+    /* The reason this function exists. `{title && <Text />}` is `false` when the title is empty
+       and `{caption ?? null}` is `null` — React paints nothing for either, so a scrim and an
+       empty overlay over a bare photograph would be the visible cost of checking only for
+       `undefined`. */
+    expect(hasOverlay(undefined)).toBe(false);
+    expect(hasOverlay(null)).toBe(false);
+    expect(hasOverlay(false)).toBe(false);
+    expect(hasOverlay(true)).toBe(false);
   });
 });
 

--- a/packages/ui/src/media/imageFrame.test.ts
+++ b/packages/ui/src/media/imageFrame.test.ts
@@ -1,19 +1,33 @@
-import { describe, expect, it } from '@jest/globals';
+import { afterAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { hasOverlay, imageAccessibility, scrimGeometry } from './imageFrame';
 
 describe('imageAccessibility', () => {
+  /* The warnings are the point of half these cases, so they are captured rather than printed:
+     an assertion that a defect was reported is what stops the reporting from being dropped in
+     a later refactor, and a silent test run is worth having on its own. */
+  const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+  beforeEach(() => {
+    warn.mockClear();
+  });
+
+  afterAll(() => {
+    warn.mockRestore();
+  });
+
   it('announces an image that has alternative text', () => {
-    expect(imageAccessibility('The couple cutting the cake')).toEqual({
+    expect(imageAccessibility('The couple cutting the cake', false)).toEqual({
       accessible: true,
       accessibilityRole: 'image',
       accessibilityLabel: 'The couple cutting the cake',
       accessibilityElementsHidden: false,
       importantForAccessibility: 'yes',
     });
+    expect(warn).not.toHaveBeenCalled();
   });
 
   it('hides a decorative image rather than announcing an empty one', () => {
-    const props = imageAccessibility(undefined);
+    const props = imageAccessibility(undefined, true);
 
     /* Empty rather than absent: expo-image maps accessibilityLabel to the web `alt` attribute,
        and `alt=""` is what removes an image from the accessibility tree. A missing attribute
@@ -23,6 +37,44 @@ describe('imageAccessibility', () => {
     expect(props.accessibilityElementsHidden).toBe(true);
     expect(props.importantForAccessibility).toBe('no-hide-descendants');
     expect(props.accessibilityRole).toBeUndefined();
+
+    /* Declaring an image decorative is a decision, not a mistake, so it is the one hiding path
+       that must stay quiet. A warning here would train people to ignore the others. */
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('reports an empty `alt` instead of silently hiding the photograph', () => {
+    /* How an empty caption field arrives: `alt={caption}` where the admin left it blank. The
+       types cannot catch it — `''` is a string — and the result is a photograph that a screen
+       reader never mentions, which is indistinguishable from the image not being there. */
+    const props = imageAccessibility('', false);
+
+    expect(props.accessible).toBe(false);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[0]).toContain('empty string');
+  });
+
+  it('reports an image that was given neither `alt` nor `decorative`', () => {
+    /* Unreachable from TypeScript and entirely reachable from a JavaScript caller or a prop bag
+       that came out of `JSON.parse`. The image is still hidden — that is the safe default for a
+       frame that is about to render — but it is hidden loudly. */
+    const props = imageAccessibility(undefined, false);
+
+    expect(props.accessible).toBe(false);
+    expect(props.accessibilityElementsHidden).toBe(true);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[0]).toContain('neither');
+  });
+
+  it('describes the image when it is given both, and says so', () => {
+    /* A contradiction resolved toward the reader who cannot see the picture. Silently honouring
+       `decorative` would drop a description someone actually wrote. */
+    const props = imageAccessibility('The ceremony arch', true);
+
+    expect(props.accessibilityLabel).toBe('The ceremony arch');
+    expect(props.accessible).toBe(true);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[0]).toContain('both');
   });
 });
 

--- a/packages/ui/src/media/imageFrame.test.ts
+++ b/packages/ui/src/media/imageFrame.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from '@jest/globals';
+import { imageAccessibility, scrimGeometry } from './imageFrame';
+
+describe('imageAccessibility', () => {
+  it('announces an image that has alternative text', () => {
+    expect(imageAccessibility('The couple cutting the cake')).toEqual({
+      accessible: true,
+      accessibilityRole: 'image',
+      accessibilityLabel: 'The couple cutting the cake',
+      accessibilityElementsHidden: false,
+      importantForAccessibility: 'yes',
+    });
+  });
+
+  it('hides a decorative image rather than announcing an empty one', () => {
+    const props = imageAccessibility(undefined);
+
+    /* Empty rather than absent: expo-image maps accessibilityLabel to the web `alt` attribute,
+       and `alt=""` is what removes an image from the accessibility tree. A missing attribute
+       makes a screen reader read the file name instead. */
+    expect(props.accessibilityLabel).toBe('');
+    expect(props.accessible).toBe(false);
+    expect(props.accessibilityElementsHidden).toBe(true);
+    expect(props.importantForAccessibility).toBe('no-hide-descendants');
+    expect(props.accessibilityRole).toBeUndefined();
+  });
+});
+
+describe('scrimGeometry', () => {
+  const gradient = ['#00000000', '#2A0F1CC7'] as const;
+
+  it('renders nothing at all when there is no scrim', () => {
+    expect(scrimGeometry(gradient, 'none')).toBeNull();
+  });
+
+  it('passes the theme gradient through untouched', () => {
+    /* The colours are the tenant's — tinted toward the brand by the resolver — and this file
+       only decides the direction. A scrim that mixed in its own colour would put a second,
+       untenanted palette on top of every photograph. */
+    expect(scrimGeometry(gradient, 'bottom')?.colors).toBe(gradient);
+    expect(scrimGeometry(gradient, 'top')?.colors).toBe(gradient);
+  });
+
+  it('ramps toward the bottom edge for text sitting at the bottom', () => {
+    const geometry = scrimGeometry(gradient, 'bottom');
+
+    expect(geometry?.start).toEqual({ x: 0.5, y: 0 });
+    expect(geometry?.end).toEqual({ x: 0.5, y: 1 });
+  });
+
+  it('ramps toward the top edge for text sitting at the top', () => {
+    const geometry = scrimGeometry(gradient, 'top');
+
+    expect(geometry?.start).toEqual({ x: 0.5, y: 1 });
+    expect(geometry?.end).toEqual({ x: 0.5, y: 0 });
+  });
+
+  it('leaves the subject of the photograph alone and covers the same share of either edge', () => {
+    const bottom = scrimGeometry(gradient, 'bottom');
+    const top = scrimGeometry(gradient, 'top');
+
+    /* Both are measured along their own axis, so identical locations mean identical coverage
+       of opposite edges — a top scrim and a bottom scrim are the same weight of overlay. */
+    expect(bottom?.locations).toEqual(top?.locations);
+
+    const [onset, full] = bottom?.locations ?? [];
+    expect(onset).toBeGreaterThan(0.5);
+    expect(onset).toBeLessThan(full ?? 0);
+    expect(full).toBe(1);
+  });
+});

--- a/packages/ui/src/media/imageFrame.ts
+++ b/packages/ui/src/media/imageFrame.ts
@@ -1,11 +1,14 @@
+import type { ReactNode } from 'react';
+
 /**
- * The two decisions an image frame makes that are worth testing on their own: how the picture is
- * described to a screen reader, and where the scrim sits.
+ * The decisions an image frame makes that are worth testing on their own: how the picture is
+ * described to a screen reader, whether there is anything overlaid on it, and where the scrim
+ * sits.
  *
- * Both live here rather than inside `Image.tsx` because this file imports neither React nor
- * React Native, so it runs in a plain Jest process. Component render tests are not possible in
- * this repo yet (#110); pulling the judgement out of the JSX is what keeps any of this covered
- * in the meantime.
+ * They live here rather than inside `Image.tsx` because this file pulls in no runtime import at
+ * all — the one `import type` is erased — so it runs in a plain Jest process. Component render
+ * tests are not possible in this repo yet (#110); pulling the judgement out of the JSX is what
+ * keeps any of this covered in the meantime.
  */
 
 /* -------------------------------------------------------------------------------------------
@@ -49,6 +52,21 @@ export const imageAccessibility = (alt: string | undefined): ImageAccessibility 
         accessibilityElementsHidden: false,
         importantForAccessibility: 'yes',
       };
+
+/* -------------------------------------------------------------------------------------------
+ * Overlay
+ * ----------------------------------------------------------------------------------------- */
+
+/**
+ * Whether the `children` slot will actually paint something.
+ *
+ * `children === undefined` is not enough. `{title && <Text>{title}</Text>}` evaluates to `false`
+ * when the title is empty and `{caption ?? null}` to `null` — React renders nothing for either,
+ * and both are how a caller writes "sometimes there is a caption". Treating them as content puts
+ * a scrim and an empty overlay over a photograph that has no text on it at all.
+ */
+export const hasOverlay = (children: ReactNode): boolean =>
+  children !== undefined && children !== null && typeof children !== 'boolean';
 
 /* -------------------------------------------------------------------------------------------
  * Scrim

--- a/packages/ui/src/media/imageFrame.ts
+++ b/packages/ui/src/media/imageFrame.ts
@@ -29,29 +29,67 @@ export type ImageAccessibility = {
 };
 
 /**
- * `undefined` means the image was explicitly declared decorative, not that somebody forgot —
- * the component's prop types make the two impossible to confuse.
+ * Complains in development and stays silent in a shipped build.
+ *
+ * An unlabelled photograph is a defect, but it is not one worth blanking a hero image over, so
+ * this is a warning rather than a throw. Metro replaces `process.env.NODE_ENV` at build time,
+ * so the branch is eliminated from the production bundle entirely.
+ */
+const warnInDevelopment = (message: string): void => {
+  if (process.env.NODE_ENV !== 'production') {
+    console.warn(`<Image>: ${message}`);
+  }
+};
+
+/**
+ * The description a screen reader will read, or the decision to say nothing.
  *
  * A decorative image is hidden outright rather than announced with an empty label: on web
  * `alt=""` already removes it from the accessibility tree, and on native the two hiding props
  * are what iOS and Android respectively read. Announcing "image" with no description is worse
  * than silence, because the listener has to stop and work out that nothing was said.
+ *
+ * Both arguments are needed to tell "nothing to describe" apart from "nobody wrote one", and
+ * the difference matters: the first is a deliberate choice and the second is a bug that hides a
+ * photograph from a reader who has no other way to know it is there. The prop types already
+ * make the second impossible in TypeScript, but the types are not what runs — a JavaScript
+ * caller, a `JSON.parse`d prop bag or a stale build all reach this function with neither. So
+ * does `alt=""`, which is how an empty caption field arrives, and which the type system cannot
+ * catch at all.
  */
-export const imageAccessibility = (alt: string | undefined): ImageAccessibility =>
-  alt === undefined
-    ? {
-        accessible: false,
-        accessibilityLabel: '',
-        accessibilityElementsHidden: true,
-        importantForAccessibility: 'no-hide-descendants',
-      }
-    : {
-        accessible: true,
-        accessibilityRole: 'image',
-        accessibilityLabel: alt,
-        accessibilityElementsHidden: false,
-        importantForAccessibility: 'yes',
-      };
+export const imageAccessibility = (
+  alt: string | undefined,
+  decorative: boolean,
+): ImageAccessibility => {
+  if (alt !== undefined && alt !== '') {
+    /* Both were given. Describing the image is the safer of the two, so the label wins and the
+       contradiction is reported rather than resolved silently. */
+    if (decorative) warnInDevelopment('both `alt` and `decorative` were given; using `alt`.');
+
+    return {
+      accessible: true,
+      accessibilityRole: 'image',
+      accessibilityLabel: alt,
+      accessibilityElementsHidden: false,
+      importantForAccessibility: 'yes',
+    };
+  }
+
+  if (!decorative) {
+    warnInDevelopment(
+      alt === ''
+        ? '`alt` is an empty string, so this image is invisible to a screen reader. Describe it, or pass `decorative` if there is nothing to describe.'
+        : 'neither `alt` nor `decorative` was given. Describe the image, or pass `decorative` if there is nothing to describe.',
+    );
+  }
+
+  return {
+    accessible: false,
+    accessibilityLabel: '',
+    accessibilityElementsHidden: true,
+    importantForAccessibility: 'no-hide-descendants',
+  };
+};
 
 /* -------------------------------------------------------------------------------------------
  * Overlay

--- a/packages/ui/src/media/imageFrame.ts
+++ b/packages/ui/src/media/imageFrame.ts
@@ -1,0 +1,113 @@
+/**
+ * The two decisions an image frame makes that are worth testing on their own: how the picture is
+ * described to a screen reader, and where the scrim sits.
+ *
+ * Both live here rather than inside `Image.tsx` because this file imports neither React nor
+ * React Native, so it runs in a plain Jest process. Component render tests are not possible in
+ * this repo yet (#110); pulling the judgement out of the JSX is what keeps any of this covered
+ * in the meantime.
+ */
+
+/* -------------------------------------------------------------------------------------------
+ * Alternative text
+ * ----------------------------------------------------------------------------------------- */
+
+/**
+ * What the accessibility layer needs, expressed structurally so this file stays free of React
+ * Native. Every field is assignable to the prop of the same name on a View or an expo-image.
+ */
+export type ImageAccessibility = {
+  readonly accessible: boolean;
+  /** Becomes the `alt` attribute on web. Empty string is the correct value for decoration. */
+  readonly accessibilityLabel: string;
+  readonly accessibilityElementsHidden: boolean;
+  readonly importantForAccessibility: 'yes' | 'no-hide-descendants';
+  readonly accessibilityRole?: 'image';
+};
+
+/**
+ * `undefined` means the image was explicitly declared decorative, not that somebody forgot —
+ * the component's prop types make the two impossible to confuse.
+ *
+ * A decorative image is hidden outright rather than announced with an empty label: on web
+ * `alt=""` already removes it from the accessibility tree, and on native the two hiding props
+ * are what iOS and Android respectively read. Announcing "image" with no description is worse
+ * than silence, because the listener has to stop and work out that nothing was said.
+ */
+export const imageAccessibility = (alt: string | undefined): ImageAccessibility =>
+  alt === undefined
+    ? {
+        accessible: false,
+        accessibilityLabel: '',
+        accessibilityElementsHidden: true,
+        importantForAccessibility: 'no-hide-descendants',
+      }
+    : {
+        accessible: true,
+        accessibilityRole: 'image',
+        accessibilityLabel: alt,
+        accessibilityElementsHidden: false,
+        importantForAccessibility: 'yes',
+      };
+
+/* -------------------------------------------------------------------------------------------
+ * Scrim
+ * ----------------------------------------------------------------------------------------- */
+
+/**
+ * Which edge the overlay text sits against. Enumerated rather than an angle, because a scrim
+ * pointing anywhere other than at the text is decoration that costs contrast for nothing.
+ */
+export type ScrimPlacement = 'none' | 'top' | 'bottom';
+
+/** Exactly the geometry `expo-linear-gradient` needs, and nothing else. */
+export type ScrimGeometry = {
+  readonly colors: readonly [string, string];
+  readonly locations: readonly [number, number];
+  readonly start: { readonly x: number; readonly y: number };
+  readonly end: { readonly x: number; readonly y: number };
+};
+
+/**
+ * Where the transparent end gives way to the tint, as a fraction of the frame.
+ *
+ * A scrim that starts at the far edge is a wash over the whole photograph; one that starts too
+ * late is a hard band with a visible seam. Just past half leaves the subject of the image alone
+ * and still ramps up gradually enough that no edge is visible.
+ */
+const SCRIM_ONSET = 0.55;
+
+/**
+ * The theme's gradient, aimed at the text.
+ *
+ * `theme.image.scrimGradient` is `[transparent, tinted]` — tinted toward the brand rather than
+ * flat black (see resolveTheme), so the overlay belongs to the event's palette instead of
+ * reading as a generic darkening layer. Only the direction is decided here; the colour and the
+ * strength are the tenant's.
+ *
+ * Returns `null` for 'none' so the caller renders no gradient view at all, rather than a
+ * transparent one that still costs a layer on every card in a list.
+ */
+export const scrimGeometry = (
+  gradient: readonly [string, string],
+  placement: ScrimPlacement,
+): ScrimGeometry | null => {
+  switch (placement) {
+    case 'none':
+      return null;
+    case 'top':
+      return {
+        colors: gradient,
+        locations: [SCRIM_ONSET, 1],
+        start: { x: 0.5, y: 1 },
+        end: { x: 0.5, y: 0 },
+      };
+    case 'bottom':
+      return {
+        colors: gradient,
+        locations: [SCRIM_ONSET, 1],
+        start: { x: 0.5, y: 0 },
+        end: { x: 0.5, y: 1 },
+      };
+  }
+};


### PR DESCRIPTION
Closes #27

## What changed

`@occasio/ui` gains `Image` — the only image component the codebase should ever use. It wraps `expo-image`, takes its aspect ratio from `theme.image.heroAspect` and crops into it, shows a blurhash placeholder rather than a spinner, lays the theme's brand-tinted scrim gradient over the photograph when there is overlay text to keep legible, and refuses to compile without alternative text. `expo-image` and `expo-linear-gradient` are added to the app (via `expo install`, SDK 57) and declared as peers of the UI package.

## Why this way

**No `contentFit` prop.** The ratio is enforced by the token, not by the upload (§8 of the design intent) — and `contentFit="contain"` would letterbox, which is that enforcement quietly switched off. `cover` is hardcoded, and the frame owns the ratio.

**`aspect` and `radius` are enumerated, not numeric.** `'hero' | 'square'` and `'hero' | 'none'`. A free number is how a design system loses its grid; `square` exists because a grid cell's ratio belongs to the layout, not to the photograph in it.

**Alt text is a union, not an optional string.** `{ alt: string }` or `{ decorative: true }`, never both and never neither, so `<Image source={…} />` does not compile. A decorative image is hidden outright (`accessibilityElementsHidden` + `importantForAccessibility` on native, `alt=""` on web) rather than announced with an empty label — "image", with nothing after it, is worse than silence.

**The scrim defaults to appearing exactly when there is something to make legible** — `bottom` when `children` are passed, `none` otherwise — because a scrim over a bare photograph is contrast spent for nothing. Only the direction is decided here; the colour and the strength are `theme.image.scrimGradient`, which `resolveTheme` already mixes toward `brand[11]`.

**`expo-linear-gradient` is a second new dependency, and it is not avoidable.** React Native 0.86 can express a gradient natively through `experimental_backgroundImage`, but react-native-web 0.21 does not implement it — the scrim would silently render nothing on the web build, which is the platform that ships first (D30). A stepped stack of `View`s was the other option and looks like one.

**`FILL` is written out rather than taken from `StyleSheet.absoluteFill`.** They are not the same object on both platforms: React Native exports a frozen plain object (RN 0.86 dropped `absoluteFillObject` from the types entirely), react-native-web exports a compiled class handle. Spreading the web one into a style object produces something that looks right and positions nothing.

**`transition` comes from `theme.motion`**, so the OS "reduce motion" setting turns the cross-fade off rather than leaving one animation nobody asked for. `cachePolicy="memory-disk"` is the D20 half that survives a cold start on venue wifi.

**The judgement is in `imageFrame.ts`, which imports neither React nor React Native**, so it runs in a plain Jest process: how an image is described to a screen reader, and where the scrim ramps. That is deliberate — see the verification note below.

## What is verified, and what is not

- `npm run verify` passes (144 tests, 8 enforcement probes) and `npm run test:visual` captures 40 screenshots with every route clean.
- `npx expo-doctor` reports 21/21 after both installs, from `apps/mobile`. Neither package needed a root `overrides` pin.
- **The rendered output of `<Image>` is not tested.** Component render tests are not possible in this repo yet (#110), and this PR does not attempt them. Nothing here has been observed on screen: the crop, the blurhash swap, the gradient direction and the overlay position are argued from the APIs, not checked. What *is* covered is the pure half extracted into `imageFrame.ts` — the accessibility props for both branches, and the scrim geometry for all three placements.
- Nothing in `apps/` renders `<Image>` yet, so the visual gate exercised the new dependencies' presence in the bundle but not the component.

## Follow-up worth an issue

`import { Image } from 'react-native'` is still legal. CONTRIBUTING's meta-rule says a convention is machine-enforced or it does not exist, so "never a bare Image" wants a `no-restricted-imports` entry in `eslint.config.mjs` with a probe in `tools/enforcement/`. That is root config, outside this PR's lane — flagging it rather than reaching for it.

## Checks

- [x] `npm run verify` passes locally
- [x] Scoped to one issue — anything else was split out
- [x] Title is in conventional-commit form (it becomes the squashed commit)
- [x] New architectural rules, if any, have a probe in `tools/enforcement/` (none added; the one that is wanted is noted above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145VPJXGgJA9PWqeNXDr1DG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a reusable image component for hero and square layouts, with cropping, rounded corners, placeholders, caching and loading priorities.
  - Added support for optional top or bottom gradient scrims and content overlays.
  - Added reduced-motion-aware image transitions.
  - Added accessibility support for descriptive and decorative images, including required alternative text handling.
  - Added image utilities for consistent accessibility behaviour and overlay geometry across the app.

- **Tests**
  - Added coverage for image accessibility and gradient scrim behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->