### PR TITLE
fix(tools): close three holes in the checks that are supposed to catch things

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -217,9 +217,15 @@ export default tseslint.config(
   },
 
   /* The two files whose entire job is translating an elevation spec into platform shadow
-     properties. Everything else goes through them. */
+     properties. Everything else goes through them.
+
+     Named exactly rather than as `elevation*.ts`: the glob also exempted anything else starting
+     with the word, so a future `elevationCard.ts` would have been born outside the rule without
+     anyone deciding that. It also exempted `elevation__enforcement_probe.ts` — the probe that
+     was proving the exemption worked — so that probe was really only proving the glob matched
+     its own name. It now lints the real translator path through `lintText`. */
   {
-    files: ['packages/ui/src/theme/elevation*.ts'],
+    files: ['packages/ui/src/theme/elevation.ts', 'packages/ui/src/theme/elevation.web.ts'],
     rules: { 'occasio/no-raw-shadow-props': 'off' },
   },
 

--- a/tools/enforcement/verify-enforcement.mjs
+++ b/tools/enforcement/verify-enforcement.mjs
@@ -68,6 +68,15 @@ const CASES = [
     code: "export const s = { card: { ['boxShadow']: '0 1px 2px #000' } };\n",
   },
   {
+    /* The other half of the computed-key case: a bracketed *variable* is not a known key, and
+       reporting it would flag `{ [dataKey]: value }` as a hand-written shadow. */
+    label: 'ELEV a computed variable key is not reported',
+    file: 'packages/ui/src/__enforcement_probe_shadow_dynamic.ts',
+    rule: 'occasio/no-raw-shadow-props',
+    shouldFire: false,
+    code: "const k = 'width';\nexport const s = { card: { [k]: 4 } };\n",
+  },
+  {
     /*
      * Linted in memory at the translator's real path rather than written to disk under a name
      * the exemption happens to match. Writing a file called `elevation__enforcement_probe.ts`

--- a/tools/enforcement/verify-enforcement.mjs
+++ b/tools/enforcement/verify-enforcement.mjs
@@ -17,7 +17,13 @@ import { fileURLToPath } from 'node:url';
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
 
-/** @type {{ label: string, file: string, rule: string, shouldFire: boolean, code: string }[]} */
+/**
+ * `file` is written to disk and linted; `virtualPath` is linted in memory as if it were that
+ * path. Use `virtualPath` whenever the path under test is one a real source file already owns.
+ *
+ * @type {{ label: string, file?: string, virtualPath?: string, rule: string,
+ *          shouldFire: boolean, code: string }[]}
+ */
 const CASES = [
   {
     label: 'D8   theme may not import the data layer',
@@ -55,8 +61,22 @@ const CASES = [
     code: "export const s = { card: { shadowColor: 'x', shadowRadius: 4, elevation: 2 } };\n",
   },
   {
+    label: 'ELEV computed keys do not smuggle a shadow prop past the rule',
+    file: 'packages/ui/src/__enforcement_probe_shadow_computed.ts',
+    rule: 'occasio/no-raw-shadow-props',
+    shouldFire: true,
+    code: "export const s = { card: { ['boxShadow']: '0 1px 2px #000' } };\n",
+  },
+  {
+    /*
+     * Linted in memory at the translator's real path rather than written to disk under a name
+     * the exemption happens to match. Writing a file called `elevation__enforcement_probe.ts`
+     * only proved that `elevation*.ts` matched it — which was true, and was the bug: the glob
+     * exempted the probe as readily as the translator. Nothing here may write to
+     * `elevation.ts`, because that is a real source file.
+     */
     label: 'ELEV the elevation translator IS allowed to use them',
-    file: 'packages/ui/src/theme/elevation__enforcement_probe.ts',
+    virtualPath: 'packages/ui/src/theme/elevation.ts',
     rule: 'occasio/no-raw-shadow-props',
     shouldFire: false,
     code: "export const s = { shadowColor: 'x' };\n",
@@ -80,23 +100,34 @@ const CASES = [
 const eslint = new ESLint({ cwd: repoRoot });
 let failures = 0;
 
-for (const testCase of CASES) {
+/** Lints the case, on disk or in memory, and returns whether its rule fired. */
+const runCase = async (testCase) => {
+  if (testCase.virtualPath !== undefined) {
+    const [result] = await eslint.lintText(testCase.code, {
+      filePath: join(repoRoot, testCase.virtualPath),
+    });
+    return (result?.messages ?? []).some((m) => m.ruleId === testCase.rule);
+  }
   const absolute = join(repoRoot, testCase.file);
   mkdirSync(dirname(absolute), { recursive: true });
   writeFileSync(absolute, testCase.code);
   try {
     const [result] = await eslint.lintFiles([absolute]);
-    const fired = (result?.messages ?? []).some((m) => m.ruleId === testCase.rule);
-    if (fired === testCase.shouldFire) {
-      console.log(`  PASS  ${testCase.label}`);
-    } else {
-      failures += 1;
-      console.error(
-        `  FAIL  ${testCase.label}\n        rule ${testCase.rule} fired=${String(fired)}, expected=${String(testCase.shouldFire)}`,
-      );
-    }
+    return (result?.messages ?? []).some((m) => m.ruleId === testCase.rule);
   } finally {
     rmSync(absolute, { force: true });
+  }
+};
+
+for (const testCase of CASES) {
+  const fired = await runCase(testCase);
+  if (fired === testCase.shouldFire) {
+    console.log(`  PASS  ${testCase.label}`);
+  } else {
+    failures += 1;
+    console.error(
+      `  FAIL  ${testCase.label}\n        rule ${testCase.rule} fired=${String(fired)}, expected=${String(testCase.shouldFire)}`,
+    );
   }
 }
 

--- a/tools/eslint-plugin-occasio/rules/no-raw-shadow-props.js
+++ b/tools/eslint-plugin-occasio/rules/no-raw-shadow-props.js
@@ -26,7 +26,10 @@ const SHADOW_PROPERTIES = new Set([
  * limit of static analysis rather than a hole anyone can aim for.
  */
 const staticKeyName = (key) => {
-  if (key.type === 'Identifier') return key.name;
+  /* Deliberately no Identifier branch. In `{ [boxShadow]: 1 }` the identifier is a *reference*
+     — the property written is whatever that variable holds, which may be anything — so reading
+     `key.name` would report a raw shadow prop for code that writes `dataKey`. Only a key whose
+     text is the key qualifies. */
   if (key.type === 'Literal' && typeof key.value === 'string') return key.value;
   if (key.type === 'TemplateLiteral' && key.expressions.length === 0) {
     return key.quasis[0]?.value.cooked ?? null;

--- a/tools/eslint-plugin-occasio/rules/no-raw-shadow-props.js
+++ b/tools/eslint-plugin-occasio/rules/no-raw-shadow-props.js
@@ -16,8 +16,28 @@ const SHADOW_PROPERTIES = new Set([
   'elevation',
 ]);
 
+/**
+ * The property this node writes, or `null` when it cannot be known without running the code.
+ *
+ * Computed keys are read rather than skipped. `{ ['boxShadow']: … }` and `{ [`elevation`]: … }`
+ * produce exactly the property this rule exists to ban, and skipping every computed key made
+ * the brackets an opt-out — which is the shape of an escape hatch, not of a rule. A key built
+ * from a variable still returns `null`, because there is nothing to compare against; that is a
+ * limit of static analysis rather than a hole anyone can aim for.
+ */
+const staticKeyName = (key) => {
+  if (key.type === 'Identifier') return key.name;
+  if (key.type === 'Literal' && typeof key.value === 'string') return key.value;
+  if (key.type === 'TemplateLiteral' && key.expressions.length === 0) {
+    return key.quasis[0]?.value.cooked ?? null;
+  }
+  return null;
+};
+
 const propertyName = (node) => {
-  if (node.computed) return null;
+  /* An unbracketed key is an Identifier or a string Literal; a bracketed one is any expression,
+     and only the ones with a knowable value are checked. */
+  if (node.computed) return staticKeyName(node.key);
   if (node.key.type === 'Identifier') return node.key.name;
   if (node.key.type === 'Literal' && typeof node.key.value === 'string') return node.key.value;
   return null;

--- a/tools/review/check-reviewed.mjs
+++ b/tools/review/check-reviewed.mjs
@@ -127,18 +127,37 @@ const claudeReviewed = rateLimited && (claudeFindings > 0 || claudeComment);
  * commit changing who may read invitation contact details, eight minutes after the review it
  * appeared to have.
  */
-const timestamps = [
-  ...reviews.filter((r) => byReviewer(r) || byClaude(r)).map((r) => r.submitted_at),
-  ...reviewComments.filter((c) => byReviewer(c) || byClaude(c)).map((c) => c.created_at),
-  ...issueComments.filter((c) => byReviewer(c) || byClaude(c)).map((c) => c.created_at),
+/*
+ * Only evidence that could make `reviewed` true may date it. Any reviewer comment would be
+ * wrong here in a specific and useful way: "Review limit reached" is posted by the reviewer,
+ * after the commit, and says a review did *not* happen — counting it would let the one comment
+ * that means "unreviewed" certify a stale review as fresh. Claude's activity is admitted only
+ * on the condition D42 gives it, matching `claudeReviewed` above.
+ */
+const reviewEvidence = [
+  ...reviews.filter((r) => byReviewer(r) && r.submitted_at != null).map((r) => r.submitted_at),
+  ...reviewComments.filter(byReviewer).map((c) => c.created_at),
+  ...issueComments
+    .filter((c) => byReviewer(c) && c.body.includes('Walkthrough'))
+    .map((c) => c.created_at),
+  ...(rateLimited
+    ? [
+        ...reviewComments.filter(byClaude).map((c) => c.created_at),
+        ...issueComments.filter(byClaude).map((c) => c.created_at),
+      ]
+    : []),
 ].filter((value) => value != null);
-const lastReviewAt = timestamps.length === 0 ? null : timestamps.sort().at(-1);
+const lastReviewAt = reviewEvidence.length === 0 ? null : reviewEvidence.sort().at(-1);
 
 const headCommit = await apiOne(`/repos/${REPO}/commits/${prData.head.sha}`);
 const headAt = headCommit.commit?.committer?.date ?? null;
-/* Unknown timestamps must not read as fresh: an absent one is a reason to look, not to pass. */
+/*
+ * Fails closed. An absent timestamp is a reason to look rather than to pass, and treating one
+ * as `not stale` would have made every unknown a quiet approval — which is the failure this
+ * whole file exists to answer, reintroduced by its newest check.
+ */
 const stale =
-  lastReviewAt === null || headAt === null ? false : Date.parse(headAt) > Date.parse(lastReviewAt);
+  lastReviewAt == null || headAt === null ? true : Date.parse(headAt) > Date.parse(lastReviewAt);
 
 const reviewed = walkthrough || findings > 0 || submitted > 0 || claudeReviewed;
 
@@ -156,7 +175,9 @@ console.log(`  head commit : ${prData.head.sha.slice(0, 7)} ${headAt ?? 'unknown
 
 if (reviewed && stale) {
   console.error(
-    `\nNOT REVIEWED. Head commit ${prData.head.sha.slice(0, 7)} (${String(headAt)}) is newer than the last review (${String(lastReviewAt)}).`,
+    lastReviewAt == null || headAt === null
+      ? `\nNOT REVIEWED. Could not date the review (${String(lastReviewAt)}) or the head commit (${String(headAt)}), so freshness cannot be established.`
+      : `\nNOT REVIEWED. Head commit ${prData.head.sha.slice(0, 7)} (${String(headAt)}) is newer than the last review (${String(lastReviewAt)}).`,
   );
   console.error(
     'The pull request has been reviewed; the code about to merge has not. Wait for the',

--- a/tools/review/check-reviewed.mjs
+++ b/tools/review/check-reviewed.mjs
@@ -110,7 +110,35 @@ const submitted = reviews.filter((r) => byReviewer(r) && r.submitted_at != null)
 const byClaude = (item) => (item.user?.login ?? '') === CLAUDE_REVIEWER_LOGIN;
 const claudeFindings = reviewComments.filter(byClaude).length;
 const claudeComment = issueComments.some(byClaude);
-const claudeReviewed = claudeFindings > 0 || claudeComment;
+/*
+ * Claude counts as a reviewer only where D42 puts it: standing in for CodeRabbit after the
+ * budget ran out. Without the `rateLimited` conjunct, any Claude comment on any PR — a reply in
+ * a thread, an answer to a question, anything the app posts — satisfied this gate, so the
+ * fallback reviewer doubled as a way to skip review entirely.
+ */
+const claudeReviewed = rateLimited && (claudeFindings > 0 || claudeComment);
+
+/*
+ * When the newest review happened, and when the code it would have read was written.
+ *
+ * A review is of a commit, not of a pull request. Push a fix after the review and the PR still
+ * carries a walkthrough, findings and a submitted review — every signal below is still true —
+ * while the diff that is about to land has been read by nobody. On #134 that was a 374-line
+ * commit changing who may read invitation contact details, eight minutes after the review it
+ * appeared to have.
+ */
+const timestamps = [
+  ...reviews.filter((r) => byReviewer(r) || byClaude(r)).map((r) => r.submitted_at),
+  ...reviewComments.filter((c) => byReviewer(c) || byClaude(c)).map((c) => c.created_at),
+  ...issueComments.filter((c) => byReviewer(c) || byClaude(c)).map((c) => c.created_at),
+].filter((value) => value != null);
+const lastReviewAt = timestamps.length === 0 ? null : timestamps.sort().at(-1);
+
+const headCommit = await apiOne(`/repos/${REPO}/commits/${prData.head.sha}`);
+const headAt = headCommit.commit?.committer?.date ?? null;
+/* Unknown timestamps must not read as fresh: an absent one is a reason to look, not to pass. */
+const stale =
+  lastReviewAt === null || headAt === null ? false : Date.parse(headAt) > Date.parse(lastReviewAt);
 
 const reviewed = walkthrough || findings > 0 || submitted > 0 || claudeReviewed;
 
@@ -123,6 +151,19 @@ console.log(`  findings    : ${String(findings)}`);
 console.log(`  reviews     : ${String(submitted)}`);
 console.log(`  rate limited: ${String(rateLimited)}`);
 console.log(`  claude      : ${String(claudeReviewed)} (findings: ${String(claudeFindings)})`);
+console.log(`  last review : ${lastReviewAt ?? 'none'}`);
+console.log(`  head commit : ${prData.head.sha.slice(0, 7)} ${headAt ?? 'unknown'}`);
+
+if (reviewed && stale) {
+  console.error(
+    `\nNOT REVIEWED. Head commit ${prData.head.sha.slice(0, 7)} (${String(headAt)}) is newer than the last review (${String(lastReviewAt)}).`,
+  );
+  console.error(
+    'The pull request has been reviewed; the code about to merge has not. Wait for the',
+  );
+  console.error('incremental review of this commit, which normally lands within a few minutes.');
+  process.exit(1);
+}
 
 if (!reviewed) {
   console.error(


### PR DESCRIPTION
Three findings from the retrospective review in #132, plus #136 found while running the loop. All four are the same shape: **a check that passes while not exercising what it claims.**

### Bracketed keys walked past the shadow rule

`no-raw-shadow-props` returned early on every computed key, so this got no diagnostic:

```ts
style={{ ['boxShadow']: '0 1px 2px #000' }}
```

That is the exact property the rule exists to ban, written with two extra characters. Static keys are now read — string literals, and template literals with no expressions. A key built from a variable still returns `null`, which is a limit of static analysis rather than a hole anyone can aim at.

### The exemption glob covered its own probe

`packages/ui/src/theme/elevation*.ts` exempted the two translator files from the shadow rule — and also `elevation__enforcement_probe.ts`, which is the probe whose job was to prove the exemption worked.

So the probe passed because the glob matched *its own name*. It would have kept passing if the exemption had stopped covering `elevation.ts` altogether, which is the only thing it was supposed to be checking. It would also have silently exempted any future `elevationCard.ts`.

Now two exact paths, and the probe lints in memory at the real translator path via `ESLint#lintText` — nothing may write over a real source file. I verified it by pointing the exemption at a path that does not exist: the probe fails. The old one could not.

### Claude counted as a reviewer outside the case D42 gives it

`check-reviewed` accepted any `claude[bot]` comment as evidence of a review, with no requirement that CodeRabbit had actually been rate limited. Any Claude comment on any PR satisfied the gate — the fallback reviewer doubled as a way around review. Now conjoined with `rateLimited`.

### A review is of a commit, not of a pull request (#136)

Not from the review; found by hitting it. Push a fix after the review and the PR still carries a walkthrough, findings and a submitted review — every signal the gate reads is still true — while the diff about to land has been read by nobody.

This happened on #134 an hour ago. CodeRabbit reviewed at `07:46:00Z`; I pushed `7025acf` at `07:54:04Z` — 374 lines including a change to who may read invitation contact details. `check:reviewed` said **Reviewed** and the PR looked mergeable. I held it by hand, which is exactly the judgement the gate is supposed to make for me.

It now compares the head commit's date against the newest reviewer activity:

```
  last review : 2026-09-06T07:46:00Z
  head commit : 7025acf 2026-09-06T07:54:04Z

NOT REVIEWED. Head commit 7025acf is newer than the last review.
```

Exit codes checked against three live PRs: #134 → 1 (stale), #120 → 0 (reviewed after its head), #126 → 1 (never reviewed).

Enforcement probes: 8 → 9.

Closes #136.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145VPJXGgJA9PWqeNXDr1DG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved linting accuracy for statically determinable computed property names, while preserving handling for dynamic expressions.
  - Tightened validation of elevation-related styling exemptions to ensure they apply only to the intended files.

- **Chores**
  - Improved enforcement checks with more reliable test-path handling and centralised result validation.
  - Updated review verification to accept only relevant, current review evidence and clearly report stale approvals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->