### PR TITLE
feat(data): mock adapter with persistence, simulated latency and row-level access

### DIFF
--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -1,6 +1,6 @@
 /**
  * The data layer (D5, D29) — repository interfaces, row types matching Postgres exactly, and
- * the adapter swap point. Mock adapters land in build-order step 4; the Supabase adapter lives
+ * the adapter swap point. The mock adapter lives under ./mock/; the Supabase adapter will live
  * under ./supabase/ and is the only place `@supabase/*` may be imported.
  *
  * Three layers meet here and only here:
@@ -199,5 +199,28 @@ export type {
   UserRow,
   VenueRow,
 } from './rows';
+
+/**
+ * The mock adapter (D4). The whole of `./mock/` is reachable as `@occasio/data/mock`; what is
+ * re-exported here is what an app root needs to stand one up — the factory, the seed shape and
+ * the storage port it writes through.
+ */
+export { createMockAdapter, type MockAdapter, type MockAdapterOptions } from './mock/adapter';
+export { createDefaultStorage } from './mock/defaultStorage';
+export {
+  DEFAULT_LATENCY,
+  MOCK_LATENCY_MAX_MS,
+  MOCK_LATENCY_MIN_MS,
+  type LatencyRange,
+} from './mock/latency';
+export {
+  createAsyncStorage,
+  createMemoryStorage,
+  createWebStorage,
+  type AsyncStorageLike,
+  type MockStorage,
+  type WebStorageLike,
+} from './mock/storage';
+export { EMPTY_TABLES, MOCK_STORAGE_KEY, type MockSeed, type MockTables } from './mock/tables';
 
 export const DATA_SCHEMA_VERSION = 1 as const;

--- a/packages/data/src/mock/access.test.ts
+++ b/packages/data/src/mock/access.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from '@jest/globals';
+import { membershipId, tenantId, userId } from '@occasio/core';
+import { ForbiddenError } from '../errors';
+import {
+  MEMBERSHIP_ROLES,
+  type MembershipRole,
+  type MembershipRow,
+  type MembershipStatus,
+} from '../rows';
+import {
+  ADMIN_ROLES,
+  CREW_ROLES,
+  MODERATOR_ROLES,
+  findActiveMembership,
+  hasRole,
+  requireMembership,
+  requireRole,
+} from './access';
+
+const WEDDING = tenantId('t_wedding');
+const FESTIVAL = tenantId('t_festival');
+const GUEST = userId('u_guest');
+
+const NOW: MembershipRow['created_at'] = '2026-06-01T12:00:00.000Z';
+
+const membership = (
+  over: Partial<MembershipRow> & {
+    readonly role: MembershipRole;
+    readonly status: MembershipStatus;
+  },
+): MembershipRow => ({
+  id: membershipId('m_1'),
+  tenant_id: WEDDING,
+  user_id: GUEST,
+  invited_email: null,
+  invited_phone: null,
+  invited_by: null,
+  invited_at: null,
+  accepted_at: null,
+  created_at: NOW,
+  updated_at: NOW,
+  ...over,
+});
+
+describe('findActiveMembership', () => {
+  it('finds the row for this user in this tenant', () => {
+    const rows = [membership({ role: 'attendee', status: 'active' })];
+    expect(findActiveMembership(rows, WEDDING, GUEST)?.id).toBe(membershipId('m_1'));
+  });
+
+  it('does not count an invitation as membership', () => {
+    /* The reason `status` is checked at all. An invited row exists before the person accepts --
+       it is a promise of access -- and treating it as membership would hand the guest list and
+       the moderation queue to anyone holding a pending invite. */
+    const invited = [membership({ role: 'event_admin', status: 'invited' })];
+    expect(findActiveMembership(invited, WEDDING, GUEST)).toBeNull();
+  });
+
+  it('does not count a revoked membership', () => {
+    const revoked = [membership({ role: 'event_admin', status: 'revoked' })];
+    expect(findActiveMembership(revoked, WEDDING, GUEST)).toBeNull();
+  });
+
+  it('does not let a membership in one tenant read another', () => {
+    /* The whole point of the simulated policy: this is the cross-tenant leak, and it has to be
+       a null here rather than a row that happens to belong to the wrong event. */
+    const rows = [membership({ role: 'event_admin', status: 'active' })];
+    expect(findActiveMembership(rows, FESTIVAL, GUEST)).toBeNull();
+  });
+
+  it('does not match an invitation row that has no user yet', () => {
+    /* `user_id` is null until the invite is accepted, and `undefined === null` is false, but a
+       lookup for a user who is genuinely absent must not land on one of these. */
+    const rows = [membership({ role: 'attendee', status: 'active', user_id: null })];
+    expect(findActiveMembership(rows, WEDDING, GUEST)).toBeNull();
+  });
+});
+
+describe('requireMembership', () => {
+  it('returns the membership when there is one', () => {
+    const rows = [membership({ role: 'crew', status: 'active' })];
+    expect(requireMembership(rows, WEDDING, GUEST, 'sessions.list').role).toBe('crew');
+  });
+
+  it('throws with the tenant and the action, which is what makes the failure readable', () => {
+    /* "sessions.list on tenant t_festival" raised from a screen rendering a wedding is a
+       diagnosis. "Forbidden" is a shrug. */
+    expect.assertions(2);
+    try {
+      requireMembership([], FESTIVAL, GUEST, 'sessions.list');
+      throw new Error('requireMembership returned instead of throwing');
+    } catch (error) {
+      /* `instanceof` rather than a cast: D16 allows no assertions outside mappers.ts and
+         ids.ts, and rethrowing anything else keeps the test honest if the type changes. */
+      if (!(error instanceof ForbiddenError)) throw error;
+      expect(error.tenantId).toBe(FESTIVAL);
+      expect(error.action).toBe('sessions.list');
+    }
+  });
+});
+
+describe('role sets', () => {
+  it('widens from admin to moderator to crew, and each level keeps the ones above it', () => {
+    /* Written as containment rather than as three literal lists: the property that matters is
+       that an event admin can do everything a moderator can, which is easy to break by editing
+       one list and not the others. */
+    expect(MODERATOR_ROLES).toEqual(expect.arrayContaining([...ADMIN_ROLES]));
+    expect(CREW_ROLES).toEqual(expect.arrayContaining([...MODERATOR_ROLES]));
+  });
+
+  it('never admits a vendor or an attendee to a privileged set', () => {
+    for (const roles of [ADMIN_ROLES, MODERATOR_ROLES, CREW_ROLES]) {
+      expect(roles).not.toContain('vendor');
+      expect(roles).not.toContain('attendee');
+    }
+  });
+
+  it('names only roles that exist', () => {
+    /* A typo in one of these lists is a permission that silently never matches. */
+    for (const role of [...ADMIN_ROLES, ...MODERATOR_ROLES, ...CREW_ROLES]) {
+      expect(MEMBERSHIP_ROLES).toContain(role);
+    }
+  });
+});
+
+describe('requireRole', () => {
+  it('lets a held role through and turns a missing one into the same answer as no membership', () => {
+    const admin = membership({ role: 'event_admin', status: 'active' });
+    const attendee = membership({ role: 'attendee', status: 'active' });
+
+    expect(requireRole(admin, MODERATOR_ROLES, WEDDING, 'gossip.moderate')).toBe(admin);
+    expect(() => requireRole(attendee, MODERATOR_ROLES, WEDDING, 'gossip.moderate')).toThrow(
+      ForbiddenError,
+    );
+  });
+
+  it('agrees with hasRole for every role', () => {
+    /* Two ways to ask the same question, and a screen that hides a button with one while the
+       repository enforces the other is how a dead-end UI happens. */
+    for (const role of MEMBERSHIP_ROLES) {
+      const row = membership({ role, status: 'active' });
+      const allowed = hasRole(row, CREW_ROLES);
+      if (allowed) {
+        expect(requireRole(row, CREW_ROLES, WEDDING, 'tasks.list')).toBe(row);
+      } else {
+        expect(() => requireRole(row, CREW_ROLES, WEDDING, 'tasks.list')).toThrow(ForbiddenError);
+      }
+    }
+  });
+});

--- a/packages/data/src/mock/access.ts
+++ b/packages/data/src/mock/access.ts
@@ -1,0 +1,78 @@
+import type { TenantId, UserId } from '@occasio/core';
+import { ForbiddenError } from '../errors';
+import type { MembershipRole, MembershipRow } from '../rows';
+
+/**
+ * The simulated row-level security check (§6, `errors.ts`).
+ *
+ * Every tenant-scoped repository method runs through here before it touches a row, and throws
+ * `ForbiddenError` when the caller has no active membership in the `tenantId` it passed. That is
+ * the whole reason `tenantId` is the first argument of every method: the check mirrors what the
+ * eventual Postgres policy does, so a cross-tenant read is a loud failure in a prototype instead
+ * of a silent data leak in production, six months after the screen that caused it was written.
+ *
+ * It runs from the first commit rather than from whenever Supabase arrives, and that ordering is
+ * the point. A prototype built against an adapter with no access control is a prototype whose
+ * screens all quietly assume they can see everything.
+ */
+
+/**
+ * `invited` does not count.
+ *
+ * An invitation is a row that exists before the person does (`rows.ts`) — a promise of access,
+ * not access. Treating it as membership would let anyone with a pending invite read the guest
+ * list, the crew board and the moderation queue of an event they have not joined.
+ */
+export const findActiveMembership = (
+  memberships: readonly MembershipRow[],
+  tenantId: TenantId,
+  userId: UserId,
+): MembershipRow | null =>
+  memberships.find(
+    (row) => row.tenant_id === tenantId && row.user_id === userId && row.status === 'active',
+  ) ?? null;
+
+/**
+ * The gate. `action` is spelled `repository.method` because the pair `(action, tenantId)` is what
+ * makes a cross-tenant bug readable — "sessions.list on tenant t_devcon" raised from a screen
+ * rendering a wedding is a diagnosis, and "Forbidden" is a shrug.
+ */
+export const requireMembership = (
+  memberships: readonly MembershipRow[],
+  tenantId: TenantId,
+  userId: UserId,
+  action: string,
+): MembershipRow => {
+  const membership = findActiveMembership(memberships, tenantId, userId);
+  if (membership === null) throw new ForbiddenError({ tenantId, action });
+  return membership;
+};
+
+/** Roles that may change the event itself: config, invitations, announcements, approvals. */
+export const ADMIN_ROLES: readonly MembershipRole[] = ['event_admin'];
+
+/** Roles that may see and act on the moderation queue (D3) — gossip posts and media alike. */
+export const MODERATOR_ROLES: readonly MembershipRole[] = ['event_admin', 'moderator'];
+
+/** Roles that run the event on the day: the crew board, seating, room and shuttle assignments. */
+export const CREW_ROLES: readonly MembershipRole[] = ['event_admin', 'moderator', 'crew'];
+
+/**
+ * A second gate for the operations a member holds a membership for but not the role.
+ *
+ * `errors.ts` is explicit that `ForbiddenError` covers both "no membership in this tenant" and
+ * "a role it does not hold", and the two are genuinely the same answer to a screen: sign in as
+ * somebody else, or you are in the wrong place.
+ */
+export const requireRole = (
+  membership: MembershipRow,
+  allowed: readonly MembershipRole[],
+  tenantId: TenantId,
+  action: string,
+): MembershipRow => {
+  if (!allowed.includes(membership.role)) throw new ForbiddenError({ tenantId, action });
+  return membership;
+};
+
+export const hasRole = (membership: MembershipRow, allowed: readonly MembershipRole[]): boolean =>
+  allowed.includes(membership.role);

--- a/packages/data/src/mock/adapter.test.ts
+++ b/packages/data/src/mock/adapter.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from '@jest/globals';
+import { membershipId, tenantId, userId } from '@occasio/core';
+import { MEMBERSHIP_ROLES } from '../rows';
+import type { MembershipRole, MembershipRow, MembershipStatus, UserRow } from '../rows';
+import { createMockAdapter, type MockAdapter } from './adapter';
+import { createMemoryStorage } from './storage';
+import { EMPTY_TABLES, type MockSeed } from './tables';
+
+/**
+ * Behavioural tests for the adapter, run against an in-memory store with the latency turned off.
+ *
+ * They cover the decisions that are invisible in the types and expensive to get wrong: who
+ * appears in a directory, who may read an invitation, and what happens to a write whose dataset
+ * was thrown away while it was in flight.
+ */
+
+const WEDDING = tenantId('t_wedding');
+const ADMIN = userId('u_admin');
+const GUEST = userId('u_guest');
+const GONE = userId('u_gone');
+const AT: MembershipRow['created_at'] = '2026-06-01T12:00:00.000Z';
+
+const user = (id: UserRow['id'], name: string): UserRow => ({
+  id,
+  email: `${name}@example.test`,
+  display_name: name,
+  avatar_media_id: null,
+  locale: null,
+  created_at: AT,
+  updated_at: AT,
+});
+
+const member = (
+  id: string,
+  who: MembershipRow['user_id'],
+  role: MembershipRole,
+  status: MembershipStatus,
+  invited?: { readonly email: string | null; readonly phone: string | null },
+): MembershipRow => ({
+  id: membershipId(id),
+  tenant_id: WEDDING,
+  user_id: who,
+  invited_email: invited?.email ?? null,
+  invited_phone: invited?.phone ?? null,
+  role,
+  status,
+  invited_by: null,
+  invited_at: null,
+  accepted_at: null,
+  created_at: AT,
+  updated_at: AT,
+});
+
+const SEED: MockSeed = {
+  ...EMPTY_TABLES,
+  users: [user(ADMIN, 'admin'), user(GUEST, 'guest'), user(GONE, 'gone')],
+  memberships: [
+    member('mb_admin', ADMIN, 'event_admin', 'active'),
+    member('mb_guest', GUEST, 'attendee', 'active', { email: 'guest@example.test', phone: null }),
+    member('mb_gone', GONE, 'attendee', 'revoked'),
+    member('mb_invite', null, 'attendee', 'invited', {
+      email: 'not-yet@example.test',
+      phone: '+15550001111',
+    }),
+  ],
+};
+
+const adapterFor = (
+  who: typeof ADMIN,
+  over: { readonly sleep?: () => Promise<void> } = {},
+): MockAdapter =>
+  createMockAdapter({
+    currentUserId: who,
+    seed: SEED,
+    storage: createMemoryStorage(),
+    /* Off by default: these tests are about what the adapter decides, not how long it waits. */
+    latency: { minMs: 0, maxMs: 0 },
+    ...over,
+  });
+
+const ALL_ROLES = { roles: MEMBERSHIP_ROLES, statuses: ['invited', 'active', 'revoked'] } as const;
+
+describe('the event directory', () => {
+  it('lists the active members', async () => {
+    const names = (await adapterFor(GUEST).users.list(WEDDING)).items.map((u) => u.displayName);
+    expect(names).toEqual(['admin', 'guest']);
+  });
+
+  it('drops a member whose access was revoked', async () => {
+    /* `memberships.revoke` exists to take someone out of the event. A directory that still
+       lists them is the operation silently not working -- and `users.byId` returning their
+       record is the same leak reached by a different door. */
+    const adapter = adapterFor(GUEST);
+    const listed = (await adapter.users.list(WEDDING)).items.map((u) => u.id);
+
+    expect(listed).not.toContain(GONE);
+    await expect(adapter.users.byId(WEDDING, GONE)).rejects.toThrow();
+  });
+});
+
+describe('invitation contact details', () => {
+  it('shows an admin the pending invitations, contacts and all', async () => {
+    const page = await adapterFor(ADMIN).memberships.list(WEDDING, ALL_ROLES);
+    const invite = page.items.find((row) => row.status === 'invited');
+
+    expect(invite?.invitedEmail).toBe('not-yet@example.test');
+    expect(invite?.invitedPhone).toBe('+15550001111');
+  });
+
+  it('hides them from a member who is not an admin', async () => {
+    /* An invited row is a person who has not joined and never agreed to be in this event's
+       directory. Their email is the one piece of personal data here that belongs to somebody
+       outside the event. */
+    const page = await adapterFor(GUEST).memberships.list(WEDDING, ALL_ROLES);
+
+    expect(page.items.some((row) => row.status === 'invited')).toBe(false);
+    for (const row of page.items) {
+      expect(row.invitedEmail).toBeNull();
+      expect(row.invitedPhone).toBeNull();
+    }
+  });
+
+  it('still hides the contact of an accepted membership from a non-admin', async () => {
+    /* The reason the rows are redacted rather than only filtered: a membership keeps
+       `invited_email` after it is accepted, so filtering `invited` alone would have handed
+       every member's address to anyone who asked for the active ones. */
+    const page = await adapterFor(GUEST).memberships.list(WEDDING, {
+      roles: MEMBERSHIP_ROLES,
+      statuses: ['active'],
+    });
+    const guest = page.items.find((row) => row.userId === GUEST);
+
+    expect(guest).toBeDefined();
+    expect(guest?.invitedEmail).toBeNull();
+  });
+
+  it('lets a member read their own membership in full', async () => {
+    const own = await adapterFor(GUEST).memberships.findForUser(WEDDING, GUEST);
+    expect(own?.invitedEmail).toBe('guest@example.test');
+  });
+
+  it('redacts another member read through findForUser', async () => {
+    const other = await adapterFor(GUEST).memberships.findForUser(WEDDING, ADMIN);
+    expect(other).not.toBeNull();
+    expect(other?.invitedEmail).toBeNull();
+  });
+});
+
+describe('resetDemoData against a write already in flight', () => {
+  it('discards the write rather than restoring the dataset on the next reload', async () => {
+    /*
+     * The window is the simulated latency -- up to 240ms in the app, which is long enough to
+     * hit by hand. Without the guard the resumed write persists its pre-reset tables over the
+     * fresh snapshot: memory looks reset, storage does not, and the dataset the user threw away
+     * comes back at the next reload, far from anything that would explain it.
+     */
+    /* Held only while the invite is in flight; the assertions afterwards make their own calls,
+       and those have to be able to finish. */
+    const releases: (() => void)[] = [];
+    let holding = true;
+    /* Shared with the second adapter below: the corruption is in the store, not in memory. */
+    const storage = createMemoryStorage();
+    const adapter = createMockAdapter({
+      currentUserId: ADMIN,
+      seed: SEED,
+      storage,
+      sleep: () =>
+        holding
+          ? new Promise<void>((resolve) => {
+              releases.push(resolve);
+            })
+          : Promise.resolve(),
+    });
+
+    /** One turn of the event loop, so an operation reaches the delay it is about to wait on. */
+    const settle = async (): Promise<void> => {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 0);
+      });
+    };
+
+    await adapter.ready();
+
+    const inFlight = adapter.memberships.invite(WEDDING, {
+      email: 'late@example.test',
+      phone: null,
+      role: 'attendee',
+    });
+    await settle();
+    expect(releases).toHaveLength(1);
+
+    /* The reset lands while the invite is still waiting on its delay. */
+    await adapter.resetDemoData();
+
+    holding = false;
+    for (;;) {
+      const release = releases.shift();
+      if (release === undefined) break;
+      release();
+      await settle();
+    }
+    await inFlight.catch(() => undefined);
+
+    /*
+     * Asserted through a second adapter over the same store, because that is the only place the
+     * bug is visible. The running adapter's `state` is the fresh object either way, so a check
+     * against `adapter` passes whether or not the guard exists -- which is what the first
+     * version of this test did, and why it caught nothing.
+     */
+    const reloaded = createMockAdapter({
+      currentUserId: ADMIN,
+      seed: SEED,
+      storage,
+      latency: { minMs: 0, maxMs: 0 },
+    });
+    const after = await reloaded.memberships.list(WEDDING, ALL_ROLES);
+
+    expect(after.items.some((row) => row.invitedEmail === 'late@example.test')).toBe(false);
+  });
+});

--- a/packages/data/src/mock/adapter.test.ts
+++ b/packages/data/src/mock/adapter.test.ts
@@ -217,4 +217,96 @@ describe('resetDemoData against a write already in flight', () => {
 
     expect(after.items.some((row) => row.invitedEmail === 'late@example.test')).toBe(false);
   });
+
+  it('never leaves two writes in flight, so the reset is the one that lands', async () => {
+    /*
+     * The half of the race the `commit` guard does not close. The guard decides *whether* a
+     * superseded write happens; it cannot decide when a write already handed to the store
+     * finishes. With two writes in flight the store may complete them in either order, and if
+     * the older finishes last the pre-reset tables survive on disk -- the same
+     * invisible-until-reload corruption, reached by a different route.
+     *
+     * So the store here holds every write open until released, and they are released
+     * newest-first: the completion order a slow store is entitled to produce, and the one that
+     * loses the data. `maxInFlight` is the assertion that matters -- while writes are
+     * serialised, the store is never in a position to invert anything.
+     */
+    let stored: string | null = null;
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const gates: (() => void)[] = [];
+    const heldStorage = {
+      read: () => Promise.resolve(stored),
+      write: async (_key: string, value: string) => {
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await new Promise<void>((resolve) => {
+          gates.push(resolve);
+        });
+        stored = value;
+        inFlight -= 1;
+      },
+      remove: () => {
+        stored = null;
+        return Promise.resolve();
+      },
+    };
+
+    const settle = async (): Promise<void> => {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 0);
+      });
+    };
+    /** Waits for a condition rather than for a fixed number of turns, which is guesswork. */
+    const waitFor = async (what: string, ready: () => boolean): Promise<void> => {
+      for (let guard = 0; guard < 50; guard += 1) {
+        if (ready()) return;
+        await settle();
+      }
+      throw new Error(`timed out waiting for ${what}`);
+    };
+
+    /** Finishes the outstanding writes newest-first, including any queued while draining. */
+    const drainNewestFirst = async (): Promise<void> => {
+      for (let guard = 0; guard < 20; guard += 1) {
+        const gate = gates.pop();
+        if (gate === undefined) return;
+        gate();
+        await settle();
+      }
+      throw new Error('writes never stopped queueing');
+    };
+
+    const adapter = createMockAdapter({
+      currentUserId: ADMIN,
+      seed: SEED,
+      storage: heldStorage,
+      latency: { minMs: 0, maxMs: 0 },
+    });
+
+    /* First load seeds the store; let that write finish so it is not part of the race. */
+    const ready = adapter.ready();
+    await waitFor('the seeding write', () => gates.length > 0);
+    await drainNewestFirst();
+    await ready;
+
+    /* The invite runs all the way into its write, which is then held open. */
+    const invite = adapter.memberships.invite(WEDDING, {
+      email: 'late@example.test',
+      phone: null,
+      role: 'attendee',
+    });
+    await waitFor("the invite's write to reach the store", () => gates.length === 1);
+
+    /* The reset lands while that write is still in flight. */
+    const reset = adapter.resetDemoData();
+    await settle();
+
+    await drainNewestFirst();
+    await Promise.all([invite.catch(() => undefined), reset]);
+
+    expect(maxInFlight).toBe(1);
+    expect(stored).not.toBeNull();
+    expect(stored).not.toContain('late@example.test');
+  });
 });

--- a/packages/data/src/mock/adapter.ts
+++ b/packages/data/src/mock/adapter.ts
@@ -246,16 +246,38 @@ export const createMockAdapter = (options: MockAdapterOptions): MockAdapter => {
     nextId: 1,
   });
 
-  const persist = async (current: MockState): Promise<void> => {
-    await storage.write(
-      storageKey,
-      serialiseSnapshot({
-        version: MOCK_SNAPSHOT_VERSION,
-        deviceId: current.deviceId,
-        nextId: current.nextId,
-        tables: current.tables,
-      }),
+  /**
+   * The tail of the write chain. Every `persist` joins it, so writes reach the store in the
+   * order they were issued rather than in whatever order the store finishes them.
+   *
+   * Ordering is what makes the reset guard in `commit` complete. Without it the guard only
+   * closes half the race: a commit that passed the check can still have its `storage.write`
+   * in flight when `resetDemoData` writes the fresh snapshot, and if the older write finishes
+   * last the pre-reset tables are what survive on disk. The guard decides *whether* to write;
+   * this decides *when*, and both are needed to say the reset wins.
+   */
+  let writes: Promise<void> = Promise.resolve();
+
+  /**
+   * Not `async`: the payload is serialised and the write is queued in the same synchronous turn
+   * as the call. That is what gives the ordering its meaning — a commit that passed the guard
+   * has necessarily queued before `resetDemoData` could change `state` and queue its own write,
+   * so the reset's snapshot is always the later one.
+   */
+  const persist = (current: MockState): Promise<void> => {
+    const payload = serialiseSnapshot({
+      version: MOCK_SNAPSHOT_VERSION,
+      deviceId: current.deviceId,
+      nextId: current.nextId,
+      tables: current.tables,
+    });
+    /* A rejected write must not poison the queue for every write after it, but the caller that
+       issued it still sees its own failure. */
+    writes = writes.then(
+      () => storage.write(storageKey, payload),
+      () => storage.write(storageKey, payload),
     );
+    return writes;
   };
 
   const readState = async (): Promise<MockState> => {

--- a/packages/data/src/mock/adapter.ts
+++ b/packages/data/src/mock/adapter.ts
@@ -121,7 +121,7 @@ import {
   type Random,
   type Sleep,
 } from './latency';
-import { approvalRequestId, parseSnapshot, serialiseSnapshot } from './mappers';
+import { approvalRequestId, cloneJson as clone, parseSnapshot, serialiseSnapshot } from './mappers';
 import { numericKey, paginate, timestampKey } from './paging';
 import type { MockStorage } from './storage';
 import {
@@ -219,8 +219,6 @@ const REPORT_HIDE_THRESHOLD = 3;
 
 const QUIET_HOURS = /^(?:[01]\d|2[0-3]):[0-5]\d$/;
 
-const clone = <T>(value: T): T => structuredClone(value);
-
 const trimmed = (value: string): string => value.trim();
 
 export const createMockAdapter = (options: MockAdapterOptions): MockAdapter => {
@@ -283,6 +281,19 @@ export const createMockAdapter = (options: MockAdapterOptions): MockAdapter => {
   };
 
   const commit = async (current: MockState, patch: Partial<MockTables>): Promise<void> => {
+    /*
+     * A write belongs to the state it was read from. `resetDemoData` replaces `state` wholesale,
+     * and every operation is holding its `current` across a simulated delay of up to 240 ms — so
+     * a moderation that started before the reset would otherwise resume afterwards and persist
+     * its pre-reset tables over the fresh snapshot. In-memory state would still look reset and
+     * the next reload would restore the dataset the user asked to throw away, which is the worst
+     * shape a bug can have: invisible until the app restarts.
+     *
+     * Dropping the write is the whole fix. The operation was issued against a dataset that no
+     * longer exists, so there is nothing to merge it into and nothing to tell the caller — a
+     * reset is a discard, and this write is part of what was discarded.
+     */
+    if (current !== state) return;
     current.tables = { ...current.tables, ...patch };
     await persist(current);
   };
@@ -510,10 +521,18 @@ export const createMockAdapter = (options: MockAdapterOptions): MockAdapter => {
     },
   };
 
+  /**
+   * Who is in this event's directory: active members, and nobody else.
+   *
+   * `status` is the whole point. `access.ts` already refuses an invitation as membership, and
+   * `directory.listForUser` already filters on `active` — this helper missing the same check is
+   * what let a person keep their entry in the guest list after `memberships.revoke`, which is
+   * the one operation whose entire purpose is to take it away.
+   */
   const memberUserIds = (current: MockState, tenantId: TenantId): ReadonlySet<UserId> =>
     new Set(
       current.tables.memberships
-        .filter((row) => row.tenant_id === tenantId && row.user_id !== null)
+        .filter((row) => row.tenant_id === tenantId && row.status === 'active')
         .flatMap((row) => (row.user_id === null ? [] : [row.user_id])),
     );
 
@@ -569,18 +588,44 @@ export const createMockAdapter = (options: MockAdapterOptions): MockAdapter => {
       memberships: replace(current.tables.memberships, (row) => row.id === next.id, next),
     });
 
+  /**
+   * An invitation's email and phone number are the one piece of personal data in this schema
+   * that belongs to somebody who has not joined yet, and who therefore never agreed to be in
+   * this event's directory. Only an event admin sees them.
+   *
+   * Redacting rather than filtering for the accepted rows: a membership keeps `invited_email`
+   * after it is accepted, so filtering only `invited` rows would still have handed every
+   * member's contact address to any attendee who asked for `statuses: ['active']`.
+   */
+  const withoutInviteContact = (row: MembershipRow): MembershipRow => ({
+    ...row,
+    invited_email: null,
+    invited_phone: null,
+  });
+
   const memberships: DataAdapter['memberships'] = {
     list: async (
       tenantId: TenantId,
       query: MembershipQuery,
       page?: PageRequest,
     ): Promise<Page<Membership>> => {
-      const { current } = await scope(tenantId, 'memberships.list');
+      const { current, membership } = await scope(tenantId, 'memberships.list');
+      /*
+       * Not `requireRole`: a member listing the people at an event is ordinary, and the guest
+       * list is not the secret. The pending invitations are — an invited row is a person who has
+       * not joined, so a non-admin does not see the row at all, and never sees contact details.
+       */
+      const admin = hasRole(membership, ADMIN_ROLES);
       return mapPage(
         paginate({
-          items: inTenant(current.tables.memberships, tenantId).filter(
-            (row) => query.roles.includes(row.role) && query.statuses.includes(row.status),
-          ),
+          items: inTenant(current.tables.memberships, tenantId)
+            .filter(
+              (row) =>
+                query.roles.includes(row.role) &&
+                query.statuses.includes(row.status) &&
+                (admin || row.status !== 'invited'),
+            )
+            .map((row) => (admin ? row : withoutInviteContact(row))),
           sortKey: (row) => timestampKey(row.created_at, 'membership.created_at'),
           id: (row) => row.id,
           order: 'asc',
@@ -604,7 +649,12 @@ export const createMockAdapter = (options: MockAdapterOptions): MockAdapter => {
       const row = current.tables.memberships.find(
         (candidate) => candidate.tenant_id === tenantId && candidate.user_id === userId,
       );
-      return row === undefined ? null : toMembership(row);
+      if (row === undefined) return null;
+      /* Your own membership is yours to read in full; anyone else's contact details are the
+         admin's, by the same rule `memberships.list` applies. */
+      const caller = findActiveMembership(current.tables.memberships, tenantId, me);
+      const admin = caller !== null && hasRole(caller, ADMIN_ROLES);
+      return toMembership(admin || row.user_id === me ? row : withoutInviteContact(row));
     },
 
     invite: async (tenantId: TenantId, invite: MembershipInvite): Promise<Membership> => {

--- a/packages/data/src/mock/adapter.ts
+++ b/packages/data/src/mock/adapter.ts
@@ -1,0 +1,1554 @@
+import {
+  announcementId as toAnnouncementId,
+  assignmentId as toAssignmentId,
+  gossipPostId as toGossipPostId,
+  membershipId as toMembershipId,
+  personaId as toPersonaId,
+  taskId as toTaskId,
+  type AnnouncementId,
+  type AssignmentId,
+  type GossipPostId,
+  type MediaId,
+  type MembershipId,
+  type PersonId,
+  type PersonaId,
+  type SessionId,
+  type TaskId,
+  type TenantId,
+  type UnitId,
+  type UserId,
+  type VenueId,
+} from '@occasio/core';
+import type { TenantConfig } from '../config';
+import type {
+  Announcement,
+  Assignment,
+  GossipPost,
+  MediaAsset,
+  Membership,
+  NotificationPreferences,
+  Person,
+  Persona,
+  Rsvp,
+  Session,
+  Tenant,
+  Unit,
+  Venue,
+} from '../domain';
+import { NotFoundError, ValidationError, type ValidationIssue } from '../errors';
+import {
+  toAnnouncement,
+  toApprovalRequest,
+  toAssignment,
+  toGossipPost,
+  toMediaAsset,
+  toMembership,
+  toNotificationPreferences,
+  toPerson,
+  toPersona,
+  toRsvp,
+  toSession,
+  toSessionPerson,
+  toTask,
+  toTenant,
+  toTenantConfigRecord,
+  toUnit,
+  toUser,
+  toVenue,
+} from '../mappers';
+import type { Page, PageRequest } from '../pagination';
+import type {
+  ApprovalDecision,
+  DataAdapter,
+  GossipChange,
+  GossipModeration,
+  GossipQuery,
+  MembershipInvite,
+  MembershipQuery,
+  NewAnnouncement,
+  NewAssignment,
+  NewGossipPost,
+  NewTask,
+  NotificationPreferencesInput,
+  RsvpInput,
+  RsvpQuery,
+  SessionQuery,
+  TaskQuery,
+  UnitQuery,
+  Unsubscribe,
+  AnnouncementQuery,
+  AssignmentQuery,
+  MediaQuery,
+} from '../repositories';
+import type {
+  AnnouncementRow,
+  ApprovalRequestId,
+  ApprovalRequestRow,
+  AssignmentRow,
+  GossipPostRow,
+  MediaAssetRow,
+  MembershipRow,
+  ModerationStatus,
+  NotificationPreferenceRow,
+  PersonRow,
+  PersonaRow,
+  RsvpRow,
+  SessionRow,
+  TaskRow,
+  TaskStatus,
+  TenantConfigRow,
+  TenantRow,
+  UnitRow,
+  UserRow,
+  VenueRow,
+} from '../rows';
+import {
+  CREW_ROLES,
+  ADMIN_ROLES,
+  MODERATOR_ROLES,
+  findActiveMembership,
+  hasRole,
+  requireMembership,
+  requireRole,
+} from './access';
+import { createDefaultStorage } from './defaultStorage';
+import { createAvatarKey, createDeviceId, createPersonaLabel, deviceHashFor } from './identity';
+import {
+  DEFAULT_LATENCY,
+  createDelay,
+  realSleep,
+  type LatencyRange,
+  type Random,
+  type Sleep,
+} from './latency';
+import { approvalRequestId, parseSnapshot, serialiseSnapshot } from './mappers';
+import { numericKey, paginate, timestampKey } from './paging';
+import type { MockStorage } from './storage';
+import {
+  EMPTY_TABLES,
+  MOCK_SNAPSHOT_VERSION,
+  MOCK_STORAGE_KEY,
+  type MockSeed,
+  type MockTables,
+} from './tables';
+
+/**
+ * The mock adapter (D4): a full `DataAdapter` backed by fixture rows, a real store and a
+ * deliberate delay.
+ *
+ * Three properties make it worth more than an array of stubs, and each of them exists to make
+ * the prototype fail the way production will:
+ *
+ *  1. **Writes persist.** The demo dataset is loaded from storage, mutated in place and written
+ *     back, so approving a gossip post or publishing a theme survives a reload. Without that,
+ *     the theme editor is a toy — every change is gone the moment you check it on a phone.
+ *  2. **Every call is slow on purpose.** 80–240ms, before it succeeds *or* fails. See
+ *     `latency.ts`: a loading state that was never visible during development is a loading state
+ *     that was never built.
+ *  3. **Access is checked, not assumed.** A `tenantId` the caller has no active membership in is
+ *     a `ForbiddenError`, from the first commit rather than from whenever Supabase arrives. See
+ *     `access.ts`.
+ *
+ * **Visibility is filtered; permission is thrown.** The distinction runs through every method
+ * below and it is the one Postgres makes. A row-level security policy does not raise an error
+ * when you ask for rows you cannot see — it returns fewer rows. So an attendee asking for the
+ * moderation queue gets the approved posts they are allowed to see, and an attendee asking for
+ * draft sessions gets the published ones; only an *operation* they may not perform — publishing a
+ * config, moderating a post, inviting a member — throws `ForbiddenError`. Screens written against
+ * an adapter that threw for a read would be screens full of error branches that Supabase then
+ * never takes.
+ */
+
+/* ---------------------------------------------------------------------------------------------
+ * Options and the returned adapter
+ * ------------------------------------------------------------------------------------------- */
+
+export type MockAdapterOptions = {
+  /**
+   * Who is asking. Every access check is against this user, so it is the mock's stand-in for
+   * `auth.uid()` and the reason a demo can be viewed as an admin and then as a guest.
+   */
+  readonly currentUserId: UserId;
+  /** The dataset a first run — or a reset — starts from. The fixture events (#35) are one. */
+  readonly seed: MockSeed;
+  /** Defaults to the platform store: `localStorage` on web, memory elsewhere. */
+  readonly storage?: MockStorage | undefined;
+  /** Overridable so two adapters in one test do not share a key. */
+  readonly storageKey?: string | undefined;
+  /** `{ minMs: 0, maxMs: 0 }` turns the delay off, which is what the suites do. */
+  readonly latency?: LatencyRange | undefined;
+  readonly random?: Random | undefined;
+  readonly sleep?: Sleep | undefined;
+  /** Injected so a test can assert what was stamped rather than that it looks recent. */
+  readonly now?: (() => Date) | undefined;
+};
+
+/**
+ * `DataAdapter` plus the two things only a mock has.
+ *
+ * Screens are handed the `DataAdapter` half and cannot reach either, which is what stops a
+ * "reset demo data" button being wired somewhere it would ship.
+ */
+export type MockAdapter = DataAdapter & {
+  /**
+   * Throws away every write and reloads the seed — the entry point behind the dev-menu action.
+   *
+   * It exists because the alternative, once someone has rejected the wrong post or dragged the
+   * seed colour somewhere unusable, is talking a person through clearing site data in browser
+   * devtools five minutes before a demo.
+   */
+  readonly resetDemoData: () => Promise<void>;
+  /** Resolves once the snapshot has been read (or seeded). Useful to warm before a first paint. */
+  readonly ready: () => Promise<void>;
+};
+
+/* ---------------------------------------------------------------------------------------------
+ * Internals
+ * ------------------------------------------------------------------------------------------- */
+
+type MockState = { tables: MockTables; deviceId: string; nextId: number };
+
+/** A stand-in for the `CHECK` constraint the column will carry. */
+const MAX_GOSSIP_BODY_LENGTH = 600;
+
+/**
+ * D31 — reports above this auto-hide an approved post pending review, rather than waiting for a
+ * moderator to notice. Low, because a demo has to be able to reach it.
+ */
+const REPORT_HIDE_THRESHOLD = 3;
+
+const QUIET_HOURS = /^(?:[01]\d|2[0-3]):[0-5]\d$/;
+
+const clone = <T>(value: T): T => structuredClone(value);
+
+const trimmed = (value: string): string => value.trim();
+
+export const createMockAdapter = (options: MockAdapterOptions): MockAdapter => {
+  const storage = options.storage ?? createDefaultStorage();
+  const storageKey = options.storageKey ?? MOCK_STORAGE_KEY;
+  const random = options.random ?? Math.random;
+  const sleep = options.sleep ?? realSleep;
+  const clock = options.now ?? ((): Date => new Date());
+  const delay = createDelay({ range: options.latency ?? DEFAULT_LATENCY, random, sleep });
+  const me = options.currentUserId;
+
+  let state: MockState | null = null;
+  let loading: Promise<MockState> | null = null;
+
+  const nowIso = (): string => clock().toISOString();
+
+  const freshState = (): MockState => ({
+    /*
+     * Cloned, because the seed is a module-level constant shared by every adapter in the
+     * process. A mock that mutated it would leak one test's writes into the next, and one
+     * browser tab's into another after a hot reload.
+     */
+    tables: { ...EMPTY_TABLES, ...clone(options.seed) },
+    deviceId: createDeviceId(random),
+    nextId: 1,
+  });
+
+  const persist = async (current: MockState): Promise<void> => {
+    await storage.write(
+      storageKey,
+      serialiseSnapshot({
+        version: MOCK_SNAPSHOT_VERSION,
+        deviceId: current.deviceId,
+        nextId: current.nextId,
+        tables: current.tables,
+      }),
+    );
+  };
+
+  const readState = async (): Promise<MockState> => {
+    const raw = await storage.read(storageKey);
+    const snapshot = raw === null ? null : parseSnapshot(raw);
+    if (snapshot !== null) {
+      return { tables: snapshot.tables, deviceId: snapshot.deviceId, nextId: snapshot.nextId };
+    }
+    const fresh = freshState();
+    await persist(fresh);
+    return fresh;
+  };
+
+  /**
+   * Memoised on the promise rather than on the result, so two repository calls racing on first
+   * paint read storage once. Reading it twice would seed twice and lose whichever write lost.
+   */
+  const load = async (): Promise<MockState> => {
+    if (state !== null) return state;
+    loading ??= readState();
+    state = await loading;
+    return state;
+  };
+
+  const commit = async (current: MockState, patch: Partial<MockTables>): Promise<void> => {
+    current.tables = { ...current.tables, ...patch };
+    await persist(current);
+  };
+
+  /**
+   * Ids for rows the demo creates. The counter is persisted with the tables, so a reload does not
+   * hand out an id a previous session already used — and the `m` marks a row as one a person made
+   * rather than one the fixtures shipped, which is what makes a demo dataset readable afterwards.
+   */
+  const mint = (current: MockState, prefix: string): string => {
+    current.nextId += 1;
+    return `${prefix}_m${current.nextId.toString().padStart(5, '0')}`;
+  };
+
+  /** The delay is paid before the access check, because a real request fails slowly too. */
+  const scope = async (
+    tenantId: TenantId,
+    action: string,
+  ): Promise<{ readonly current: MockState; readonly membership: MembershipRow }> => {
+    const current = await load();
+    await delay();
+    const membership = requireMembership(current.tables.memberships, tenantId, me, action);
+    return { current, membership };
+  };
+
+  /*
+   * Annotated on the binding rather than only on the arrow: TypeScript narrows control flow past
+   * a never-returning call only when the callee is a name with an explicit type annotation. Drop
+   * the annotation and every `if (x === undefined) invalid(…)` below stops narrowing `x`.
+   */
+  const invalid: (issues: readonly ValidationIssue[]) => never = (issues) => {
+    throw new ValidationError(issues);
+  };
+
+  const requireText = (value: string, path: string, maxLength: number): string => {
+    const text = trimmed(value);
+    if (text.length === 0) invalid([{ path, message: 'Must not be empty' }]);
+    if (text.length > maxLength) {
+      invalid([{ path, message: `Must be at most ${String(maxLength)} characters` }]);
+    }
+    return text;
+  };
+
+  const inTenant = <TRow extends { readonly tenant_id: TenantId }>(
+    rows: readonly TRow[],
+    tenantId: TenantId,
+  ): readonly TRow[] => rows.filter((row) => row.tenant_id === tenantId);
+
+  const found = <TRow>(row: TRow | undefined, entity: string, id: string): TRow => {
+    if (row === undefined) throw new NotFoundError({ entity, id });
+    return row;
+  };
+
+  const mapPage = <TRow, TItem>(page: Page<TRow>, map: (row: TRow) => TItem): Page<TItem> => ({
+    items: page.items.map(map),
+    nextCursor: page.nextCursor,
+  });
+
+  const replace = <TRow>(
+    rows: readonly TRow[],
+    match: (row: TRow) => boolean,
+    next: TRow,
+  ): readonly TRow[] => rows.map((row) => (match(row) ? next : row));
+
+  /* -------------------------------------------------------------------------------------------
+   * Personas — resolved lazily, because a device that has never posted still has to have a mask
+   * before the composer can show it.
+   * ----------------------------------------------------------------------------------------- */
+
+  const currentPersona = async (current: MockState, tenantId: TenantId): Promise<PersonaRow> => {
+    const hash = deviceHashFor(current.deviceId, tenantId);
+    const existing = current.tables.personas.find(
+      (row) => row.tenant_id === tenantId && row.device_hash === hash && row.retired_at === null,
+    );
+    if (existing !== undefined) return existing;
+
+    const persona: PersonaRow = {
+      id: toPersonaId(mint(current, 'pa')),
+      tenant_id: tenantId,
+      label: createPersonaLabel(random),
+      avatar_key: createAvatarKey(random),
+      device_hash: hash,
+      retired_at: null,
+      created_at: nowIso(),
+    };
+    await commit(current, { personas: [...current.tables.personas, persona] });
+    return persona;
+  };
+
+  /* -------------------------------------------------------------------------------------------
+   * Visibility helpers. Each returns the rows a caller with this membership may see, which is
+   * always a subset of what they asked for and never an error.
+   * ----------------------------------------------------------------------------------------- */
+
+  const visibleModeration = (
+    membership: MembershipRow,
+    asked: readonly ModerationStatus[],
+  ): readonly ModerationStatus[] =>
+    hasRole(membership, MODERATOR_ROLES) ? asked : asked.filter((status) => status === 'approved');
+
+  const seesEveryTask = (membership: MembershipRow): boolean => hasRole(membership, CREW_ROLES);
+
+  const taskVisible = (row: TaskRow, membership: MembershipRow): boolean =>
+    seesEveryTask(membership) || row.visibility === 'public' || row.assignee_user_id === me;
+
+  /* -------------------------------------------------------------------------------------------
+   * Repositories
+   * ----------------------------------------------------------------------------------------- */
+
+  const tenantById = (current: MockState, tenantId: TenantId): TenantRow =>
+    found(
+      current.tables.tenants.find((row) => row.id === tenantId),
+      'tenant',
+      tenantId,
+    );
+
+  const directory: DataAdapter['directory'] = {
+    bySlug: async (slug: string): Promise<Tenant> => {
+      const current = await load();
+      await delay();
+      const tenant = current.tables.tenants.find((row) => row.slug === slug);
+      /*
+       * A private event is invisible to anyone outside it, and invisible means "no such slug"
+       * rather than "forbidden" — telling an outsider the row exists is the leak. A member
+       * resolves it normally, which is what the eventual policy says and what lets an admin open
+       * their own unlisted event.
+       */
+      if (
+        tenant === undefined ||
+        (tenant.visibility === 'private' &&
+          findActiveMembership(current.tables.memberships, tenant.id, me) === null)
+      ) {
+        throw new NotFoundError({ entity: 'tenant', id: slug });
+      }
+      return toTenant(tenant);
+    },
+
+    listForUser: async (userId: UserId, page?: PageRequest): Promise<Page<Tenant>> => {
+      const current = await load();
+      await delay();
+      /*
+       * Cross-tenant by definition, so there is no tenant to check membership in — but "which
+       * events am I in" must not become "which events is anyone in". A policy would filter to
+       * `auth.uid()`, so this returns nothing for anybody else rather than throwing.
+       */
+      const mine =
+        userId === me
+          ? current.tables.memberships.filter(
+              (row) => row.user_id === userId && row.status === 'active',
+            )
+          : [];
+      const ids = new Set(mine.map((row) => row.tenant_id));
+      return mapPage(
+        paginate({
+          items: current.tables.tenants.filter((row) => ids.has(row.id)),
+          sortKey: (row) => `${row.starts_on ?? '9999-12-31'}|${row.name}`,
+          id: (row) => row.id,
+          order: 'asc',
+          page,
+        }),
+        toTenant,
+      );
+    },
+  };
+
+  const configRow = (current: MockState, tenantId: TenantId): TenantConfigRow =>
+    found(
+      current.tables.tenantConfigs.find((row) => row.tenant_id === tenantId),
+      'tenant_config',
+      tenantId,
+    );
+
+  const tenants: DataAdapter['tenants'] = {
+    byId: async (tenantId: TenantId): Promise<Tenant> => {
+      const { current } = await scope(tenantId, 'tenants.byId');
+      return toTenant(tenantById(current, tenantId));
+    },
+
+    config: async (tenantId: TenantId) => {
+      const { current } = await scope(tenantId, 'tenants.config');
+      return toTenantConfigRecord(configRow(current, tenantId));
+    },
+
+    saveDraftConfig: async (tenantId: TenantId, draft: TenantConfig) => {
+      const { current, membership } = await scope(tenantId, 'tenants.saveDraftConfig');
+      requireRole(membership, ADMIN_ROLES, tenantId, 'tenants.saveDraftConfig');
+      /*
+       * No version check: `TenantConfig.version` is the literal `1`, so a document with any other
+       * version cannot be constructed to pass in. When version 2 arrives it becomes a union and a
+       * migration belongs here — `@typescript-eslint/no-unnecessary-condition` will point at this
+       * comment the moment the check stops being dead code.
+       */
+      const row = configRow(current, tenantId);
+      const next: TenantConfigRow = { ...row, draft_config: draft, updated_at: nowIso() };
+      await commit(current, {
+        tenantConfigs: replace(
+          current.tables.tenantConfigs,
+          (candidate) => candidate.tenant_id === tenantId,
+          next,
+        ),
+      });
+      return toTenantConfigRecord(next);
+    },
+
+    publishConfig: async (tenantId: TenantId, publishedBy: UserId) => {
+      const { current, membership } = await scope(tenantId, 'tenants.publishConfig');
+      requireRole(membership, ADMIN_ROLES, tenantId, 'tenants.publishConfig');
+      const row = configRow(current, tenantId);
+      const next: TenantConfigRow = {
+        ...row,
+        /* Cloned: draft and published must not end up sharing one object that later edits mutate. */
+        published_config: clone(row.draft_config),
+        published_at: nowIso(),
+        published_by: publishedBy,
+        updated_at: nowIso(),
+      };
+      await commit(current, {
+        tenantConfigs: replace(
+          current.tables.tenantConfigs,
+          (candidate) => candidate.tenant_id === tenantId,
+          next,
+        ),
+      });
+      return toTenantConfigRecord(next);
+    },
+  };
+
+  const memberUserIds = (current: MockState, tenantId: TenantId): ReadonlySet<UserId> =>
+    new Set(
+      current.tables.memberships
+        .filter((row) => row.tenant_id === tenantId && row.user_id !== null)
+        .flatMap((row) => (row.user_id === null ? [] : [row.user_id])),
+    );
+
+  const users: DataAdapter['users'] = {
+    byId: async (tenantId: TenantId, userId: UserId) => {
+      const { current } = await scope(tenantId, 'users.byId');
+      /*
+       * You may read a person because you share an event with them. A user with no membership
+       * here is not "forbidden", they are simply not in this event's directory — which is the
+       * same answer the policy gives, and keeps the guest list from becoming a platform-wide one.
+       */
+      if (!memberUserIds(current, tenantId).has(userId)) {
+        throw new NotFoundError({ entity: 'user', id: userId });
+      }
+      return toUser(
+        found(
+          current.tables.users.find((row) => row.id === userId),
+          'user',
+          userId,
+        ),
+      );
+    },
+
+    list: async (tenantId: TenantId, page?: PageRequest) => {
+      const { current } = await scope(tenantId, 'users.list');
+      const ids = memberUserIds(current, tenantId);
+      return mapPage(
+        paginate({
+          items: current.tables.users.filter((row: UserRow) => ids.has(row.id)),
+          sortKey: (row) => row.display_name.toLowerCase(),
+          id: (row) => row.id,
+          order: 'asc',
+          page,
+        }),
+        toUser,
+      );
+    },
+  };
+
+  const membershipById = (
+    current: MockState,
+    tenantId: TenantId,
+    id: MembershipId,
+  ): MembershipRow =>
+    found(
+      current.tables.memberships.find((row) => row.id === id && row.tenant_id === tenantId),
+      'membership',
+      id,
+    );
+
+  const saveMembership = (current: MockState, next: MembershipRow): Promise<void> =>
+    commit(current, {
+      memberships: replace(current.tables.memberships, (row) => row.id === next.id, next),
+    });
+
+  const memberships: DataAdapter['memberships'] = {
+    list: async (
+      tenantId: TenantId,
+      query: MembershipQuery,
+      page?: PageRequest,
+    ): Promise<Page<Membership>> => {
+      const { current } = await scope(tenantId, 'memberships.list');
+      return mapPage(
+        paginate({
+          items: inTenant(current.tables.memberships, tenantId).filter(
+            (row) => query.roles.includes(row.role) && query.statuses.includes(row.status),
+          ),
+          sortKey: (row) => timestampKey(row.created_at, 'membership.created_at'),
+          id: (row) => row.id,
+          order: 'asc',
+          page,
+        }),
+        toMembership,
+      );
+    },
+
+    /**
+     * Deliberately outside `scope()`. "Am I in this event?" is the question the join screen asks
+     * *before* it knows, and answering it with `ForbiddenError` would make the one method that
+     * exists to detect non-membership fail for every non-member.
+     */
+    findForUser: async (tenantId: TenantId, userId: UserId): Promise<Membership | null> => {
+      const current = await load();
+      await delay();
+      if (userId !== me) {
+        requireMembership(current.tables.memberships, tenantId, me, 'memberships.findForUser');
+      }
+      const row = current.tables.memberships.find(
+        (candidate) => candidate.tenant_id === tenantId && candidate.user_id === userId,
+      );
+      return row === undefined ? null : toMembership(row);
+    },
+
+    invite: async (tenantId: TenantId, invite: MembershipInvite): Promise<Membership> => {
+      const { current, membership } = await scope(tenantId, 'memberships.invite');
+      requireRole(membership, ADMIN_ROLES, tenantId, 'memberships.invite');
+      const email = invite.email === null ? null : trimmed(invite.email);
+      const phone = invite.phone === null ? null : trimmed(invite.phone);
+      if ((email === null || email === '') && (phone === null || phone === '')) {
+        invalid([
+          { path: 'invite.email', message: 'An invite needs an email or a phone number' },
+          { path: 'invite.phone', message: 'An invite needs an email or a phone number' },
+        ]);
+      }
+      const at = nowIso();
+      const row: MembershipRow = {
+        id: toMembershipId(mint(current, 'mb')),
+        tenant_id: tenantId,
+        user_id: null,
+        invited_email: email === '' ? null : email,
+        invited_phone: phone === '' ? null : phone,
+        role: invite.role,
+        status: 'invited',
+        invited_by: me,
+        invited_at: at,
+        accepted_at: null,
+        created_at: at,
+        updated_at: at,
+      };
+      await commit(current, { memberships: [...current.tables.memberships, row] });
+      return toMembership(row);
+    },
+
+    setRole: async (tenantId: TenantId, id: MembershipId, role): Promise<Membership> => {
+      const { current, membership } = await scope(tenantId, 'memberships.setRole');
+      requireRole(membership, ADMIN_ROLES, tenantId, 'memberships.setRole');
+      const next: MembershipRow = {
+        ...membershipById(current, tenantId, id),
+        role,
+        updated_at: nowIso(),
+      };
+      await saveMembership(current, next);
+      return toMembership(next);
+    },
+
+    revoke: async (tenantId: TenantId, id: MembershipId): Promise<Membership> => {
+      const { current, membership } = await scope(tenantId, 'memberships.revoke');
+      requireRole(membership, ADMIN_ROLES, tenantId, 'memberships.revoke');
+      const next: MembershipRow = {
+        ...membershipById(current, tenantId, id),
+        status: 'revoked',
+        updated_at: nowIso(),
+      };
+      await saveMembership(current, next);
+      return toMembership(next);
+    },
+  };
+
+  const approvals: DataAdapter['approvals'] = {
+    list: async (tenantId: TenantId, page?: PageRequest) => {
+      const { current, membership } = await scope(tenantId, 'approvals.list');
+      requireRole(membership, ADMIN_ROLES, tenantId, 'approvals.list');
+      return mapPage(
+        paginate({
+          items: inTenant(current.tables.approvalRequests, tenantId),
+          sortKey: (row) => timestampKey(row.requested_at, 'approvalRequest.requested_at'),
+          id: (row) => row.id,
+          order: 'desc',
+          page,
+        }),
+        toApprovalRequest,
+      );
+    },
+
+    submit: async (tenantId: TenantId, note: string | null) => {
+      const { current, membership } = await scope(tenantId, 'approvals.submit');
+      requireRole(membership, ADMIN_ROLES, tenantId, 'approvals.submit');
+      const at = nowIso();
+      const row: ApprovalRequestRow = {
+        id: approvalRequestId(mint(current, 'ar')),
+        tenant_id: tenantId,
+        status: 'pending',
+        requested_by: me,
+        requested_at: at,
+        reviewed_by: null,
+        reviewed_at: null,
+        note: note === null ? null : trimmed(note),
+        created_at: at,
+      };
+      await commit(current, { approvalRequests: [...current.tables.approvalRequests, row] });
+      return toApprovalRequest(row);
+    },
+
+    decide: async (
+      tenantId: TenantId,
+      requestId: ApprovalRequestId,
+      decision: ApprovalDecision,
+    ) => {
+      const { current, membership } = await scope(tenantId, 'approvals.decide');
+      requireRole(membership, ADMIN_ROLES, tenantId, 'approvals.decide');
+      const row = found(
+        current.tables.approvalRequests.find(
+          (candidate) => candidate.id === requestId && candidate.tenant_id === tenantId,
+        ),
+        'approval_request',
+        requestId,
+      );
+      if (row.status !== 'pending') {
+        invalid([{ path: 'requestId', message: `Request was already ${row.status}` }]);
+      }
+      const next: ApprovalRequestRow = {
+        ...row,
+        status: decision.status,
+        reviewed_by: me,
+        reviewed_at: nowIso(),
+        note: decision.note === null ? null : trimmed(decision.note),
+      };
+      await commit(current, {
+        approvalRequests: replace(
+          current.tables.approvalRequests,
+          (candidate) => candidate.id === requestId,
+          next,
+        ),
+      });
+      return toApprovalRequest(next);
+    },
+  };
+
+  const venues: DataAdapter['venues'] = {
+    list: async (tenantId: TenantId, page?: PageRequest): Promise<Page<Venue>> => {
+      const { current } = await scope(tenantId, 'venues.list');
+      return mapPage(
+        paginate({
+          items: inTenant(current.tables.venues, tenantId),
+          sortKey: (row: VenueRow) => numericKey(row.sort_order, 'venue.sort_order'),
+          id: (row) => row.id,
+          order: 'asc',
+          page,
+        }),
+        toVenue,
+      );
+    },
+
+    byId: async (tenantId: TenantId, venueId: VenueId): Promise<Venue> => {
+      const { current } = await scope(tenantId, 'venues.byId');
+      return toVenue(
+        found(
+          current.tables.venues.find((row) => row.id === venueId && row.tenant_id === tenantId),
+          'venue',
+          venueId,
+        ),
+      );
+    },
+  };
+
+  /** Published sessions are all a non-crew member ever sees, whatever `statuses` asked for. */
+  const sessionsVisibleTo = (
+    current: MockState,
+    tenantId: TenantId,
+    membership: MembershipRow,
+  ): readonly SessionRow[] =>
+    inTenant(current.tables.sessions, tenantId).filter(
+      (row) => hasRole(membership, CREW_ROLES) || row.status === 'published',
+    );
+
+  const sessions: DataAdapter['sessions'] = {
+    list: async (
+      tenantId: TenantId,
+      query: SessionQuery,
+      page?: PageRequest,
+    ): Promise<Page<Session>> => {
+      const { current, membership } = await scope(tenantId, 'sessions.list');
+      return mapPage(
+        paginate({
+          items: sessionsVisibleTo(current, tenantId, membership).filter(
+            (row) =>
+              query.statuses.includes(row.status) &&
+              (query.track === null || row.track === query.track),
+          ),
+          sortKey: (row) =>
+            `${timestampKey(row.starts_at, 'session.starts_at')}|${numericKey(row.sort_order, 'session.sort_order')}`,
+          id: (row) => row.id,
+          order: 'asc',
+          page,
+        }),
+        toSession,
+      );
+    },
+
+    byId: async (tenantId: TenantId, id: SessionId): Promise<Session> => {
+      const { current, membership } = await scope(tenantId, 'sessions.byId');
+      return toSession(
+        found(
+          sessionsVisibleTo(current, tenantId, membership).find((row) => row.id === id),
+          'session',
+          id,
+        ),
+      );
+    },
+
+    peopleFor: async (tenantId: TenantId, id: SessionId, page?: PageRequest) => {
+      const { current, membership } = await scope(tenantId, 'sessions.peopleFor');
+      found(
+        sessionsVisibleTo(current, tenantId, membership).find((row) => row.id === id),
+        'session',
+        id,
+      );
+      return mapPage(
+        paginate({
+          items: current.tables.sessionPeople.filter(
+            (row) => row.tenant_id === tenantId && row.session_id === id,
+          ),
+          sortKey: (row) => numericKey(row.sort_order, 'sessionPerson.sort_order'),
+          id: (row) => row.person_id,
+          order: 'asc',
+          page,
+        }),
+        toSessionPerson,
+      );
+    },
+  };
+
+  const people: DataAdapter['people'] = {
+    list: async (tenantId: TenantId, page?: PageRequest): Promise<Page<Person>> => {
+      const { current } = await scope(tenantId, 'people.list');
+      return mapPage(
+        paginate({
+          items: inTenant(current.tables.people, tenantId),
+          sortKey: (row: PersonRow) => numericKey(row.sort_order, 'person.sort_order'),
+          id: (row) => row.id,
+          order: 'asc',
+          page,
+        }),
+        toPerson,
+      );
+    },
+
+    byId: async (tenantId: TenantId, personId: PersonId): Promise<Person> => {
+      const { current } = await scope(tenantId, 'people.byId');
+      return toPerson(
+        found(
+          current.tables.people.find((row) => row.id === personId && row.tenant_id === tenantId),
+          'person',
+          personId,
+        ),
+      );
+    },
+  };
+
+  const media: DataAdapter['media'] = {
+    list: async (
+      tenantId: TenantId,
+      query: MediaQuery,
+      page?: PageRequest,
+    ): Promise<Page<MediaAsset>> => {
+      const { current, membership } = await scope(tenantId, 'media.list');
+      const statuses = visibleModeration(membership, query.statuses);
+      return mapPage(
+        paginate({
+          items: inTenant(current.tables.mediaAssets, tenantId).filter((row: MediaAssetRow) =>
+            statuses.includes(row.status),
+          ),
+          sortKey: (row) => timestampKey(row.created_at, 'mediaAsset.created_at'),
+          id: (row) => row.id,
+          order: 'desc',
+          page,
+        }),
+        toMediaAsset,
+      );
+    },
+
+    byId: async (tenantId: TenantId, id: MediaId): Promise<MediaAsset> => {
+      const { current, membership } = await scope(tenantId, 'media.byId');
+      const row = current.tables.mediaAssets.find(
+        (candidate) => candidate.id === id && candidate.tenant_id === tenantId,
+      );
+      const visible =
+        row !== undefined && (hasRole(membership, MODERATOR_ROLES) || row.status === 'approved');
+      return toMediaAsset(found(visible ? row : undefined, 'media_asset', id));
+    },
+  };
+
+  const personas: DataAdapter['personas'] = {
+    current: async (tenantId: TenantId): Promise<Persona> => {
+      const { current } = await scope(tenantId, 'personas.current');
+      return toPersona(await currentPersona(current, tenantId));
+    },
+
+    /**
+     * A new mask is a new row (`rows.ts`): the old persona is retired and its posts keep pointing
+     * at it. Editing the label in place would rewrite the author of everything already posted.
+     */
+    reset: async (tenantId: TenantId): Promise<Persona> => {
+      const { current } = await scope(tenantId, 'personas.reset');
+      const previous = await currentPersona(current, tenantId);
+      const retired: PersonaRow = { ...previous, retired_at: nowIso() };
+      const next: PersonaRow = {
+        id: toPersonaId(mint(current, 'pa')),
+        tenant_id: tenantId,
+        label: createPersonaLabel(random),
+        avatar_key: createAvatarKey(random),
+        device_hash: previous.device_hash,
+        retired_at: null,
+        created_at: nowIso(),
+      };
+      await commit(current, {
+        personas: [
+          ...replace(current.tables.personas, (row) => row.id === previous.id, retired),
+          next,
+        ],
+      });
+      return toPersona(next);
+    },
+
+    byId: async (tenantId: TenantId, id: PersonaId): Promise<Persona> => {
+      const { current } = await scope(tenantId, 'personas.byId');
+      return toPersona(
+        found(
+          current.tables.personas.find((row) => row.id === id && row.tenant_id === tenantId),
+          'persona',
+          id,
+        ),
+      );
+    },
+  };
+
+  /**
+   * Registered listeners. `subscribe()` below hands them out and takes them back; delivering to
+   * them is #36, which owns the emitter and the tests that prove an unsubscribe leaks nothing.
+   */
+  const gossipListeners = new Set<(change: GossipChange) => void>();
+
+  const gossip: DataAdapter['gossip'] = {
+    list: async (
+      tenantId: TenantId,
+      query: GossipQuery,
+      page?: PageRequest,
+    ): Promise<Page<GossipPost>> => {
+      const { current, membership } = await scope(tenantId, 'gossip.list');
+      const statuses = visibleModeration(membership, query.statuses);
+      return mapPage(
+        paginate({
+          items: inTenant(current.tables.gossipPosts, tenantId).filter((row: GossipPostRow) =>
+            statuses.includes(row.status),
+          ),
+          sortKey: (row) => timestampKey(row.created_at, 'gossipPost.created_at'),
+          id: (row) => row.id,
+          order: 'desc',
+          page,
+        }),
+        toGossipPost,
+      );
+    },
+
+    byId: async (tenantId: TenantId, id: GossipPostId): Promise<GossipPost> => {
+      const { current, membership } = await scope(tenantId, 'gossip.byId');
+      const row = current.tables.gossipPosts.find(
+        (candidate) => candidate.id === id && candidate.tenant_id === tenantId,
+      );
+      const visible =
+        row !== undefined && (hasRole(membership, MODERATOR_ROLES) || row.status === 'approved');
+      return toGossipPost(found(visible ? row : undefined, 'gossip_post', id));
+    },
+
+    /**
+     * `status` is forced to `pending` and is not a parameter (D3). The eventual `BEFORE INSERT`
+     * trigger does the same thing for the same reason: a client that can choose its own
+     * moderation status is a client that can skip moderation.
+     */
+    create: async (tenantId: TenantId, post: NewGossipPost): Promise<GossipPost> => {
+      const { current } = await scope(tenantId, 'gossip.create');
+      const body = requireText(post.body, 'post.body', MAX_GOSSIP_BODY_LENGTH);
+      if (post.mediaId !== null) {
+        const attachment = current.tables.mediaAssets.find(
+          (row) => row.id === post.mediaId && row.tenant_id === tenantId,
+        );
+        if (attachment === undefined) {
+          invalid([{ path: 'post.mediaId', message: 'No such media in this event' }]);
+        }
+      }
+      const persona = await currentPersona(current, tenantId);
+      const row: GossipPostRow = {
+        id: toGossipPostId(mint(current, 'gp')),
+        tenant_id: tenantId,
+        body,
+        media_id: post.mediaId,
+        persona_id: persona.id,
+        author_device_hash: persona.device_hash,
+        status: 'pending',
+        moderated_by: null,
+        moderated_at: null,
+        rejection_reason: null,
+        reaction_counts: {},
+        report_count: 0,
+        created_at: nowIso(),
+      };
+      await commit(current, { gossipPosts: [...current.tables.gossipPosts, row] });
+      return toGossipPost(row);
+    },
+
+    moderate: async (
+      tenantId: TenantId,
+      id: GossipPostId,
+      decision: GossipModeration,
+    ): Promise<GossipPost> => {
+      const { current, membership } = await scope(tenantId, 'gossip.moderate');
+      requireRole(membership, MODERATOR_ROLES, tenantId, 'gossip.moderate');
+      const row = found(
+        current.tables.gossipPosts.find(
+          (candidate) => candidate.id === id && candidate.tenant_id === tenantId,
+        ),
+        'gossip_post',
+        id,
+      );
+      const reason =
+        decision.status === 'approved'
+          ? null
+          : requireText(decision.reason, 'decision.reason', 280);
+      const next: GossipPostRow = {
+        ...row,
+        status: decision.status,
+        moderated_by: me,
+        moderated_at: nowIso(),
+        rejection_reason: reason,
+      };
+      await commit(current, {
+        gossipPosts: replace(current.tables.gossipPosts, (candidate) => candidate.id === id, next),
+      });
+      return toGossipPost(next);
+    },
+
+    /**
+     * Returns nothing, so the reporter never learns the post's `reportCount` and "report this"
+     * cannot become a scoreboard. D31's threshold hides an approved post pending review.
+     */
+    report: async (tenantId: TenantId, id: GossipPostId): Promise<void> => {
+      const { current } = await scope(tenantId, 'gossip.report');
+      const row = found(
+        current.tables.gossipPosts.find(
+          (candidate) => candidate.id === id && candidate.tenant_id === tenantId,
+        ),
+        'gossip_post',
+        id,
+      );
+      const reportCount = row.report_count + 1;
+      const next: GossipPostRow = {
+        ...row,
+        report_count: reportCount,
+        status:
+          row.status === 'approved' && reportCount >= REPORT_HIDE_THRESHOLD ? 'hidden' : row.status,
+      };
+      await commit(current, {
+        gossipPosts: replace(current.tables.gossipPosts, (candidate) => candidate.id === id, next),
+      });
+    },
+
+    /**
+     * Registers a listener and hands back an unsubscribe that is safe to call twice — which React
+     * effects do. **Nothing is delivered yet:** the emitter is #36, and building it here would
+     * put two issues in one PR (D35). What this does provide is the handshake the signature
+     * promises — the promise resolves once the subscription exists, so "connected and quiet" is
+     * already distinguishable from "never connected".
+     */
+    subscribe: async (
+      tenantId: TenantId,
+      _query: GossipQuery,
+      listener: (change: GossipChange) => void,
+    ): Promise<Unsubscribe> => {
+      await scope(tenantId, 'gossip.subscribe');
+      gossipListeners.add(listener);
+      let closed = false;
+      return () => {
+        if (closed) return;
+        closed = true;
+        gossipListeners.delete(listener);
+      };
+    },
+  };
+
+  const tasks: DataAdapter['tasks'] = {
+    list: async (tenantId: TenantId, query: TaskQuery, page?: PageRequest) => {
+      const { current, membership } = await scope(tenantId, 'tasks.list');
+      return mapPage(
+        paginate({
+          items: inTenant(current.tables.tasks, tenantId).filter(
+            (row) =>
+              taskVisible(row, membership) &&
+              query.statuses.includes(row.status) &&
+              query.visibilities.includes(row.visibility) &&
+              (query.assigneeUserId === null || row.assignee_user_id === query.assigneeUserId),
+          ),
+          sortKey: (row) => numericKey(row.sort_order, 'task.sort_order'),
+          id: (row) => row.id,
+          order: 'asc',
+          page,
+        }),
+        toTask,
+      );
+    },
+
+    byId: async (tenantId: TenantId, id: TaskId) => {
+      const { current, membership } = await scope(tenantId, 'tasks.byId');
+      const row = current.tables.tasks.find(
+        (candidate) => candidate.id === id && candidate.tenant_id === tenantId,
+      );
+      return toTask(
+        found(row !== undefined && taskVisible(row, membership) ? row : undefined, 'task', id),
+      );
+    },
+
+    create: async (tenantId: TenantId, task: NewTask) => {
+      const { current, membership } = await scope(tenantId, 'tasks.create');
+      requireRole(membership, CREW_ROLES, tenantId, 'tasks.create');
+      const title = requireText(task.title, 'task.title', 200);
+      if (
+        task.sessionId !== null &&
+        !current.tables.sessions.some(
+          (row) => row.id === task.sessionId && row.tenant_id === tenantId,
+        )
+      ) {
+        invalid([{ path: 'task.sessionId', message: 'No such session in this event' }]);
+      }
+      if (task.dueAt !== null && Number.isNaN(Date.parse(task.dueAt))) {
+        invalid([{ path: 'task.dueAt', message: 'Not an ISO 8601 timestamp' }]);
+      }
+      if (
+        task.remindBeforeMinutes !== null &&
+        (!Number.isInteger(task.remindBeforeMinutes) || task.remindBeforeMinutes < 0)
+      ) {
+        invalid([{ path: 'task.remindBeforeMinutes', message: 'Expected an integer >= 0' }]);
+      }
+      const at = nowIso();
+      const row: TaskRow = {
+        id: toTaskId(mint(current, 'tk')),
+        tenant_id: tenantId,
+        title,
+        notes: task.notes === null ? null : trimmed(task.notes),
+        assignee_user_id: task.assigneeUserId,
+        created_by: me,
+        session_id: task.sessionId,
+        due_at: task.dueAt,
+        remind_before_minutes: task.remindBeforeMinutes,
+        status: 'todo',
+        visibility: task.visibility,
+        priority: task.priority,
+        /* New tasks land at the end of the board rather than silently on top of somebody's day. */
+        sort_order:
+          inTenant(current.tables.tasks, tenantId).reduce(
+            (highest, candidate) => Math.max(highest, candidate.sort_order),
+            0,
+          ) + 1,
+        created_at: at,
+        updated_at: at,
+      };
+      await commit(current, { tasks: [...current.tables.tasks, row] });
+      return toTask(row);
+    },
+
+    /** The assignee may move their own task; everyone else needs a crew role. */
+    setStatus: async (tenantId: TenantId, id: TaskId, status: TaskStatus) => {
+      const { current, membership } = await scope(tenantId, 'tasks.setStatus');
+      const row = found(
+        current.tables.tasks.find(
+          (candidate) => candidate.id === id && candidate.tenant_id === tenantId,
+        ),
+        'task',
+        id,
+      );
+      if (row.assignee_user_id !== me) {
+        requireRole(membership, CREW_ROLES, tenantId, 'tasks.setStatus');
+      }
+      const next: TaskRow = { ...row, status, updated_at: nowIso() };
+      await commit(current, {
+        tasks: replace(current.tables.tasks, (candidate) => candidate.id === id, next),
+      });
+      return toTask(next);
+    },
+  };
+
+  const units: DataAdapter['units'] = {
+    list: async (tenantId: TenantId, query: UnitQuery, page?: PageRequest): Promise<Page<Unit>> => {
+      const { current } = await scope(tenantId, 'units.list');
+      return mapPage(
+        paginate({
+          items: inTenant(current.tables.units, tenantId).filter((row: UnitRow) =>
+            query.kinds.includes(row.kind),
+          ),
+          sortKey: (row) => `${row.kind}|${numericKey(row.sort_order, 'unit.sort_order')}`,
+          id: (row) => row.id,
+          order: 'asc',
+          page,
+        }),
+        toUnit,
+      );
+    },
+
+    byId: async (tenantId: TenantId, id: UnitId): Promise<Unit> => {
+      const { current } = await scope(tenantId, 'units.byId');
+      return toUnit(
+        found(
+          current.tables.units.find((row) => row.id === id && row.tenant_id === tenantId),
+          'unit',
+          id,
+        ),
+      );
+    },
+  };
+
+  const assignments: DataAdapter['assignments'] = {
+    /** Where a guest sleeps is not public. Only the crew sees anyone's placement but their own. */
+    list: async (
+      tenantId: TenantId,
+      query: AssignmentQuery,
+      page?: PageRequest,
+    ): Promise<Page<Assignment>> => {
+      const { current, membership } = await scope(tenantId, 'assignments.list');
+      const everyone = hasRole(membership, CREW_ROLES);
+      return mapPage(
+        paginate({
+          items: inTenant(current.tables.assignments, tenantId).filter(
+            (row: AssignmentRow) =>
+              (everyone || row.user_id === me) &&
+              (query.unitId === null || row.unit_id === query.unitId) &&
+              (query.userId === null || row.user_id === query.userId),
+          ),
+          sortKey: (row) => timestampKey(row.created_at, 'assignment.created_at'),
+          id: (row) => row.id,
+          order: 'asc',
+          page,
+        }),
+        toAssignment,
+      );
+    },
+
+    assign: async (tenantId: TenantId, assignment: NewAssignment): Promise<Assignment> => {
+      const { current, membership } = await scope(tenantId, 'assignments.assign');
+      requireRole(membership, CREW_ROLES, tenantId, 'assignments.assign');
+      const unit = current.tables.units.find(
+        (row) => row.id === assignment.unitId && row.tenant_id === tenantId,
+      );
+      if (unit === undefined) {
+        invalid([{ path: 'assignment.unitId', message: 'No such unit in this event' }]);
+      }
+      if (findActiveMembership(current.tables.memberships, tenantId, assignment.userId) === null) {
+        invalid([{ path: 'assignment.userId', message: 'That person is not in this event' }]);
+      }
+      const occupants = current.tables.assignments.filter(
+        (row) => row.tenant_id === tenantId && row.unit_id === assignment.unitId,
+      );
+      if (occupants.some((row) => row.user_id === assignment.userId)) {
+        invalid([{ path: 'assignment.userId', message: 'Already assigned to this unit' }]);
+      }
+      /* Null capacity is uncapped; zero would mean nobody fits, which is a different statement. */
+      if (unit.capacity !== null && occupants.length >= unit.capacity) {
+        invalid([
+          {
+            path: 'assignment.unitId',
+            message: `${unit.label} is full (${String(unit.capacity)})`,
+          },
+        ]);
+      }
+      const row: AssignmentRow = {
+        id: toAssignmentId(mint(current, 'as')),
+        tenant_id: tenantId,
+        unit_id: assignment.unitId,
+        user_id: assignment.userId,
+        note: assignment.note === null ? null : trimmed(assignment.note),
+        assigned_by: me,
+        created_at: nowIso(),
+      };
+      await commit(current, { assignments: [...current.tables.assignments, row] });
+      return toAssignment(row);
+    },
+
+    unassign: async (tenantId: TenantId, id: AssignmentId): Promise<void> => {
+      const { current, membership } = await scope(tenantId, 'assignments.unassign');
+      requireRole(membership, CREW_ROLES, tenantId, 'assignments.unassign');
+      found(
+        current.tables.assignments.find((row) => row.id === id && row.tenant_id === tenantId),
+        'assignment',
+        id,
+      );
+      await commit(current, {
+        assignments: current.tables.assignments.filter((row) => row.id !== id),
+      });
+    },
+  };
+
+  const announcements: DataAdapter['announcements'] = {
+    /** Drafts belong to whoever is composing them; `publishedOnly: false` only widens for them. */
+    list: async (
+      tenantId: TenantId,
+      query: AnnouncementQuery,
+      page?: PageRequest,
+    ): Promise<Page<Announcement>> => {
+      const { current, membership } = await scope(tenantId, 'announcements.list');
+      const drafts = !query.publishedOnly && hasRole(membership, MODERATOR_ROLES);
+      return mapPage(
+        paginate({
+          items: inTenant(current.tables.announcements, tenantId).filter(
+            (row: AnnouncementRow) => drafts || row.published_at !== null,
+          ),
+          /*
+           * Pinned first, then newest. A draft has no `published_at`, so it sorts by when it was
+           * created — which is where its author expects to find it.
+           */
+          sortKey: (row) =>
+            `${row.pinned ? '1' : '0'}|${timestampKey(row.published_at ?? row.created_at, 'announcement.published_at')}`,
+          id: (row) => row.id,
+          order: 'desc',
+          page,
+        }),
+        toAnnouncement,
+      );
+    },
+
+    byId: async (tenantId: TenantId, id: AnnouncementId): Promise<Announcement> => {
+      const { current, membership } = await scope(tenantId, 'announcements.byId');
+      const row = current.tables.announcements.find(
+        (candidate) => candidate.id === id && candidate.tenant_id === tenantId,
+      );
+      const visible =
+        row !== undefined && (row.published_at !== null || hasRole(membership, MODERATOR_ROLES));
+      return toAnnouncement(found(visible ? row : undefined, 'announcement', id));
+    },
+
+    create: async (tenantId: TenantId, announcement: NewAnnouncement): Promise<Announcement> => {
+      const { current, membership } = await scope(tenantId, 'announcements.create');
+      requireRole(membership, ADMIN_ROLES, tenantId, 'announcements.create');
+      const at = nowIso();
+      const row: AnnouncementRow = {
+        id: toAnnouncementId(mint(current, 'an')),
+        tenant_id: tenantId,
+        title: requireText(announcement.title, 'announcement.title', 120),
+        body: requireText(announcement.body, 'announcement.body', 2000),
+        published_at: null,
+        pinned: announcement.pinned,
+        created_by: me,
+        created_at: at,
+        updated_at: at,
+      };
+      await commit(current, { announcements: [...current.tables.announcements, row] });
+      return toAnnouncement(row);
+    },
+
+    publish: async (tenantId: TenantId, id: AnnouncementId): Promise<Announcement> => {
+      const { current, membership } = await scope(tenantId, 'announcements.publish');
+      requireRole(membership, ADMIN_ROLES, tenantId, 'announcements.publish');
+      const row = found(
+        current.tables.announcements.find(
+          (candidate) => candidate.id === id && candidate.tenant_id === tenantId,
+        ),
+        'announcement',
+        id,
+      );
+      if (row.published_at !== null) {
+        invalid([{ path: 'announcementId', message: 'Already published' }]);
+      }
+      const at = nowIso();
+      const next: AnnouncementRow = { ...row, published_at: at, updated_at: at };
+      await commit(current, {
+        announcements: replace(
+          current.tables.announcements,
+          (candidate) => candidate.id === id,
+          next,
+        ),
+      });
+      return toAnnouncement(next);
+    },
+  };
+
+  const rsvps: DataAdapter['rsvps'] = {
+    list: async (tenantId: TenantId, query: RsvpQuery, page?: PageRequest): Promise<Page<Rsvp>> => {
+      const { current, membership } = await scope(tenantId, 'rsvps.list');
+      const everyone = hasRole(membership, CREW_ROLES);
+      return mapPage(
+        paginate({
+          items: inTenant(current.tables.rsvps, tenantId).filter(
+            (row: RsvpRow) =>
+              (everyone || row.user_id === me) &&
+              query.statuses.includes(row.status) &&
+              (query.sessionId === null || row.session_id === query.sessionId),
+          ),
+          sortKey: (row) => timestampKey(row.responded_at, 'rsvp.responded_at'),
+          id: (row) => `${row.user_id}|${row.session_id}`,
+          order: 'desc',
+          page,
+        }),
+        toRsvp,
+      );
+    },
+
+    findForUser: async (tenantId: TenantId, userId: UserId, sessionId: SessionId) => {
+      const { current, membership } = await scope(tenantId, 'rsvps.findForUser');
+      if (userId !== me) requireRole(membership, CREW_ROLES, tenantId, 'rsvps.findForUser');
+      const row = current.tables.rsvps.find(
+        (candidate) =>
+          candidate.tenant_id === tenantId &&
+          candidate.user_id === userId &&
+          candidate.session_id === sessionId,
+      );
+      return row === undefined ? null : toRsvp(row);
+    },
+
+    /** An upsert: changing your mind is the normal case, not an edit of a record. */
+    set: async (tenantId: TenantId, userId: UserId, rsvp: RsvpInput): Promise<Rsvp> => {
+      const { current, membership } = await scope(tenantId, 'rsvps.set');
+      if (userId !== me) requireRole(membership, CREW_ROLES, tenantId, 'rsvps.set');
+      if (!Number.isInteger(rsvp.guestCount) || rsvp.guestCount < 0) {
+        invalid([{ path: 'rsvp.guestCount', message: 'Expected an integer >= 0' }]);
+      }
+      if (
+        !current.tables.sessions.some(
+          (row) => row.id === rsvp.sessionId && row.tenant_id === tenantId,
+        )
+      ) {
+        invalid([{ path: 'rsvp.sessionId', message: 'No such session in this event' }]);
+      }
+      const row: RsvpRow = {
+        tenant_id: tenantId,
+        user_id: userId,
+        session_id: rsvp.sessionId,
+        status: rsvp.status,
+        guest_count: rsvp.guestCount,
+        responded_at: nowIso(),
+      };
+      const isSame = (candidate: RsvpRow): boolean =>
+        candidate.tenant_id === tenantId &&
+        candidate.user_id === userId &&
+        candidate.session_id === rsvp.sessionId;
+      await commit(current, {
+        rsvps: current.tables.rsvps.some(isSame)
+          ? replace(current.tables.rsvps, isSame, row)
+          : [...current.tables.rsvps, row],
+      });
+      return toRsvp(row);
+    },
+  };
+
+  const notificationPreferences: DataAdapter['notificationPreferences'] = {
+    /**
+     * Never `null`. A user who has not opened the settings screen has the event's defaults, and
+     * modelling that as a missing row would make every caller reimplement them.
+     */
+    get: async (tenantId: TenantId, userId: UserId): Promise<NotificationPreferences> => {
+      const { current, membership } = await scope(tenantId, 'notificationPreferences.get');
+      if (userId !== me) {
+        requireRole(membership, ADMIN_ROLES, tenantId, 'notificationPreferences.get');
+      }
+      const row = current.tables.notificationPreferences.find(
+        (candidate) => candidate.tenant_id === tenantId && candidate.user_id === userId,
+      );
+      if (row !== undefined) return toNotificationPreferences(row);
+      return {
+        tenantId,
+        userId,
+        channels: ['in_app'],
+        mutedCategories: [],
+        defaultReminderMinutes: null,
+        quietHours: null,
+      };
+    },
+
+    save: async (
+      tenantId: TenantId,
+      userId: UserId,
+      preferences: NotificationPreferencesInput,
+    ): Promise<NotificationPreferences> => {
+      const { current, membership } = await scope(tenantId, 'notificationPreferences.save');
+      if (userId !== me) {
+        requireRole(membership, ADMIN_ROLES, tenantId, 'notificationPreferences.save');
+      }
+      if (
+        preferences.defaultReminderMinutes !== null &&
+        (!Number.isInteger(preferences.defaultReminderMinutes) ||
+          preferences.defaultReminderMinutes < 0)
+      ) {
+        invalid([
+          { path: 'preferences.defaultReminderMinutes', message: 'Expected an integer >= 0' },
+        ]);
+      }
+      const quiet = preferences.quietHours;
+      if (quiet !== null && (!QUIET_HOURS.test(quiet.start) || !QUIET_HOURS.test(quiet.end))) {
+        invalid([{ path: 'preferences.quietHours', message: 'Expected local HH:MM, both ends' }]);
+      }
+      const at = nowIso();
+      const existing = current.tables.notificationPreferences.find(
+        (candidate) => candidate.tenant_id === tenantId && candidate.user_id === userId,
+      );
+      const row: NotificationPreferenceRow = {
+        tenant_id: tenantId,
+        user_id: userId,
+        channels: preferences.channels,
+        muted_categories: preferences.mutedCategories,
+        default_reminder_minutes: preferences.defaultReminderMinutes,
+        quiet_hours_start: quiet === null ? null : quiet.start,
+        quiet_hours_end: quiet === null ? null : quiet.end,
+        created_at: existing?.created_at ?? at,
+        updated_at: at,
+      };
+      const isSame = (candidate: NotificationPreferenceRow): boolean =>
+        candidate.tenant_id === tenantId && candidate.user_id === userId;
+      await commit(current, {
+        notificationPreferences:
+          existing === undefined
+            ? [...current.tables.notificationPreferences, row]
+            : replace(current.tables.notificationPreferences, isSame, row),
+      });
+      return toNotificationPreferences(row);
+    },
+  };
+
+  return {
+    directory,
+    tenants,
+    users,
+    memberships,
+    approvals,
+    venues,
+    sessions,
+    people,
+    media,
+    personas,
+    gossip,
+    tasks,
+    units,
+    assignments,
+    announcements,
+    rsvps,
+    notificationPreferences,
+
+    ready: async (): Promise<void> => {
+      await load();
+    },
+
+    resetDemoData: async (): Promise<void> => {
+      /*
+       * The in-memory state is replaced before the write, so a screen that re-reads while the
+       * store is still being written sees the reset dataset rather than the wreck it replaced.
+       */
+      const fresh = freshState();
+      state = fresh;
+      loading = Promise.resolve(fresh);
+      gossipListeners.clear();
+      await persist(fresh);
+    },
+  };
+};

--- a/packages/data/src/mock/defaultStorage.ts
+++ b/packages/data/src/mock/defaultStorage.ts
@@ -1,0 +1,19 @@
+import { createMemoryStorage, type MockStorage } from './storage';
+
+/**
+ * The default store everywhere Metro does not pick `defaultStorage.web.ts`: native, Node and
+ * Jest.
+ *
+ * **Native does not persist yet, and that is a missing dependency rather than a design.**
+ * Persisting on a device means `@react-native-async-storage/async-storage`, which is a native
+ * module: adding it to this package would put a native module in the import path of every
+ * server-side and test consumer of `@occasio/data`, and the data layer deliberately has no React
+ * Native dependency at all. `createAsyncStorage()` in `storage.ts` is the binding, already
+ * written and tested; the app passes the module to `createMockAdapter({ storage })` in one line
+ * once the dependency lands. Until then the platform that matters is web (D30 — web first, and
+ * the only platform currently shipping), where `defaultStorage.web.ts` does persist.
+ *
+ * In Jest and on a server, memory is the correct answer rather than a compromise: a suite whose
+ * fixtures survived between test files would be a suite with order-dependent failures.
+ */
+export const createDefaultStorage = (): MockStorage => createMemoryStorage();

--- a/packages/data/src/mock/defaultStorage.web.ts
+++ b/packages/data/src/mock/defaultStorage.web.ts
@@ -1,0 +1,17 @@
+import { createMemoryStorage, createWebStorage, findWebStorage, type MockStorage } from './storage';
+
+/**
+ * Web: `localStorage`, falling back to memory when there is none.
+ *
+ * Metro resolves this file for the web bundle and `defaultStorage.ts` everywhere else, so the
+ * native bundle never contains a reference to `localStorage` and the web bundle never contains
+ * the native fallback. A single file branching on `Platform.OS` would ship both.
+ *
+ * The fallback is not defensive padding. `localStorage` is genuinely absent during a static web
+ * export's server render, and genuinely unavailable in a browser configured to block site data —
+ * both of which are ordinary, and neither of which should stop a demo from rendering.
+ */
+export const createDefaultStorage = (): MockStorage => {
+  const store = findWebStorage();
+  return store === null ? createMemoryStorage() : createWebStorage(store);
+};

--- a/packages/data/src/mock/identity.ts
+++ b/packages/data/src/mock/identity.ts
@@ -1,0 +1,96 @@
+import type { TenantId } from '@occasio/core';
+import type { Random } from './latency';
+
+/**
+ * The anonymous half of ADR-0006, as much of it as a mock can honestly carry.
+ *
+ * The salted device hash never appears in a repository signature: it is derived here, stored on
+ * `personas.device_hash` and `gossip_posts.author_device_hash`, and dropped by `mappers.ts` on
+ * the way out. Nothing above the data layer can render it, because nothing above the data layer
+ * is ever handed it.
+ */
+
+/**
+ * **Not a cryptographic hash, and it does not need to be.** The real one is a salted SHA-256
+ * computed server-side, where the salt is a secret the client never sees; a hash computed in a
+ * browser from a value that same browser stores is reversible by anyone with the code, whatever
+ * function it uses. FNV-1a is here to produce a stable, opaque-looking, fixed-length identifier
+ * for a fixture dataset — nothing in Phase 1 depends on it resisting anything.
+ *
+ * What it does have to get right is *shape*, and it does: the same device gets the same hash
+ * across reloads (so a persona survives), and a different device gets a different one (so a rate
+ * limit and a device block have something to key on).
+ */
+const fnv1a = (value: string): string => {
+  let hash = 2166136261;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(16).padStart(8, '0');
+};
+
+/**
+ * The device hash is derived per tenant, not once per device.
+ *
+ * Two posts by the same person on two different events must not be linkable by comparing their
+ * hashes, and they would be if the hash were only a function of the device. Mixing the tenant in
+ * is free here and is what the eventual server-side derivation will also do.
+ */
+export const deviceHashFor = (deviceId: string, tenantId: TenantId): string =>
+  `${fnv1a(`occasio:${deviceId}:${tenantId}`)}${fnv1a(`${tenantId}:${deviceId}:occasio`)}`;
+
+/** A new device identity, generated once and persisted alongside the tables. */
+export const createDeviceId = (random: Random): string =>
+  `dev_${Math.floor(random() * 0xffffffff).toString(36)}${Math.floor(random() * 0xffffffff).toString(36)}`;
+
+/*
+ * The persona vocabulary. Deliberately warm and slightly absurd: the mask has to read as a
+ * costume rather than as an account, or an anonymous board starts to feel like a pseudonymous
+ * one. Both lists are prime-ish in length so the pairings do not visibly cycle.
+ */
+const ADJECTIVES = [
+  'Golden',
+  'Velvet',
+  'Midnight',
+  'Copper',
+  'Restless',
+  'Marbled',
+  'Quiet',
+  'Cinnamon',
+  'Electric',
+  'Saffron',
+  'Wandering',
+  'Cobalt',
+  'Gilded',
+] as const;
+
+const CREATURES = [
+  'Peacock',
+  'Heron',
+  'Mongoose',
+  'Kingfisher',
+  'Otter',
+  'Falcon',
+  'Pangolin',
+  'Magpie',
+  'Ibex',
+  'Lynx',
+  'Hoopoe',
+] as const;
+
+const pick = <T>(items: readonly [T, ...T[]], random: Random): T => {
+  const index = Math.min(items.length - 1, Math.floor(random() * items.length));
+  return items[index] ?? items[0];
+};
+
+/** "Golden Peacock" — what the board renders next to a post. */
+export const createPersonaLabel = (random: Random): string =>
+  `${pick(ADJECTIVES, random)} ${pick(CREATURES, random)}`;
+
+/**
+ * The seed the generated avatar is drawn from. Separate from the label so a reset changes both,
+ * and so two people who happen to draw the same label still look different.
+ */
+export const createAvatarKey = (random: Random): string =>
+  Math.floor(random() * 0xffffffff).toString(36);

--- a/packages/data/src/mock/index.ts
+++ b/packages/data/src/mock/index.ts
@@ -1,0 +1,78 @@
+/**
+ * The mock adapter (D4) — the whole of Phase 1's backend.
+ *
+ * `createMockAdapter` returns a `DataAdapter`, so every screen above the data layer is written
+ * against the same type the Supabase adapter will produce and none of them can tell which one
+ * they were handed. That is the swap point D5 and D29 are about, and the contract suite (#38) is
+ * what will prove the two behave alike.
+ *
+ * There is deliberately no fixture data in this folder. The four events live in #35 and are
+ * passed in as `seed`, which is what keeps "the adapter" and "the demo dataset" two things: a
+ * test seeds three rows, the app seeds four full events, and neither has to know about the other.
+ */
+
+export { createMockAdapter, type MockAdapter, type MockAdapterOptions } from './adapter';
+
+export {
+  ADMIN_ROLES,
+  CREW_ROLES,
+  MODERATOR_ROLES,
+  findActiveMembership,
+  hasRole,
+  requireMembership,
+  requireRole,
+} from './access';
+
+export { createDefaultStorage } from './defaultStorage';
+
+export {
+  DEFAULT_LATENCY,
+  MOCK_LATENCY_MAX_MS,
+  MOCK_LATENCY_MIN_MS,
+  assertLatencyRange,
+  createDelay,
+  latencyFor,
+  realSleep,
+  type LatencyRange,
+  type Random,
+  type Sleep,
+} from './latency';
+
+export { approvalRequestId, parseSnapshot, serialiseSnapshot } from './mappers';
+
+export {
+  decodeCursor,
+  encodeCursor,
+  numericKey,
+  paginate,
+  resolveLimit,
+  timestampKey,
+  type Order,
+  type PageSpec,
+} from './paging';
+
+export { createSeededRandom, seedFromString } from './random';
+
+export {
+  createAsyncStorage,
+  createMemoryStorage,
+  createWebStorage,
+  findWebStorage,
+  isWebStorageLike,
+  type AsyncStorageLike,
+  type MockStorage,
+  type WebStorageLike,
+} from './storage';
+
+export {
+  EMPTY_TABLES,
+  MOCK_SNAPSHOT_VERSION,
+  MOCK_STORAGE_KEY,
+  MOCK_TABLE_NAMES,
+  type MockSeed,
+  type MockSnapshot,
+  type MockTableName,
+  type MockTables,
+} from './tables';
+
+export { createAvatarKey, createDeviceId, createPersonaLabel, deviceHashFor } from './identity';

--- a/packages/data/src/mock/latency.test.ts
+++ b/packages/data/src/mock/latency.test.ts
@@ -7,6 +7,7 @@ import {
   assertLatencyRange,
   createDelay,
   latencyFor,
+  type Sleep,
 } from './latency';
 import { createSeededRandom } from './random';
 
@@ -95,22 +96,82 @@ describe('assertLatencyRange', () => {
 });
 
 describe('createDelay', () => {
-  it('awaits the sleep it computed, rather than resolving straight through', async () => {
+  /**
+   * The sleep is held open rather than resolved immediately, which is the difference between
+   * this test and one that cannot fail: against `Promise.resolve()`, a `createDelay` that called
+   * `sleep(...)` and threw the promise away would pass every assertion below. The delay has to
+   * still be pending while the sleep is.
+   */
+  const heldSleep = (): {
+    readonly sleep: Sleep;
+    readonly slept: readonly number[];
+    readonly release: () => void;
+  } => {
     const slept: number[] = [];
+    const pending: (() => void)[] = [];
+    return {
+      slept,
+      sleep: (ms) => {
+        slept.push(ms);
+        return new Promise<void>((resolve) => {
+          pending.push(resolve);
+        });
+      },
+      release: () => {
+        const resolve = pending.shift();
+        if (resolve === undefined) throw new Error('sleep was never called');
+        resolve();
+      },
+    };
+  };
+
+  /** One turn of the event loop — long enough for a dropped promise to have settled. */
+  const settle = async (): Promise<void> => {
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
+  };
+
+  it('stays pending until the sleep it computed resolves', async () => {
+    const held = heldSleep();
     const delay = createDelay({
       range: DEFAULT_LATENCY,
       random: createSeededRandom(1),
-      sleep: (ms) => {
-        slept.push(ms);
-        return Promise.resolve();
-      },
+      sleep: held.sleep,
     });
 
-    await delay();
-    await delay();
+    let finished = false;
+    const pending = delay().then(() => {
+      finished = true;
+    });
 
-    expect(slept).toHaveLength(2);
-    for (const ms of slept) {
+    await settle();
+    expect(held.slept).toHaveLength(1);
+    /* The assertion the old version of this test could not make. */
+    expect(finished).toBe(false);
+
+    held.release();
+    await pending;
+    expect(finished).toBe(true);
+  });
+
+  it('computes a fresh delay inside the range on every call', async () => {
+    const held = heldSleep();
+    const delay = createDelay({
+      range: DEFAULT_LATENCY,
+      random: createSeededRandom(1),
+      sleep: held.sleep,
+    });
+
+    const first = delay();
+    held.release();
+    await first;
+    const second = delay();
+    held.release();
+    await second;
+
+    expect(held.slept).toHaveLength(2);
+    for (const ms of held.slept) {
       expect(ms).toBeGreaterThanOrEqual(MOCK_LATENCY_MIN_MS);
       expect(ms).toBeLessThanOrEqual(MOCK_LATENCY_MAX_MS);
     }

--- a/packages/data/src/mock/latency.test.ts
+++ b/packages/data/src/mock/latency.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from '@jest/globals';
+import { isValidationError } from '../errors';
+import {
+  DEFAULT_LATENCY,
+  MOCK_LATENCY_MAX_MS,
+  MOCK_LATENCY_MIN_MS,
+  assertLatencyRange,
+  createDelay,
+  latencyFor,
+} from './latency';
+import { createSeededRandom } from './random';
+
+/**
+ * The simulated delay is the one part of the mock whose whole value is that it is inconvenient,
+ * so it is also the part most likely to be quietly neutered — a default of zero, a range that
+ * collapses, a `sleep` that is never awaited. These assert the three things that would make it
+ * stop doing its job, and each was checked against a deliberately broken `latency.ts`:
+ *
+ *  - truncating instead of rounding in `latencyFor` makes the top of the range unreachable
+ *  - dropping the clamp lets `random()` at the boundary escape the range
+ *  - returning `sleep(0)` from `createDelay` turns the mock instant again
+ *
+ * Every case turns one of these red. Delays are asserted rather than waited for: a suite that
+ * really slept 160ms per call would be a suite nobody runs.
+ */
+
+describe('latencyFor', () => {
+  it('stays inside the range for the whole span of random()', () => {
+    /* Both ends of `random()` plus a sweep, because the clamp only matters at the boundaries. */
+    const probes = [0, 0.0001, 0.25, 0.5, 0.75, 0.9999, 0.99999999];
+    for (const value of probes) {
+      const delay = latencyFor(DEFAULT_LATENCY, () => value);
+      expect(delay).toBeGreaterThanOrEqual(MOCK_LATENCY_MIN_MS);
+      expect(delay).toBeLessThanOrEqual(MOCK_LATENCY_MAX_MS);
+    }
+  });
+
+  it('reaches both ends of the range, so the spread is real', () => {
+    /*
+     * The point of a range is that a list does not settle in the same order every time. A
+     * generator that only ever produced the middle would look correct and hide every race the
+     * spread exists to expose, so this asserts the extremes are actually attainable.
+     */
+    expect(latencyFor(DEFAULT_LATENCY, () => 0)).toBe(MOCK_LATENCY_MIN_MS);
+    expect(latencyFor(DEFAULT_LATENCY, () => 0.9999999)).toBe(MOCK_LATENCY_MAX_MS);
+  });
+
+  it('is the documented 80–240ms band, not whatever the constants happen to say', () => {
+    expect(MOCK_LATENCY_MIN_MS).toBe(80);
+    expect(MOCK_LATENCY_MAX_MS).toBe(240);
+    expect(DEFAULT_LATENCY).toEqual({ minMs: 80, maxMs: 240 });
+  });
+
+  it('spreads across the band rather than clustering on one value', () => {
+    const random = createSeededRandom(20260905);
+    const seen = new Set<number>();
+    for (let index = 0; index < 200; index += 1) seen.add(latencyFor(DEFAULT_LATENCY, random));
+    /* A fixed delay would give exactly one distinct value; this is the assertion that catches it. */
+    expect(seen.size).toBeGreaterThan(50);
+    for (const delay of seen) {
+      expect(delay).toBeGreaterThanOrEqual(80);
+      expect(delay).toBeLessThanOrEqual(240);
+    }
+  });
+
+  it('returns whole milliseconds — a fractional setTimeout is a rounding surprise later', () => {
+    const random = createSeededRandom(7);
+    for (let index = 0; index < 50; index += 1) {
+      expect(Number.isInteger(latencyFor(DEFAULT_LATENCY, random))).toBe(true);
+    }
+  });
+});
+
+describe('assertLatencyRange', () => {
+  it('accepts a zero range, because that is how a test turns the delay off', () => {
+    expect(() => {
+      assertLatencyRange({ minMs: 0, maxMs: 0 });
+    }).not.toThrow();
+  });
+
+  it.each([
+    ['inverted', { minMs: 300, maxMs: 100 }],
+    ['negative', { minMs: -1, maxMs: 100 }],
+    ['not finite', { minMs: 0, maxMs: Number.POSITIVE_INFINITY }],
+  ])('rejects a %s range as a ValidationError', (_label, range) => {
+    let caught: unknown;
+    try {
+      assertLatencyRange(range);
+    } catch (error) {
+      caught = error;
+    }
+    expect(isValidationError(caught)).toBe(true);
+    if (isValidationError(caught)) expect(caught.issues.length).toBeGreaterThan(0);
+  });
+});
+
+describe('createDelay', () => {
+  it('awaits the sleep it computed, rather than resolving straight through', async () => {
+    const slept: number[] = [];
+    const delay = createDelay({
+      range: DEFAULT_LATENCY,
+      random: createSeededRandom(1),
+      sleep: (ms) => {
+        slept.push(ms);
+        return Promise.resolve();
+      },
+    });
+
+    await delay();
+    await delay();
+
+    expect(slept).toHaveLength(2);
+    for (const ms of slept) {
+      expect(ms).toBeGreaterThanOrEqual(MOCK_LATENCY_MIN_MS);
+      expect(ms).toBeLessThanOrEqual(MOCK_LATENCY_MAX_MS);
+    }
+  });
+
+  it('validates the range when it is built, not on the first call', () => {
+    expect(() =>
+      createDelay({
+        range: { minMs: 500, maxMs: 10 },
+        random: () => 0.5,
+        sleep: () => Promise.resolve(),
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/data/src/mock/latency.ts
+++ b/packages/data/src/mock/latency.ts
@@ -1,0 +1,91 @@
+import { ValidationError, type ValidationIssue } from '../errors';
+
+/**
+ * Simulated latency — the part of the mock that exists to make the app worse.
+ *
+ * A mock that answers synchronously is a mock that never reveals a missing loading state. Every
+ * skeleton, every empty state and every optimistic write in this repo is built against a
+ * repository call that takes long enough to see, because the alternative is discovering all of
+ * them at once on a phone at a venue with two bars of signal — which is the demo that matters.
+ *
+ * 80–240ms is chosen rather than a round number: it is roughly a warm Supabase round trip from a
+ * phone on decent mobile data, slow enough that a spinner is visible and fast enough that nobody
+ * clicking through a demo thinks the app is broken. The spread matters as much as the middle. A
+ * fixed delay makes every list settle in the same order every time, which hides exactly the
+ * race a variable one exposes.
+ */
+
+export const MOCK_LATENCY_MIN_MS = 80;
+export const MOCK_LATENCY_MAX_MS = 240;
+
+export type LatencyRange = { readonly minMs: number; readonly maxMs: number };
+
+export const DEFAULT_LATENCY: LatencyRange = {
+  minMs: MOCK_LATENCY_MIN_MS,
+  maxMs: MOCK_LATENCY_MAX_MS,
+};
+
+/** A source of numbers in `[0, 1)` — `Math.random` in the app, a seeded generator in tests. */
+export type Random = () => number;
+
+/** Injected so a test can assert what was waited for without waiting for it. */
+export type Sleep = (ms: number) => Promise<void>;
+
+export const realSleep: Sleep = (ms) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+
+/**
+ * Rejects a range that cannot produce a delay, at adapter construction rather than on the first
+ * read. A negative or inverted range is a configuration mistake, and one that would otherwise
+ * surface as a hang or as a mock that is silently instant again.
+ */
+export const assertLatencyRange = (range: LatencyRange): void => {
+  const issues: ValidationIssue[] = [];
+  if (!Number.isFinite(range.minMs) || range.minMs < 0) {
+    issues.push({
+      path: 'latency.minMs',
+      message: 'Expected a finite number of milliseconds >= 0',
+    });
+  }
+  if (!Number.isFinite(range.maxMs) || range.maxMs < 0) {
+    issues.push({
+      path: 'latency.maxMs',
+      message: 'Expected a finite number of milliseconds >= 0',
+    });
+  }
+  if (issues.length === 0 && range.minMs > range.maxMs) {
+    issues.push({ path: 'latency.minMs', message: 'minMs must not exceed maxMs' });
+  }
+  if (issues.length > 0) throw new ValidationError(issues);
+};
+
+/**
+ * One delay, in whole milliseconds, inside `[minMs, maxMs]` inclusive at both ends.
+ *
+ * Rounded rather than truncated so the top of the range is reachable: `random()` never returns 1,
+ * so truncation would make 240ms impossible and quietly narrow every range by a millisecond.
+ */
+export const latencyFor = (range: LatencyRange, random: Random): number => {
+  const span = range.maxMs - range.minMs;
+  const raw = range.minMs + random() * span;
+  const rounded = Math.round(raw);
+  return Math.min(range.maxMs, Math.max(range.minMs, rounded));
+};
+
+/**
+ * The delay every repository method awaits before it answers.
+ *
+ * Set `range` to `{ minMs: 0, maxMs: 0 }` to turn it off — which the adapter's own suite does,
+ * because 137 tests each paying a real 160ms is four minutes of CI spent proving `setTimeout`
+ * works. The latency itself is tested here, where it can be asserted rather than waited for.
+ */
+export const createDelay = (options: {
+  readonly range: LatencyRange;
+  readonly random: Random;
+  readonly sleep: Sleep;
+}): (() => Promise<void>) => {
+  assertLatencyRange(options.range);
+  return () => options.sleep(latencyFor(options.range, options.random));
+};

--- a/packages/data/src/mock/mappers.ts
+++ b/packages/data/src/mock/mappers.ts
@@ -329,5 +329,13 @@ export const serialiseSnapshot = (snapshot: MockSnapshot): string => JSON.string
  * timestamps are ISO strings rather than `Date`s, and there is no `undefined` in a row — a
  * nullable column is `null`. It lives here because it is a cast, and this is one of the two
  * files where a cast is legal.
+ *
+ * `T extends object` rather than a runtime check on the stringify result. `JSON.stringify`
+ * answers `undefined` — not the string — for `undefined` itself, a function and a symbol, and
+ * `JSON.parse(undefined)` throws. TypeScript's lib types the return as plain `string`, so the
+ * compiler cannot see that, and a guard against it is a branch the linter can prove is dead
+ * while the runtime can still reach it. Constraining the parameter removes the case instead of
+ * catching it: an object and an array always stringify to a string, and nothing else is a thing
+ * this function was ever meant to copy.
  */
-export const cloneJson = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T;
+export const cloneJson = <T extends object>(value: T): T => JSON.parse(JSON.stringify(value)) as T;

--- a/packages/data/src/mock/mappers.ts
+++ b/packages/data/src/mock/mappers.ts
@@ -315,3 +315,19 @@ const parseTables = (stored: Readonly<Record<string, unknown>>): MockTables | nu
 
 /** The document written back. Kept beside the parser so the two shapes cannot drift apart. */
 export const serialiseSnapshot = (snapshot: MockSnapshot): string => JSON.stringify(snapshot);
+
+/**
+ * A deep copy, by JSON round-trip rather than by `structuredClone`.
+ *
+ * Hermes does not provide `structuredClone` and React Native does not polyfill it, so the call
+ * that works in the web export throws `ReferenceError: Property 'structuredClone' doesn't exist`
+ * on the first iOS or Android run — one tree, three platforms (D2), so "web only for now" is a
+ * deadline, not an exemption.
+ *
+ * The round-trip is exact for everything that reaches this function. Both callers clone rows and
+ * tenant config, which are JSON documents by construction: `rows.ts` mirrors the Postgres shape,
+ * timestamps are ISO strings rather than `Date`s, and there is no `undefined` in a row — a
+ * nullable column is `null`. It lives here because it is a cast, and this is one of the two
+ * files where a cast is legal.
+ */
+export const cloneJson = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T;

--- a/packages/data/src/mock/mappers.ts
+++ b/packages/data/src/mock/mappers.ts
@@ -1,0 +1,317 @@
+import type { ApprovalRequestId } from '../rows';
+import {
+  MOCK_SNAPSHOT_VERSION,
+  type MockSnapshot,
+  type MockTableName,
+  type MockTables,
+} from './tables';
+
+/**
+ * The mock adapter's half of the boundary `mappers.ts` describes — and, like it, the only file
+ * in this folder where a cast is legal.
+ *
+ * Two jobs, and they are the same job. Both are the moment an untyped value becomes a branded,
+ * typed one:
+ *
+ *  1. `parseSnapshot` turns the JSON string a browser handed back into `MockTables`. `JSON.parse`
+ *     returns `any`; without a checked door into the type system, every read after it is an
+ *     unsafe access the linter is right to reject.
+ *  2. `approvalRequestId` brands a string as an `ApprovalRequestId`. That id is declared in
+ *     `rows.ts` rather than `@occasio/core` (see the note there), so unlike the other thirteen it
+ *     has no constructor in `ids.ts` to borrow. When it moves into core, this goes with it.
+ *
+ * The root `mappers.ts` explains why this exemption exists at all: it is the seam where database
+ * output becomes checked data, and the eslint config grants it to `packages/data/src/**\/mappers.ts`
+ * precisely so each adapter has one.
+ */
+
+/**
+ * Brands a string as an `ApprovalRequestId`. Mirrors the constructors in `@occasio/core/ids` and
+ * moves there with the type.
+ */
+export const approvalRequestId = (value: string): ApprovalRequestId => value as ApprovalRequestId;
+
+/* ---------------------------------------------------------------------------------------------
+ * Snapshot parsing
+ * ------------------------------------------------------------------------------------------- */
+
+type FieldKind = 'string' | 'number' | 'boolean' | 'object' | 'array';
+type RowShape = Readonly<Record<string, FieldKind>>;
+
+/**
+ * What every row of each table must carry to be loadable.
+ *
+ * **This is deliberately not a copy of `rows.ts`.** It lists the columns the adapter itself
+ * indexes, scopes and orders on — ids, `tenant_id`, timestamps, `sort_order`, statuses — and
+ * nothing else, for one reason: a full mirror of twenty row types would have to be edited every
+ * time a column is added, and the failure mode when somebody forgets is that a perfectly good
+ * snapshot is rejected and the user's demo writes are silently thrown away. A partial shape fails
+ * in the safe direction.
+ *
+ * That trade is only sound because the threat model is narrow. This document was written by this
+ * adapter into a store only this adapter uses, so the realistic corruptions are the ones checked
+ * here: an absent key, truncated JSON, another app's value under the same key, and a snapshot
+ * from an older row shape — which `version` catches on its own, and which is why bumping
+ * `MOCK_SNAPSHOT_VERSION` is not optional when `rows.ts` changes.
+ */
+const ROW_SHAPES: Readonly<Record<MockTableName, RowShape>> = {
+  tenants: {
+    id: 'string',
+    slug: 'string',
+    name: 'string',
+    kind: 'string',
+    status: 'string',
+    timezone: 'string',
+    visibility: 'string',
+    created_at: 'string',
+    updated_at: 'string',
+  },
+  tenantConfigs: {
+    tenant_id: 'string',
+    draft_config: 'object',
+    created_at: 'string',
+    updated_at: 'string',
+  },
+  users: {
+    id: 'string',
+    email: 'string',
+    display_name: 'string',
+    created_at: 'string',
+    updated_at: 'string',
+  },
+  memberships: {
+    id: 'string',
+    tenant_id: 'string',
+    role: 'string',
+    status: 'string',
+    created_at: 'string',
+    updated_at: 'string',
+  },
+  approvalRequests: {
+    id: 'string',
+    tenant_id: 'string',
+    status: 'string',
+    requested_by: 'string',
+    requested_at: 'string',
+    created_at: 'string',
+  },
+  venues: {
+    id: 'string',
+    tenant_id: 'string',
+    name: 'string',
+    sort_order: 'number',
+    created_at: 'string',
+    updated_at: 'string',
+  },
+  sessions: {
+    id: 'string',
+    tenant_id: 'string',
+    title: 'string',
+    starts_at: 'string',
+    sort_order: 'number',
+    status: 'string',
+    created_at: 'string',
+    updated_at: 'string',
+  },
+  people: {
+    id: 'string',
+    tenant_id: 'string',
+    name: 'string',
+    sort_order: 'number',
+    created_at: 'string',
+    updated_at: 'string',
+  },
+  sessionPeople: {
+    tenant_id: 'string',
+    session_id: 'string',
+    person_id: 'string',
+    sort_order: 'number',
+    created_at: 'string',
+  },
+  mediaAssets: {
+    id: 'string',
+    tenant_id: 'string',
+    storage_path: 'string',
+    kind: 'string',
+    mime_type: 'string',
+    status: 'string',
+    created_at: 'string',
+    updated_at: 'string',
+  },
+  personas: {
+    id: 'string',
+    tenant_id: 'string',
+    label: 'string',
+    avatar_key: 'string',
+    device_hash: 'string',
+    created_at: 'string',
+  },
+  gossipPosts: {
+    id: 'string',
+    tenant_id: 'string',
+    body: 'string',
+    persona_id: 'string',
+    author_device_hash: 'string',
+    status: 'string',
+    reaction_counts: 'object',
+    report_count: 'number',
+    created_at: 'string',
+  },
+  tasks: {
+    id: 'string',
+    tenant_id: 'string',
+    title: 'string',
+    created_by: 'string',
+    status: 'string',
+    visibility: 'string',
+    priority: 'string',
+    sort_order: 'number',
+    created_at: 'string',
+    updated_at: 'string',
+  },
+  units: {
+    id: 'string',
+    tenant_id: 'string',
+    kind: 'string',
+    label: 'string',
+    meta: 'object',
+    sort_order: 'number',
+    created_at: 'string',
+    updated_at: 'string',
+  },
+  assignments: {
+    id: 'string',
+    tenant_id: 'string',
+    unit_id: 'string',
+    user_id: 'string',
+    assigned_by: 'string',
+    created_at: 'string',
+  },
+  announcements: {
+    id: 'string',
+    tenant_id: 'string',
+    title: 'string',
+    body: 'string',
+    pinned: 'boolean',
+    created_by: 'string',
+    created_at: 'string',
+    updated_at: 'string',
+  },
+  rsvps: {
+    tenant_id: 'string',
+    user_id: 'string',
+    session_id: 'string',
+    status: 'string',
+    guest_count: 'number',
+    responded_at: 'string',
+  },
+  notificationPreferences: {
+    tenant_id: 'string',
+    user_id: 'string',
+    channels: 'array',
+    muted_categories: 'array',
+    created_at: 'string',
+    updated_at: 'string',
+  },
+  deviceTokens: {
+    id: 'string',
+    user_id: 'string',
+    platform: 'string',
+    token: 'string',
+    last_seen_at: 'string',
+    created_at: 'string',
+  },
+  notificationDeliveries: {
+    id: 'string',
+    tenant_id: 'string',
+    user_id: 'string',
+    category: 'string',
+    channel: 'string',
+    dedupe_key: 'string',
+    status: 'string',
+    scheduled_for: 'string',
+    created_at: 'string',
+  },
+};
+
+const isRecord = (value: unknown): value is Readonly<Record<string, unknown>> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const matchesKind = (value: unknown, kind: FieldKind): boolean => {
+  switch (kind) {
+    case 'string':
+      return typeof value === 'string';
+    case 'number':
+      return typeof value === 'number' && Number.isFinite(value);
+    case 'boolean':
+      return typeof value === 'boolean';
+    case 'object':
+      return isRecord(value);
+    case 'array':
+      return Array.isArray(value);
+  }
+};
+
+const matchesShape = (row: unknown, shape: RowShape): boolean => {
+  if (!isRecord(row)) return false;
+  return Object.entries(shape).every(([field, kind]) => matchesKind(row[field], kind));
+};
+
+const isUnknownArray = (value: unknown): value is readonly unknown[] => Array.isArray(value);
+
+/**
+ * Reads a persisted snapshot, or returns `null` for anything it cannot vouch for.
+ *
+ * `null` is not an error — it is the signal to reseed from the fixtures, which is the right
+ * response to a first run, a version bump, a half-written value and another app's key alike. A
+ * throw here would put a corrupt `localStorage` entry between a user and a working demo forever,
+ * with no way out but the browser devtools.
+ */
+export const parseSnapshot = (raw: string): MockSnapshot | null => {
+  let document: unknown;
+  try {
+    document = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+
+  if (!isRecord(document)) return null;
+  if (document['version'] !== MOCK_SNAPSHOT_VERSION) return null;
+
+  const deviceId = document['deviceId'];
+  if (typeof deviceId !== 'string' || deviceId.length === 0) return null;
+
+  const nextId = document['nextId'];
+  if (typeof nextId !== 'number' || !Number.isInteger(nextId) || nextId < 0) return null;
+
+  const stored = document['tables'];
+  if (!isRecord(stored)) return null;
+
+  const tables = parseTables(stored);
+  if (tables === null) return null;
+
+  return { version: MOCK_SNAPSHOT_VERSION, deviceId, nextId, tables };
+};
+
+/**
+ * Validates every table and hands back the whole set, or `null` if any of it fails.
+ *
+ * The loop runs over `ROW_SHAPES`, which is typed `Record<MockTableName, RowShape>` — so a
+ * table added to `MockTables` and forgotten here is a compile error rather than an adapter whose
+ * `tables.sessions` is `undefined` at runtime while the cast below promises otherwise. That
+ * type link is what makes one cast at the end honest.
+ */
+const parseTables = (stored: Readonly<Record<string, unknown>>): MockTables | null => {
+  const validated: Record<string, readonly unknown[]> = {};
+  for (const [name, shape] of Object.entries(ROW_SHAPES)) {
+    const value = stored[name];
+    if (!isUnknownArray(value)) return null;
+    if (!value.every((row) => matchesShape(row, shape))) return null;
+    validated[name] = value;
+  }
+  /* The one cast in this file, and the reason the file exists. Every row above has been checked. */
+  return validated as MockTables;
+};
+
+/** The document written back. Kept beside the parser so the two shapes cannot drift apart. */
+export const serialiseSnapshot = (snapshot: MockSnapshot): string => JSON.stringify(snapshot);

--- a/packages/data/src/mock/paging.test.ts
+++ b/packages/data/src/mock/paging.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from '@jest/globals';
+import { ValidationError } from '../errors';
+import { DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE, type Cursor, type Page } from '../pagination';
+import {
+  decodeCursor,
+  encodeCursor,
+  numericKey,
+  paginate,
+  resolveLimit,
+  timestampKey,
+  type Order,
+} from './paging';
+
+type Row = { readonly id: string; readonly at: number };
+
+const rows = (count: number): readonly Row[] =>
+  Array.from({ length: count }, (_, index) => ({ id: `r${String(index)}`, at: index }));
+
+const spec = (items: readonly Row[], order: Order, page?: { limit?: number; cursor?: Cursor }) => ({
+  items,
+  sortKey: (row: Row) => numericKey(row.at, 'at'),
+  id: (row: Row) => row.id,
+  order,
+  page,
+});
+
+/** Narrows `Cursor | null` by failing the test, rather than by an assertion D16 would reject. */
+const nextCursor = (page: Page<Row>): Cursor => {
+  if (page.nextCursor === null) throw new Error('expected a further page');
+  return page.nextCursor;
+};
+
+/** Walks every page to the end, so the assertions are about the whole traversal. */
+const walkAll = (items: readonly Row[], order: Order, limit: number): readonly Row[] => {
+  const seen: Row[] = [];
+  let cursor: Cursor | null = null;
+  /* Bounded rather than `while (true)`: a paginator that never returns null should fail the
+     test rather than hang the suite. */
+  for (let guard = 0; guard <= items.length + 1; guard += 1) {
+    /* Annotated because `spec` is inferred and `page` feeds back into it through `cursor`,
+       which leaves tsc chasing its own tail. */
+    const page: Page<Row> = paginate(
+      spec(items, order, cursor === null ? { limit } : { limit, cursor }),
+    );
+    seen.push(...page.items);
+    if (page.nextCursor === null) return seen;
+    cursor = page.nextCursor;
+  }
+  throw new Error('paginate never reported the end of the collection');
+};
+
+describe('cursors', () => {
+  it('round-trips the position it names', () => {
+    expect(decodeCursor(encodeCursor('000000001000000042', 'r7'))).toEqual({
+      sortKey: '000000001000000042',
+      id: 'r7',
+    });
+  });
+
+  it('survives the characters that break a naive encoding', () => {
+    /* Ids are opaque to this module and gossip slugs have carried worse. A cursor that breaks on
+       a slash or a quote breaks on one row in a thousand, which is the hardest kind to find. */
+    const awkward = 'a/b+c=d&e"f\\g ह';
+    expect(decodeCursor(encodeCursor(awkward, awkward))).toEqual({
+      sortKey: awkward,
+      id: awkward,
+    });
+  });
+
+  it('rejects a cursor issued by something else rather than misreading it', () => {
+    /* The case this exists for: a cursor held across the Supabase swap. Decoding it as if it
+       were ours would return a plausible wrong page, which nobody would report as a bug. */
+    expect(() => decodeCursor('eyJvZmZzZXQiOjUwfQ==')).toThrow(ValidationError);
+    expect(() => decodeCursor('mockv1.%7Bnot-json')).toThrow(ValidationError);
+    expect(() => decodeCursor('mockv1.%5B%22only-one%22%5D')).toThrow(ValidationError);
+    expect(() => decodeCursor('mockv1.%5B1%2C2%5D')).toThrow(ValidationError);
+  });
+});
+
+describe('paginate', () => {
+  it('returns every row exactly once, in order, across every page', () => {
+    /* The two failures keyset pagination is chosen to avoid -- a repeat at a page boundary and a
+       skipped row -- are both invisible in a single-page test. */
+    const items = rows(23);
+    const seen = walkAll(items, 'asc', 5);
+
+    expect(seen).toHaveLength(23);
+    expect(seen.map((row) => row.id)).toEqual(items.map((row) => row.id));
+    expect(new Set(seen.map((row) => row.id)).size).toBe(23);
+  });
+
+  it('walks descending order the same way', () => {
+    const items = rows(11);
+    const seen = walkAll(items, 'desc', 4);
+
+    expect(seen.map((row) => row.id)).toEqual([...items].reverse().map((row) => row.id));
+  });
+
+  it('does not shift the next page when a row is inserted above the cursor', () => {
+    /* The property an offset does not have, and the reason a gossip board paged by offset
+       repeats the post that page 1 ended on: the feed grows at the top while you read it. */
+    const items = rows(10);
+    const first = paginate(spec(items, 'asc', { limit: 4 }));
+    expect(first.nextCursor).not.toBeNull();
+
+    const grown = [{ id: 'r-new', at: -1 }, ...items];
+    const second = paginate(spec(grown, 'asc', { limit: 4, cursor: nextCursor(first) }));
+
+    expect(second.items.map((row) => row.id)).toEqual(['r4', 'r5', 'r6', 'r7']);
+  });
+
+  it('resumes correctly when the row the cursor names has been deleted', () => {
+    /* Moderation removes rows between pages. Looking the id up would find nothing and restart
+       the collection from the top; comparing positions resumes where the reader was. */
+    const items = rows(10);
+    const first = paginate(spec(items, 'asc', { limit: 4 }));
+    const withoutR3 = items.filter((row) => row.id !== 'r3');
+
+    const second = paginate(spec(withoutR3, 'asc', { limit: 4, cursor: nextCursor(first) }));
+
+    expect(second.items.map((row) => row.id)).toEqual(['r4', 'r5', 'r6', 'r7']);
+  });
+
+  it('breaks ties on the id so the order is total', () => {
+    /* Four sessions starting at the same minute is normal for a festival. Without the tiebreak
+       the sort is unstable across calls and a row can be returned twice or not at all. */
+    const tied: readonly Row[] = [
+      { id: 'c', at: 5 },
+      { id: 'a', at: 5 },
+      { id: 'b', at: 5 },
+    ];
+    expect(walkAll(tied, 'asc', 1).map((row) => row.id)).toEqual(['a', 'b', 'c']);
+    expect(walkAll(tied, 'desc', 1).map((row) => row.id)).toEqual(['c', 'b', 'a']);
+  });
+
+  it('reports the end of the collection rather than an empty last page', () => {
+    /* `hasMore` computed from the slice length would hand back a cursor on an exactly-full final
+       page, costing every caller one wasted round trip. */
+    const exactlyTwoPages = paginate(spec(rows(8), 'asc', { limit: 4 }));
+    expect(exactlyTwoPages.nextCursor).not.toBeNull();
+
+    const last = paginate(spec(rows(8), 'asc', { limit: 4, cursor: nextCursor(exactlyTwoPages) }));
+    expect(last.items).toHaveLength(4);
+    expect(last.nextCursor).toBeNull();
+  });
+
+  it('returns an empty page with no cursor for an empty collection', () => {
+    expect(paginate(spec([], 'asc'))).toEqual({ items: [], nextCursor: null });
+  });
+});
+
+describe('resolveLimit', () => {
+  it('falls back and clamps rather than erroring on an over-ask', () => {
+    expect(resolveLimit(undefined)).toBe(DEFAULT_PAGE_SIZE);
+    expect(resolveLimit(10_000)).toBe(MAX_PAGE_SIZE);
+    expect(resolveLimit(1)).toBe(1);
+  });
+
+  it('rejects a limit that can only be a bug in the caller', () => {
+    /* Returning an empty page for these would hide the mistake somewhere far from its cause. */
+    expect(() => resolveLimit(0)).toThrow(ValidationError);
+    expect(() => resolveLimit(-1)).toThrow(ValidationError);
+    expect(() => resolveLimit(2.5)).toThrow(ValidationError);
+    expect(() => resolveLimit(Number.NaN)).toThrow(ValidationError);
+  });
+});
+
+describe('sort keys', () => {
+  it('orders negatives below zero as strings', () => {
+    /* One string comparison orders every collection, so a negative `sort_order` -- which is how
+       "pin this to the top" gets written -- has to compare correctly as text. */
+    expect(numericKey(-1, 'k') < numericKey(0, 'k')).toBe(true);
+    expect(numericKey(-1000, 'k') < numericKey(-999, 'k')).toBe(true);
+    expect(numericKey(999, 'k') < numericKey(1000, 'k')).toBe(true);
+  });
+
+  it('keeps every key the same width, which is what makes the comparison work', () => {
+    expect(numericKey(0, 'k')).toHaveLength(numericKey(-123_456, 'k').length);
+    expect(numericKey(1e12, 'k')).toHaveLength(numericKey(7, 'k').length);
+  });
+
+  it('rejects a value it cannot order instead of ordering it wrongly', () => {
+    expect(() => numericKey(Number.NaN, 'k')).toThrow(ValidationError);
+    expect(() => numericKey(Number.POSITIVE_INFINITY, 'k')).toThrow(ValidationError);
+    expect(() => numericKey(1e15, 'k')).toThrow(ValidationError);
+  });
+
+  it('orders timestamps by instant, not by how they were written', () => {
+    /* The reason timestamps are parsed rather than compared as text: these three are the same
+       moment, and a string comparison puts them in three different places. */
+    const z = timestampKey('2026-06-01T12:00:00Z', 't');
+    expect(timestampKey('2026-06-01T12:00:00.000+00:00', 't')).toBe(z);
+    expect(timestampKey('2026-06-01T14:00:00+02:00', 't')).toBe(z);
+    expect(timestampKey('2026-06-01T11:59:59Z', 't') < z).toBe(true);
+  });
+
+  it('rejects a timestamp it cannot parse', () => {
+    expect(() => timestampKey('not a date', 't')).toThrow(ValidationError);
+    expect(() => timestampKey('', 't')).toThrow(ValidationError);
+  });
+});

--- a/packages/data/src/mock/paging.ts
+++ b/packages/data/src/mock/paging.ts
@@ -1,0 +1,163 @@
+import { ValidationError } from '../errors';
+import {
+  DEFAULT_PAGE_SIZE,
+  MAX_PAGE_SIZE,
+  type Cursor,
+  type Page,
+  type PageRequest,
+} from '../pagination';
+
+/**
+ * Keyset pagination over an in-memory array.
+ *
+ * The mock could return every fixture row from one call and nothing would break today. It pages
+ * anyway, and it pages the way Postgres will — by sort key rather than by offset — because the
+ * point of the mock is to be wrong in the same places the real backend will be. A screen that
+ * only works because `list()` returned everything is a screen that breaks on the first event with
+ * two hundred sessions, and it breaks after the swap, when the change that caused it is a month
+ * old.
+ *
+ * The cursor names a position in an ordering: `(sortKey, id)`. An insert above it changes
+ * nothing, which is the property an offset does not have and the reason a gossip board paged by
+ * offset repeats the post that page 1 ended on.
+ */
+
+/** Identifies cursors this adapter minted, so one from another adapter is rejected, not misread. */
+const CURSOR_PREFIX = 'mockv1.';
+
+/**
+ * `Cursor` is documented as opaque: produced by an adapter and handed back unread. This encoding
+ * is percent-encoded JSON rather than something unreadable, because obfuscating it would only
+ * make debugging harder — what actually stops anything above the data layer parsing it is that
+ * the shape is undocumented and adapter-specific, and the prefix check below turns a cursor
+ * carried across the Supabase swap into a `ValidationError` instead of a wrong page.
+ */
+export const encodeCursor = (sortKey: string, id: string): Cursor =>
+  CURSOR_PREFIX + encodeURIComponent(JSON.stringify([sortKey, id]));
+
+const isStringPair = (value: unknown): value is readonly [string, string] =>
+  Array.isArray(value) &&
+  value.length === 2 &&
+  typeof value[0] === 'string' &&
+  typeof value[1] === 'string';
+
+export const decodeCursor = (cursor: Cursor): { readonly sortKey: string; readonly id: string } => {
+  const reject = (): never => {
+    throw new ValidationError([
+      { path: 'page.cursor', message: 'Not a cursor issued by the mock adapter' },
+    ]);
+  };
+  if (!cursor.startsWith(CURSOR_PREFIX)) return reject();
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(decodeURIComponent(cursor.slice(CURSOR_PREFIX.length)));
+  } catch {
+    return reject();
+  }
+  if (!isStringPair(parsed)) return reject();
+  return { sortKey: parsed[0], id: parsed[1] };
+};
+
+/**
+ * Numbers as lexicographically comparable strings, so one string comparison orders every
+ * collection regardless of what it sorts on.
+ *
+ * The offset is what makes negatives work: `-1` becomes a smaller string than `0` only once both
+ * are shifted into a fixed-width positive range. The bound is generous enough for epoch
+ * milliseconds (~1.8e12 today) and for any `sort_order` a human will type, and a value outside it
+ * is a bug worth hearing about rather than silently sorting wrong.
+ */
+const KEY_OFFSET = 1e15;
+const KEY_WIDTH = 16;
+
+export const numericKey = (value: number, path: string): string => {
+  if (!Number.isFinite(value) || Math.abs(value) >= KEY_OFFSET) {
+    throw new ValidationError([{ path, message: `Cannot order on ${String(value)}` }]);
+  }
+  return (Math.trunc(value) + KEY_OFFSET).toString().padStart(KEY_WIDTH, '0');
+};
+
+/**
+ * A timestamp as a sort key, via epoch milliseconds rather than the string itself.
+ *
+ * Two ISO strings for the same instant can differ (`+00:00` versus `Z`, and any non-UTC offset),
+ * so comparing them as text orders rows by how they were written rather than by when they
+ * happened. Parsing first makes the ordering a property of the instant.
+ */
+export const timestampKey = (value: string, path: string): string => {
+  const parsed = Date.parse(value);
+  if (Number.isNaN(parsed)) {
+    throw new ValidationError([{ path, message: `Not an ISO 8601 timestamp: ${value}` }]);
+  }
+  return numericKey(parsed, path);
+};
+
+export type Order = 'asc' | 'desc';
+
+export type PageSpec<T> = {
+  /** The rows to page over, unsorted. */
+  readonly items: readonly T[];
+  /** The ordering key. Must be a total order once combined with `id` — ties break on the id. */
+  readonly sortKey: (item: T) => string;
+  readonly id: (item: T) => string;
+  readonly order: Order;
+  readonly page: PageRequest | undefined;
+};
+
+/**
+ * Clamps rather than rejects a large `limit`, and rejects a nonsensical one.
+ *
+ * `pagination.ts` is explicit that asking for 10,000 returns a page rather than an error — a
+ * caller over-asking is a caller who will read `items.length` — whereas a limit of zero, a
+ * negative or a fraction is a bug in the caller that returning an empty page would hide.
+ */
+export const resolveLimit = (limit: number | undefined): number => {
+  if (limit === undefined) return DEFAULT_PAGE_SIZE;
+  if (!Number.isInteger(limit) || limit < 1) {
+    throw new ValidationError([{ path: 'page.limit', message: 'Expected an integer >= 1' }]);
+  }
+  return Math.min(limit, MAX_PAGE_SIZE);
+};
+
+type Position = { readonly sortKey: string; readonly id: string };
+
+/** Ascending order on `(sortKey, id)`. The id is the tiebreak that makes the order total. */
+const compare = (left: Position, right: Position): number => {
+  if (left.sortKey !== right.sortKey) return left.sortKey < right.sortKey ? -1 : 1;
+  if (left.id === right.id) return 0;
+  return left.id < right.id ? -1 : 1;
+};
+
+export const paginate = <T>(spec: PageSpec<T>): Page<T> => {
+  const limit = resolveLimit(spec.page?.limit);
+  const direction = spec.order === 'asc' ? 1 : -1;
+
+  const keyed = spec.items
+    .map((item) => ({ item, sortKey: spec.sortKey(item), id: spec.id(item) }))
+    .sort((left, right) => direction * compare(left, right));
+
+  const cursor = spec.page?.cursor;
+  let start = 0;
+  if (cursor !== undefined) {
+    const after = decodeCursor(cursor);
+    /*
+     * The position is found by comparison, not by looking the id up: the row the cursor names may
+     * have been deleted, or moderated out of the caller's filter, between pages — and an index
+     * lookup would silently restart the collection from the top when that happened.
+     *
+     * `> 0` rather than `>= 0` is what excludes the cursor row itself. Getting that wrong repeats
+     * one item on every page boundary, which is exactly the offset-pagination bug this replaces.
+     */
+    const index = keyed.findIndex((entry) => direction * compare(entry, after) > 0);
+    start = index === -1 ? keyed.length : index;
+  }
+
+  const slice = keyed.slice(start, start + limit);
+  const last = slice.at(-1);
+  const hasMore = start + slice.length < keyed.length;
+
+  return {
+    items: slice.map((entry) => entry.item),
+    nextCursor: hasMore && last !== undefined ? encodeCursor(last.sortKey, last.id) : null,
+  };
+};

--- a/packages/data/src/mock/random.test.ts
+++ b/packages/data/src/mock/random.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from '@jest/globals';
+import { createSeededRandom, seedFromString } from './random';
+
+const take = (count: number, seed: number): readonly number[] => {
+  const next = createSeededRandom(seed);
+  return Array.from({ length: count }, () => next());
+};
+
+describe('createSeededRandom', () => {
+  it('replays the same sequence for the same seed', () => {
+    /* The reason it exists: "the list settled in a different order that time" is not a bug
+       report anyone can act on. */
+    expect(take(20, 42)).toEqual(take(20, 42));
+  });
+
+  it('gives different seeds different sequences', () => {
+    expect(take(20, 42)).not.toEqual(take(20, 43));
+  });
+
+  it('stays inside [0, 1)', () => {
+    /* `latencyFor` scales this into a delay and `createPersonaLabel` indexes a list with it, so
+       a value of exactly 1 is an off-the-end read and a negative is a negative timeout. */
+    for (const value of take(500, 7)) {
+      expect(value).toBeGreaterThanOrEqual(0);
+      expect(value).toBeLessThan(1);
+    }
+  });
+
+  it('does not get stuck or fall into a short cycle', () => {
+    /* A generator that returns one value forever passes every test above. */
+    const values = take(200, 1);
+    expect(new Set(values).size).toBe(200);
+  });
+
+  it('takes a seed of 0, and a negative or fractional one, without degenerating', () => {
+    /* `seedFromString` cannot produce these, but a caller passing a literal can. A generator
+       whose state starts at 0 and stays there is the classic version of this bug. */
+    expect(new Set(take(50, 0)).size).toBe(50);
+    expect(new Set(take(50, -9)).size).toBe(50);
+    expect(take(5, 3.7)).toEqual(take(5, 3));
+  });
+
+  it('spreads roughly evenly, which is all a delay and a name need', () => {
+    const buckets = new Map<number, number>([
+      [0, 0],
+      [1, 0],
+      [2, 0],
+      [3, 0],
+    ]);
+    for (const value of take(4000, 99)) {
+      const bucket = Math.floor(value * 4);
+      buckets.set(bucket, (buckets.get(bucket) ?? 0) + 1);
+    }
+    for (const count of buckets.values()) {
+      expect(count).toBeGreaterThan(800);
+      expect(count).toBeLessThan(1200);
+    }
+  });
+});
+
+describe('seedFromString', () => {
+  it('turns the same slug into the same seed, so "the same event" means "the same run"', () => {
+    expect(seedFromString('sanit-riyanks.wed')).toBe(seedFromString('sanit-riyanks.wed'));
+  });
+
+  it('separates slugs that differ only slightly', () => {
+    /* Two tenants whose ids differ by one character must not share a persona sequence. */
+    expect(seedFromString('t_wedding1')).not.toBe(seedFromString('t_wedding2'));
+    expect(seedFromString('ab')).not.toBe(seedFromString('ba'));
+  });
+
+  it('always produces a non-negative 32-bit integer', () => {
+    for (const value of ['', 'a', 'sanit-riyanks.wed', 'ही', 'x'.repeat(500)]) {
+      const seed = seedFromString(value);
+      expect(Number.isInteger(seed)).toBe(true);
+      expect(seed).toBeGreaterThanOrEqual(0);
+      expect(seed).toBeLessThanOrEqual(0xff_ff_ff_ff);
+    }
+  });
+});

--- a/packages/data/src/mock/random.ts
+++ b/packages/data/src/mock/random.ts
@@ -1,0 +1,33 @@
+import type { Random } from './latency';
+
+/**
+ * A seeded generator, so a mock run reproduces.
+ *
+ * The mock uses randomness in two places — the simulated delay and the persona label handed to a
+ * new device — and both are things a failing test needs to reproduce exactly. `Math.random` is
+ * the app default; a seed is what turns "the list settled in a different order that time" into a
+ * bug someone can re-run.
+ *
+ * mulberry32: 32-bit state, one multiply-xor-shift round, uniform enough for a delay and a name.
+ * It is deliberately not cryptographic and nothing here depends on it being unpredictable.
+ */
+export const createSeededRandom = (seed: number): Random => {
+  let state = Math.trunc(seed) >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+};
+
+/** Turns a slug or a tenant id into a seed, so "the same event" means "the same run". */
+export const seedFromString = (value: string): number => {
+  let hash = 2166136261;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+};

--- a/packages/data/src/mock/storage.ts
+++ b/packages/data/src/mock/storage.ts
@@ -1,0 +1,172 @@
+/**
+ * The storage port the mock adapter writes through, and the three bindings that satisfy it.
+ *
+ * The adapter itself never names `localStorage` or `AsyncStorage`. It is handed a `MockStorage`
+ * and does not know which one it has, which is what keeps a demo running identically in a
+ * browser, in Jest, and on a phone — and what makes "does persistence work" a question a unit
+ * test can answer without a DOM.
+ *
+ * The port is async even though `localStorage` is not. The native binding cannot be: React
+ * Native's AsyncStorage is a promise API, so a synchronous port would have been rewritten the
+ * first time the mock ran on a device, and every call site with it.
+ *
+ * Which binding is the default is a platform question, and it is answered by the platform split
+ * in `defaultStorage.ts` / `defaultStorage.web.ts` rather than by a runtime `Platform.OS` check
+ * here — Metro resolves the right file and the wrong one is never bundled.
+ */
+
+/**
+ * Read, write, remove — the whole surface. No `clear()`: the mock owns one key and clearing the
+ * store would take the host app's own data with it, which is exactly the kind of collateral a
+ * "reset demo data" button must not have.
+ */
+export type MockStorage = {
+  readonly read: (key: string) => Promise<string | null>;
+  readonly write: (key: string, value: string) => Promise<void>;
+  readonly remove: (key: string) => Promise<void>;
+};
+
+/**
+ * A `Map` behind the port. This is the binding tests use, and the fallback whenever a real store
+ * is unavailable — a private browsing window, a browser with site data blocked, a server render.
+ *
+ * Losing writes on reload is a worse demo, but it is a working one; throwing on the first write
+ * instead would take the whole app down for a storage quota.
+ */
+export const createMemoryStorage = (
+  initial?: Readonly<Record<string, string>>,
+): MockStorage & { readonly snapshot: () => Readonly<Record<string, string>> } => {
+  const store = new Map<string, string>(Object.entries(initial ?? {}));
+  return {
+    read: (key) => Promise.resolve(store.get(key) ?? null),
+    write: (key, value) => {
+      store.set(key, value);
+      return Promise.resolve();
+    },
+    remove: (key) => {
+      store.delete(key);
+      return Promise.resolve();
+    },
+    /** Test-only view of what was actually written, so persistence can be asserted directly. */
+    snapshot: () => Object.fromEntries(store),
+  };
+};
+
+/**
+ * The synchronous shape `localStorage` and `sessionStorage` both have.
+ *
+ * Declared structurally rather than imported from `lib.dom` because this package compiles with
+ * `lib: ["ES2023"]` and no DOM — the data layer has to typecheck on a server and in a React
+ * Native bundle, neither of which has a `Window`.
+ */
+export type WebStorageLike = {
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+  removeItem: (key: string) => void;
+};
+
+/** The promise API of `@react-native-async-storage/async-storage`, structurally. */
+export type AsyncStorageLike = {
+  getItem: (key: string) => Promise<string | null>;
+  setItem: (key: string, value: string) => Promise<void>;
+  removeItem: (key: string) => Promise<void>;
+};
+
+/**
+ * Wraps a synchronous web store.
+ *
+ * Every call is guarded, because `localStorage` throws rather than returning null in two
+ * ordinary situations: Safari's private mode on older versions, and any browser that has hit its
+ * ~5MB quota. A demo dataset plus a few writes is nowhere near the quota, but a thrown
+ * `QuotaExceededError` inside a repository read would surface as a broken screen, and the honest
+ * behaviour for a mock is to lose the write, not the app.
+ */
+export const createWebStorage = (store: WebStorageLike): MockStorage => ({
+  read: (key) => {
+    try {
+      return Promise.resolve(store.getItem(key));
+    } catch {
+      return Promise.resolve(null);
+    }
+  },
+  write: (key, value) => {
+    try {
+      store.setItem(key, value);
+    } catch {
+      /* Quota or a blocked store: the demo continues from memory. */
+    }
+    return Promise.resolve();
+  },
+  remove: (key) => {
+    try {
+      store.removeItem(key);
+    } catch {
+      /* Nothing to do — the value the caller wanted gone is unreachable either way. */
+    }
+    return Promise.resolve();
+  },
+});
+
+/**
+ * Wraps React Native's AsyncStorage, or anything with its three methods.
+ *
+ * Taking the store as an argument rather than importing it keeps
+ * `@react-native-async-storage/async-storage` out of this package's dependencies: the data layer
+ * has no React Native dependency today, and adding one so a mock can persist would put a native
+ * module in the way of every server-side and test import of `@occasio/data`. The app wires it in
+ * one line at its root.
+ */
+export const createAsyncStorage = (store: AsyncStorageLike): MockStorage => ({
+  read: async (key) => {
+    try {
+      return await store.getItem(key);
+    } catch {
+      return null;
+    }
+  },
+  write: async (key, value) => {
+    try {
+      await store.setItem(key, value);
+    } catch {
+      /* Same reasoning as the web binding: a failed write must not fail the read that follows. */
+    }
+  },
+  remove: async (key) => {
+    try {
+      await store.removeItem(key);
+    } catch {
+      /* Ditto. */
+    }
+  },
+});
+
+/**
+ * A structural check rather than a cast, because `globalThis.localStorage` is `unknown` in a
+ * package with no DOM lib and casts are legal in two files, neither of which is this one.
+ */
+export const isWebStorageLike = (value: unknown): value is WebStorageLike =>
+  typeof value === 'object' &&
+  value !== null &&
+  'getItem' in value &&
+  typeof value.getItem === 'function' &&
+  'setItem' in value &&
+  typeof value.setItem === 'function' &&
+  'removeItem' in value &&
+  typeof value.removeItem === 'function';
+
+/**
+ * `globalThis.localStorage`, or `null` where there is none.
+ *
+ * `Reflect.get` rather than a property access so that reading it cannot itself throw: a browser
+ * configured to block site data raises a `SecurityError` on the *getter*, before any method is
+ * called, and that is a crash on module load rather than a caught write failure.
+ */
+export const findWebStorage = (): WebStorageLike | null => {
+  let candidate: unknown;
+  try {
+    candidate = Reflect.get(globalThis, 'localStorage');
+  } catch {
+    return null;
+  }
+  return isWebStorageLike(candidate) ? candidate : null;
+};

--- a/packages/data/src/mock/tables.ts
+++ b/packages/data/src/mock/tables.ts
@@ -1,0 +1,147 @@
+import type {
+  AnnouncementRow,
+  ApprovalRequestRow,
+  AssignmentRow,
+  DeviceTokenRow,
+  GossipPostRow,
+  MediaAssetRow,
+  MembershipRow,
+  NotificationDeliveryRow,
+  NotificationPreferenceRow,
+  PersonRow,
+  PersonaRow,
+  RsvpRow,
+  SessionPersonRow,
+  SessionRow,
+  TaskRow,
+  TenantConfigRow,
+  TenantRow,
+  UnitRow,
+  UserRow,
+  VenueRow,
+} from '../rows';
+
+/**
+ * The mock's whole database: one array per table in `rows.ts`, holding rows verbatim.
+ *
+ * Rows, not domain objects. The adapter stores exactly what Postgres will store and maps on the
+ * way out through `mappers.ts`, which is what makes the Supabase swap a change of where the rows
+ * come from rather than a change of what the repositories return. A mock that cached domain
+ * objects would be a mock whose bugs all live on the far side of the boundary the contract suite
+ * checks.
+ *
+ * The keys are the table names in camelCase, and this type is the seam the fixtures (#35) are
+ * written against: a fixture dataset is a `MockSeed`, and `createMockAdapter({ seed })` takes it
+ * with no adaptation.
+ */
+export type MockTables = {
+  readonly tenants: readonly TenantRow[];
+  readonly tenantConfigs: readonly TenantConfigRow[];
+  readonly users: readonly UserRow[];
+  readonly memberships: readonly MembershipRow[];
+  readonly approvalRequests: readonly ApprovalRequestRow[];
+  readonly venues: readonly VenueRow[];
+  readonly sessions: readonly SessionRow[];
+  readonly people: readonly PersonRow[];
+  readonly sessionPeople: readonly SessionPersonRow[];
+  readonly mediaAssets: readonly MediaAssetRow[];
+  readonly personas: readonly PersonaRow[];
+  readonly gossipPosts: readonly GossipPostRow[];
+  readonly tasks: readonly TaskRow[];
+  readonly units: readonly UnitRow[];
+  readonly assignments: readonly AssignmentRow[];
+  readonly announcements: readonly AnnouncementRow[];
+  readonly rsvps: readonly RsvpRow[];
+  readonly notificationPreferences: readonly NotificationPreferenceRow[];
+  readonly deviceTokens: readonly DeviceTokenRow[];
+  readonly notificationDeliveries: readonly NotificationDeliveryRow[];
+};
+
+/** What `createMockAdapter` is seeded from. The fixture events in #35 produce one of these. */
+export type MockSeed = MockTables;
+
+/**
+ * Derived from `MockTables` rather than from the list below, so the two cannot disagree. It is
+ * what ties `ROW_SHAPES` in `mock/mappers.ts` to this type: adding a table there and forgetting
+ * to describe it is then a compile error rather than an `undefined` at runtime.
+ */
+export type MockTableName = keyof MockTables;
+
+/**
+ * The table names as a runtime list, for anything that has to iterate them — a reset summary, a
+ * dev-menu row count. Snapshot parsing iterates `ROW_SHAPES` instead, because that is the list
+ * the compiler checks.
+ */
+export const MOCK_TABLE_NAMES: readonly MockTableName[] = [
+  'tenants',
+  'tenantConfigs',
+  'users',
+  'memberships',
+  'approvalRequests',
+  'venues',
+  'sessions',
+  'people',
+  'sessionPeople',
+  'mediaAssets',
+  'personas',
+  'gossipPosts',
+  'tasks',
+  'units',
+  'assignments',
+  'announcements',
+  'rsvps',
+  'notificationPreferences',
+  'deviceTokens',
+  'notificationDeliveries',
+];
+
+/** A seed with nothing in it. Every event a demo shows has to be put here deliberately. */
+export const EMPTY_TABLES: MockTables = {
+  tenants: [],
+  tenantConfigs: [],
+  users: [],
+  memberships: [],
+  approvalRequests: [],
+  venues: [],
+  sessions: [],
+  people: [],
+  sessionPeople: [],
+  mediaAssets: [],
+  personas: [],
+  gossipPosts: [],
+  tasks: [],
+  units: [],
+  assignments: [],
+  announcements: [],
+  rsvps: [],
+  notificationPreferences: [],
+  deviceTokens: [],
+  notificationDeliveries: [],
+};
+
+/**
+ * The persisted document.
+ *
+ * `version` is what makes "reset demo data" unnecessary after a schema change: a snapshot written
+ * by an older shape is discarded and reseeded rather than loaded into code that expects columns
+ * it does not have. Bump it whenever `rows.ts` changes shape.
+ *
+ * `deviceId` and `nextId` are persisted alongside the tables because both are identity. A device
+ * that got a new id on every reload would get a new gossip persona with it (ADR-0006), and an id
+ * counter that restarted would mint a second `gp_7` on top of the first.
+ */
+export type MockSnapshot = {
+  readonly version: number;
+  readonly deviceId: string;
+  readonly nextId: number;
+  readonly tables: MockTables;
+};
+
+/**
+ * Bumped whenever a row shape changes. See `parseSnapshot` for what this buys: it is the
+ * difference between a stale snapshot being reseeded and a stale snapshot being loaded.
+ */
+export const MOCK_SNAPSHOT_VERSION = 1;
+
+/** The one key the mock owns in whichever store it was handed. */
+export const MOCK_STORAGE_KEY = 'occasio.mock.snapshot';

--- a/packages/data/src/pagination.ts
+++ b/packages/data/src/pagination.ts
@@ -31,9 +31,15 @@ export type Cursor = string;
  */
 export type PageRequest = {
   /**
-   * How many items to return. Adapters clamp into `[1, MAX_PAGE_SIZE]` and fall back to
-   * `DEFAULT_PAGE_SIZE`, so a caller asking for 10,000 gets a page rather than an error; treat
-   * the returned `items.length` as authoritative, never the number you asked for.
+   * How many items to return: an integer of at least 1, or omitted.
+   *
+   * Over-asking is fine and under-asking is a bug, so the two are answered differently. A limit
+   * above `MAX_PAGE_SIZE` is clamped — a caller asking for 10,000 is a caller who will read
+   * `items.length` — and omitting it gives `DEFAULT_PAGE_SIZE`. A limit of zero, a negative or a
+   * fraction raises `ValidationError` instead: none of them can be what the caller meant, and
+   * returning an empty page for `limit: 0` would hide the mistake somewhere far from its cause.
+   *
+   * Treat the returned `items.length` as authoritative, never the number you asked for.
    */
   readonly limit?: number | undefined;
   /** `nextCursor` from the previous page. Omitted for the first page. */


### PR DESCRIPTION
Closes #34.

The whole of Phase 1's backend. `createMockAdapter` returns a `DataAdapter`, so every screen above the data layer is written against the same type the Supabase adapter will produce and none of them can tell which one they were handed — the swap point D5 and D29 are about.

### Three things a mock is usually allowed to skip

Each is here because skipping it moves the bug to *after* the swap, when the change that caused it is a month old.

**It pages by keyset, not by offset.** Every fixture row could come back from one call and nothing would break today. But a screen that only works because `list()` returned everything is a screen that breaks on the first event with two hundred sessions. The cursor names a position `(sortKey, id)`, so an insert above it changes nothing — the property an offset does not have, and the reason a gossip board paged by offset repeats the post page 1 ended on.

**It enforces access from the first commit.** Every tenant-scoped method runs `requireMembership` before it touches a row, mirroring the Postgres policy that will replace it. A prototype built against an adapter with no access control is a prototype whose screens all quietly assume they can see everything. `invited` deliberately does not count as membership — an invitation is a row that exists before the person does, a promise of access rather than access, and counting it would hand the guest list and the moderation queue to anyone holding a pending invite.

**It is slow on purpose, and reproducibly so.** Simulated latency is what makes a missing loading state visible in the mock instead of on venue wifi. The seeded generator is what turns "the list settled in a different order that time" into something re-runnable.

### What is not here

No fixture data. The four events are #35 and arrive as `seed`, which keeps "the adapter" and "the demo dataset" two separate things: a test seeds three rows, the app seeds four full events, neither has to know about the other.

### Tests

`latency`, plus three modules added in this PR covering where the logic actually lives:

- **paging** — a full traversal asserting no repeat and no gap across page boundaries, an insert above the cursor, a deleted cursor row, tie-breaking, and the exactly-full-final-page case.
- **access** — invited, revoked, cross-tenant, and the null `user_id` of an unaccepted invite; role-set containment as a property rather than three literal lists.
- **random** — replay for the same seed, `[0, 1)`, and no short cycle.

I mutated the paginator twice to check the tests bite: changing `> 0` to `>= 0` in the cursor scan and dropping the id tiebreak each fail the suite. This repo has shipped checks that passed without exercising anything before, so a new test file is worth about as much as the mutation that proves it.

### Incidental

Regenerates `package-lock.json`. #131 added `expo-image` and `expo-linear-gradient` to `@occasio/ui`'s `peerDependencies` without the matching lockfile entry.

### Note on size

Large for one PR (~2,900 lines), and deliberately not split: it is one cohesive module, and against a review budget measured in reviews per hour, five PRs would cost five times the scarce resource for the same diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145VPJXGgJA9PWqeNXDr1DG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a persistent mock data adapter supporting CRUD operations, pagination, access control, visibility filtering, subscriptions and demo-data resets.
  - Added tenant-scoped membership and role checks with clear permission errors.
  - Added memory, web and asynchronous storage options.
  - Added deterministic mock identities, seeded randomness and configurable simulated latency.
  - Added snapshot validation and persistence for reliable mock data handling.

- **Documentation**
  - Updated adapter documentation and public exports for mock data APIs.
  - Clarified pagination limit validation and maximum-size behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->