### PR TITLE
fix(tools): a rebase is not a change, so it does not need a new review

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -28,7 +28,8 @@ const modulePathIgnorePatterns = ['<rootDir>/.claude/'];
  * the files do not import React, because with the automatic runtime they do not have to.
  */
 const transform = {
-  '^.+\\.(t|j)sx?$': [
+  /* `.mjs` included: the tools are written as ES modules and are tested like anything else. */
+  '^.+\\.(m?[tj]s|[tj]sx)$': [
     '@swc/jest',
     {
       jsc: {
@@ -50,6 +51,9 @@ export default {
         '<rootDir>/packages/*/src/**/*.test.tsx',
         // App-level logic is testable too — navigation ordering is pure and had a real bug.
         '<rootDir>/apps/*/src/**/*.test.ts',
+        /* The tools decide what merges and what lints. They are not support scripts to this
+           repo, they are part of it, and the ones with real logic are tested like it. */
+        '<rootDir>/tools/**/*.test.ts',
       ],
       testPathIgnorePatterns: ['\\.contract\\.test\\.', '\\.dom\\.test\\.'],
       moduleNameMapper,

--- a/tools/review/check-reviewed.mjs
+++ b/tools/review/check-reviewed.mjs
@@ -16,7 +16,7 @@
  *   requests also work, at a lower rate limit.
  */
 import { readFileSync } from 'node:fs';
-import { COMPARE_FILE_CAP, diffFingerprint } from './diffFingerprint.mjs';
+import { COMPARE_FILE_CAP, diffFingerprint, isDescribable } from './diffFingerprint.mjs';
 
 /**
  * Exact logins, not a substring match.
@@ -178,7 +178,7 @@ const effectiveDiff = async (sha) => {
     if (files.length >= COMPARE_FILE_CAP) return null;
     /* A file with neither a patch nor a blob sha is a file this cannot describe. Both would
        serialise as `binary:unknown`, which is one unknown matching another. */
-    if (files.some((f) => f.patch === undefined && f.sha === undefined)) return null;
+    if (!files.every(isDescribable)) return null;
     return diffFingerprint(files);
   } catch {
     /* A force-pushed commit can fall out of reach. Unknown is not "unchanged". */

--- a/tools/review/check-reviewed.mjs
+++ b/tools/review/check-reviewed.mjs
@@ -16,7 +16,7 @@
  *   requests also work, at a lower rate limit.
  */
 import { readFileSync } from 'node:fs';
-import { diffFingerprint } from './diffFingerprint.mjs';
+import { COMPARE_FILE_CAP, diffFingerprint } from './diffFingerprint.mjs';
 
 /**
  * Exact logins, not a substring match.
@@ -165,7 +165,14 @@ const effectiveDiff = async (sha) => {
     const comparison = await apiOne(
       `/repos/${REPO}/compare/${prData.base.ref}...${sha}?per_page=300`,
     );
-    return diffFingerprint(comparison.files ?? []);
+    const files = comparison.files ?? [];
+    /*
+     * The endpoint stops at 300 files. At the cap the list is truncated, so two different large
+     * pull requests can fingerprint identically while an unlisted file differs — and this
+     * function's answer is used to skip a review. Unknown, not equal.
+     */
+    if (files.length >= COMPARE_FILE_CAP) return null;
+    return diffFingerprint(files);
   } catch {
     /* A force-pushed commit can fall out of reach. Unknown is not "unchanged". */
     return null;

--- a/tools/review/check-reviewed.mjs
+++ b/tools/review/check-reviewed.mjs
@@ -16,6 +16,7 @@
  *   requests also work, at a lower rate limit.
  */
 import { readFileSync } from 'node:fs';
+import { diffFingerprint } from './diffFingerprint.mjs';
 
 /**
  * Exact logins, not a substring match.
@@ -151,13 +152,61 @@ const lastReviewAt = reviewEvidence.length === 0 ? null : reviewEvidence.sort().
 
 const headCommit = await apiOne(`/repos/${REPO}/commits/${prData.head.sha}`);
 const headAt = headCommit.commit?.committer?.date ?? null;
+
+/**
+ * The change a commit proposes, independent of where it sits in history.
+ *
+ * `/compare/base...head` is three-dot, so it reports the difference from the merge base — the
+ * pull request's own changes, without whatever the base branch has done since. Hashing the
+ * patches gives a value that survives a rebase and moves the moment a line does.
+ */
+const effectiveDiff = async (sha) => {
+  try {
+    const comparison = await apiOne(
+      `/repos/${REPO}/compare/${prData.base.ref}...${sha}?per_page=300`,
+    );
+    return diffFingerprint(comparison.files ?? []);
+  } catch {
+    /* A force-pushed commit can fall out of reach. Unknown is not "unchanged". */
+    return null;
+  }
+};
+
+/*
+ * A rebase is not a change to the code.
+ *
+ * Branch protection requires a branch to be up to date, so every open PR is rebased whenever
+ * `main` moves — and the head commit is then newer than its review while proposing exactly the
+ * same diff. CodeRabbit will not re-review that, correctly, because there is nothing new to
+ * read, so a date comparison alone leaves the PR stuck between a gate wanting a review and a
+ * reviewer with no reason to give one (#140).
+ *
+ * So the date is the cheap check and the diff is the authority: when the newest review sits on
+ * a commit proposing the same effective diff as the head, the review still applies. Any real
+ * edit changes the patches and this stops helping, which is the point.
+ */
+const reviewedSha = [...reviews]
+  .filter((r) => byReviewer(r) && r.submitted_at != null)
+  .sort((a, b) => (a.submitted_at < b.submitted_at ? -1 : 1))
+  .at(-1)?.commit_id;
+
+const sameDiffAsReviewed = async () => {
+  if (reviewedSha === undefined || reviewedSha === prData.head.sha) return false;
+  const [reviewedDiff, headDiff] = await Promise.all([
+    effectiveDiff(reviewedSha),
+    effectiveDiff(prData.head.sha),
+  ]);
+  return reviewedDiff !== null && headDiff !== null && reviewedDiff === headDiff;
+};
 /*
  * Fails closed. An absent timestamp is a reason to look rather than to pass, and treating one
  * as `not stale` would have made every unknown a quiet approval — which is the failure this
  * whole file exists to answer, reintroduced by its newest check.
  */
-const stale =
+const newerThanReview =
   lastReviewAt == null || headAt === null ? true : Date.parse(headAt) > Date.parse(lastReviewAt);
+const rebasedOnly = newerThanReview && (await sameDiffAsReviewed());
+const stale = newerThanReview && !rebasedOnly;
 
 const reviewed = walkthrough || findings > 0 || submitted > 0 || claudeReviewed;
 
@@ -172,6 +221,11 @@ console.log(`  rate limited: ${String(rateLimited)}`);
 console.log(`  claude      : ${String(claudeReviewed)} (findings: ${String(claudeFindings)})`);
 console.log(`  last review : ${lastReviewAt ?? 'none'}`);
 console.log(`  head commit : ${prData.head.sha.slice(0, 7)} ${headAt ?? 'unknown'}`);
+if (rebasedOnly) {
+  console.log(
+    `  rebase only : yes — same effective diff as the reviewed commit ${String(reviewedSha).slice(0, 7)}`,
+  );
+}
 
 if (reviewed && stale) {
   console.error(

--- a/tools/review/check-reviewed.mjs
+++ b/tools/review/check-reviewed.mjs
@@ -165,13 +165,20 @@ const effectiveDiff = async (sha) => {
     const comparison = await apiOne(
       `/repos/${REPO}/compare/${prData.base.ref}...${sha}?per_page=300`,
     );
-    const files = comparison.files ?? [];
     /*
-     * The endpoint stops at 300 files. At the cap the list is truncated, so two different large
-     * pull requests can fingerprint identically while an unlisted file differs — and this
-     * function's answer is used to skip a review. Unknown, not equal.
+     * Everything below fails closed, because this function's answer is used to skip a review and
+     * every uncertainty here is shaped the same way: two incomplete comparisons produce equal
+     * fingerprints, and equal reads as "already reviewed".
      */
+    const files = comparison.files;
+    /* An absent list fingerprints as the empty string, and so does another absent list. */
+    if (!Array.isArray(files)) return null;
+    /* The endpoint stops at 300 files; at the cap the list is truncated, so a file nobody
+       listed can differ while the two fingerprints match. */
     if (files.length >= COMPARE_FILE_CAP) return null;
+    /* A file with neither a patch nor a blob sha is a file this cannot describe. Both would
+       serialise as `binary:unknown`, which is one unknown matching another. */
+    if (files.some((f) => f.patch === undefined && f.sha === undefined)) return null;
     return diffFingerprint(files);
   } catch {
     /* A force-pushed commit can fall out of reach. Unknown is not "unchanged". */

--- a/tools/review/diffFingerprint.d.mts
+++ b/tools/review/diffFingerprint.d.mts
@@ -13,9 +13,10 @@ export type ComparedFile = {
   /** Set by GitHub only for a rename; the path the file came from. */
   readonly previous_filename?: string | undefined;
   readonly status?: string | undefined;
-  readonly patch?: string | undefined;
-  readonly sha?: string | undefined;
+  readonly patch?: string | null | undefined;
+  readonly sha?: string | null | undefined;
 };
 
 export declare const COMPARE_FILE_CAP: number;
+export declare const isDescribable: (file: ComparedFile) => boolean;
 export declare const diffFingerprint: (files: readonly ComparedFile[]) => string;

--- a/tools/review/diffFingerprint.d.mts
+++ b/tools/review/diffFingerprint.d.mts
@@ -1,0 +1,18 @@
+/**
+ * Types for the `.mjs` module beside this file.
+ *
+ * It stays `.mjs` because `check-reviewed.mjs` runs under plain `node` in CI, with no build
+ * step and no loader — a `.ts` module could not be imported there. The declaration is what
+ * lets the test import it without a `@ts-expect-error`, which would have switched off exactly
+ * the checking this repo relies on.
+ */
+
+/** One entry of GitHub's compare response, narrowed to the fields the fingerprint reads. */
+export type ComparedFile = {
+  readonly filename?: string | undefined;
+  readonly status?: string | undefined;
+  readonly patch?: string | undefined;
+  readonly sha?: string | undefined;
+};
+
+export declare const diffFingerprint: (files: readonly ComparedFile[]) => string;

--- a/tools/review/diffFingerprint.d.mts
+++ b/tools/review/diffFingerprint.d.mts
@@ -10,9 +10,12 @@
 /** One entry of GitHub's compare response, narrowed to the fields the fingerprint reads. */
 export type ComparedFile = {
   readonly filename?: string | undefined;
+  /** Set by GitHub only for a rename; the path the file came from. */
+  readonly previous_filename?: string | undefined;
   readonly status?: string | undefined;
   readonly patch?: string | undefined;
   readonly sha?: string | undefined;
 };
 
+export declare const COMPARE_FILE_CAP: number;
 export declare const diffFingerprint: (files: readonly ComparedFile[]) => string;

--- a/tools/review/diffFingerprint.mjs
+++ b/tools/review/diffFingerprint.mjs
@@ -1,0 +1,35 @@
+/**
+ * A stable identity for the change a pull request proposes.
+ *
+ * Built from GitHub's three-dot comparison, so it describes the difference from the merge base
+ * — the PR's own changes, without whatever the base branch has done since. That is what makes
+ * it survive a rebase: the commit is new, its parent is new, and the change is the same one
+ * somebody already read.
+ *
+ * Used by check-reviewed.mjs to tell "this was rebased" from "this was edited". Getting that
+ * distinction wrong in the permissive direction would let an edit ride in on an old review, so
+ * the rules below are deliberately strict: anything unknown compares as different.
+ */
+
+/**
+ * @param {{ filename?: string, patch?: string, sha?: string, status?: string }[]} files
+ * @returns {string}
+ */
+export const diffFingerprint = (files) =>
+  files
+    .map((file) => {
+      const name = file.filename ?? '';
+      /*
+       * A binary file has no patch, and its blob sha is the only thing that distinguishes one
+       * version from another. Falling back to the empty string instead would make every binary
+       * change invisible here — two different images would fingerprint identically.
+       */
+      const body = file.patch ?? `binary:${file.sha ?? 'unknown'}`;
+      /* The status matters on its own: deleting a file and adding it back with the same
+         contents is not the same change as leaving it alone. */
+      return `${name}\n${file.status ?? 'unknown'}\n${body}`;
+    })
+    /* Sorted, because the API does not promise a stable file order between calls, and a
+       fingerprint that depends on response ordering would report spurious differences. */
+    .sort()
+    .join('\n--\n');

--- a/tools/review/diffFingerprint.mjs
+++ b/tools/review/diffFingerprint.mjs
@@ -12,13 +12,26 @@
  */
 
 /**
- * @param {{ filename?: string, patch?: string, sha?: string, status?: string }[]} files
+ * The most files GitHub's compare endpoint will report. A comparison at the cap is truncated,
+ * and a fingerprint built from a truncated list can match while an unlisted file differs — so
+ * the caller must treat it as unknown rather than as a comparison.
+ */
+export const COMPARE_FILE_CAP = 300;
+
+/**
+ * @param {{ filename?: string, previous_filename?: string, patch?: string, sha?: string, status?: string }[]} files
  * @returns {string}
  */
 export const diffFingerprint = (files) =>
   files
     .map((file) => {
       const name = file.filename ?? '';
+      /*
+       * Where a rename came from. Two renames landing on the same path with the same contents
+       * are the same patch and the same status, and differ only here — without it, moving
+       * `secrets.ts` to `config.ts` fingerprints identically to moving `readme.ts` to it.
+       */
+      const from = file.previous_filename ?? 'none';
       /*
        * A binary file has no patch, and its blob sha is the only thing that distinguishes one
        * version from another. Falling back to the empty string instead would make every binary
@@ -27,7 +40,7 @@ export const diffFingerprint = (files) =>
       const body = file.patch ?? `binary:${file.sha ?? 'unknown'}`;
       /* The status matters on its own: deleting a file and adding it back with the same
          contents is not the same change as leaving it alone. */
-      return `${name}\n${file.status ?? 'unknown'}\n${body}`;
+      return `${name}\n${from}\n${file.status ?? 'unknown'}\n${body}`;
     })
     /* Sorted, because the API does not promise a stable file order between calls, and a
        fingerprint that depends on response ordering would report spurious differences. */

--- a/tools/review/diffFingerprint.mjs
+++ b/tools/review/diffFingerprint.mjs
@@ -19,6 +19,22 @@
 export const COMPARE_FILE_CAP = 300;
 
 /**
+ * Whether a file carries enough to tell one version of it from another.
+ *
+ * A file with neither a patch nor a blob sha serialises to `binary:unknown`, and so does every
+ * other such file — one unknown matching another, in the function whose answer decides whether
+ * a review can be skipped. `null` counts as absent as well as `undefined`, because these values
+ * come off the wire as JSON and a null is what an absent field often arrives as.
+ *
+ * Exported and tested rather than inlined at the call site: the first version of this guard was
+ * written inline against `undefined` only, and nothing could have caught that it missed `null`.
+ *
+ * @param {{ patch?: string | null, sha?: string | null }} file
+ * @returns {boolean}
+ */
+export const isDescribable = (file) => (file.patch ?? file.sha ?? null) !== null;
+
+/**
  * @param {{ filename?: string, previous_filename?: string, patch?: string, sha?: string, status?: string }[]} files
  * @returns {string}
  */

--- a/tools/review/diffFingerprint.test.ts
+++ b/tools/review/diffFingerprint.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from '@jest/globals';
-import { diffFingerprint, type ComparedFile } from './diffFingerprint.mjs';
+import { COMPARE_FILE_CAP, diffFingerprint, type ComparedFile } from './diffFingerprint.mjs';
 
 /**
  * The rule this encodes: a rebase is not a change, and everything else is.
@@ -61,6 +61,38 @@ describe('diffFingerprint', () => {
        asserted so that the weakness stays visible rather than being discovered later. */
     const unknown = { filename: 'assets/hero.png', status: 'modified' };
     expect(diffFingerprint([unknown])).toContain('binary:unknown');
+  });
+
+  it('separates two renames that land on the same path with the same contents', () => {
+    /* Same destination, same patch, same status -- the source path is the only difference, and
+       without it moving `secrets.ts` to `config.ts` fingerprints identically to moving
+       `readme.ts` there. */
+    const fromSecrets = file({
+      filename: 'src/config.ts',
+      status: 'renamed',
+      previous_filename: 'src/secrets.ts',
+    });
+    const fromReadme = file({
+      filename: 'src/config.ts',
+      status: 'renamed',
+      previous_filename: 'src/readme.ts',
+    });
+
+    expect(diffFingerprint([fromSecrets])).not.toBe(diffFingerprint([fromReadme]));
+  });
+
+  it('separates a rename from an ordinary edit of the destination', () => {
+    expect(
+      diffFingerprint([
+        file({ filename: 'src/config.ts', status: 'renamed', previous_filename: 'src/old.ts' }),
+      ]),
+    ).not.toBe(diffFingerprint([file({ filename: 'src/config.ts', status: 'renamed' })]));
+  });
+
+  it('names the cap the caller has to fail closed on', () => {
+    /* The fingerprint itself cannot detect truncation -- it only sees the list it is handed --
+       so the cap lives here and check-reviewed refuses at it. Pinned so the two cannot drift. */
+    expect(COMPARE_FILE_CAP).toBe(300);
   });
 
   it('reports an empty comparison distinctly from a one-file one', () => {

--- a/tools/review/diffFingerprint.test.ts
+++ b/tools/review/diffFingerprint.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from '@jest/globals';
-import { COMPARE_FILE_CAP, diffFingerprint, type ComparedFile } from './diffFingerprint.mjs';
+import {
+  COMPARE_FILE_CAP,
+  diffFingerprint,
+  isDescribable,
+  type ComparedFile,
+} from './diffFingerprint.mjs';
 
 /**
  * The rule this encodes: a rebase is not a change, and everything else is.
@@ -98,5 +103,31 @@ describe('diffFingerprint', () => {
   it('reports an empty comparison distinctly from a one-file one', () => {
     expect(diffFingerprint([])).toBe('');
     expect(diffFingerprint([file()])).not.toBe('');
+  });
+});
+
+describe('isDescribable', () => {
+  it('accepts a file with a patch, or with only a blob sha', () => {
+    expect(isDescribable({ patch: '@@ -1 +1 @@' })).toBe(true);
+    expect(isDescribable({ sha: 'abc123' })).toBe(true);
+  });
+
+  it('rejects a file with neither', () => {
+    /* Two of these fingerprint identically as `binary:unknown`, which would read as "nothing
+       changed since the review". */
+    expect(isDescribable({})).toBe(false);
+  });
+
+  it('treats null the same as absent', () => {
+    /* These arrive as JSON, where an absent field is often an explicit null. The first version
+       of this guard compared against `undefined` only and let both nulls through. */
+    expect(isDescribable({ patch: null, sha: null })).toBe(false);
+    expect(isDescribable({ patch: null, sha: 'abc123' })).toBe(true);
+    expect(isDescribable({ patch: '@@ -1 +1 @@', sha: null })).toBe(true);
+  });
+
+  it('accepts an empty patch, which is a real value', () => {
+    /* A pure rename has an empty patch rather than no patch, and it is describable. */
+    expect(isDescribable({ patch: '' })).toBe(true);
   });
 });

--- a/tools/review/diffFingerprint.test.ts
+++ b/tools/review/diffFingerprint.test.ts
@@ -55,11 +55,11 @@ describe('diffFingerprint', () => {
     expect(diffFingerprint([one])).not.toBe(diffFingerprint([two]));
   });
 
-  it('does not treat a missing sha as equal to another missing sha', () => {
-    /* Two unknowns are not a match. They fingerprint identically here, which is why
-       check-reviewed treats an unreachable comparison as "different" before it gets this far —
-       asserted so that the weakness stays visible rather than being discovered later. */
-    const unknown = { filename: 'assets/hero.png', status: 'modified' };
+  it('marks a file it cannot describe, so the caller can refuse it', () => {
+    /* Two unknowns are not a match, but they fingerprint identically here — this function sees
+       only the list it is handed. `check-reviewed` refuses such a file before calling in, and
+       the marker is asserted so the two halves of that arrangement cannot drift apart. */
+    const unknown: ComparedFile = { filename: 'assets/hero.png', status: 'modified' };
     expect(diffFingerprint([unknown])).toContain('binary:unknown');
   });
 

--- a/tools/review/diffFingerprint.test.ts
+++ b/tools/review/diffFingerprint.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from '@jest/globals';
+import { diffFingerprint, type ComparedFile } from './diffFingerprint.mjs';
+
+/**
+ * The rule this encodes: a rebase is not a change, and everything else is.
+ *
+ * It decides whether an existing review still applies to the commit about to merge, so a false
+ * "same" is a way to land unreviewed code — the failure #128 is about. The cases below are
+ * therefore weighted toward proving it reports *different* whenever it cannot be sure.
+ */
+
+const file = (over: Partial<ComparedFile> = {}): ComparedFile => ({
+  filename: 'packages/ui/src/Button.tsx',
+  status: 'modified',
+  patch: '@@ -1 +1 @@\n-old\n+new',
+  ...over,
+});
+
+describe('diffFingerprint', () => {
+  it('is unchanged by the order the API returns files in', () => {
+    /* The reason this exists at all: the comparison endpoint does not promise an order, and a
+       fingerprint that depended on one would report a rebase as an edit at random. */
+    const a = file();
+    const b = file({ filename: 'packages/ui/src/Text.tsx' });
+
+    expect(diffFingerprint([a, b])).toBe(diffFingerprint([b, a]));
+  });
+
+  it('changes when a single line of a patch changes', () => {
+    expect(diffFingerprint([file()])).not.toBe(
+      diffFingerprint([file({ patch: '@@ -1 +1 @@\n-old\n+newer' })]),
+    );
+  });
+
+  it('changes when the same patch moves to a different file', () => {
+    expect(diffFingerprint([file()])).not.toBe(
+      diffFingerprint([file({ filename: 'packages/ui/src/Other.tsx' })]),
+    );
+  });
+
+  it('changes when a file is added and removed rather than left alone', () => {
+    /* Deleting a file and adding it back with identical contents nets out to nothing in the
+       patches, and is not the same change. */
+    expect(diffFingerprint([file({ status: 'modified' })])).not.toBe(
+      diffFingerprint([file({ status: 'added' })]),
+    );
+  });
+
+  it('distinguishes two different binaries, which have no patch at all', () => {
+    /* Without the sha fallback both would fingerprint as the empty string, and swapping one
+       image for another would read as "nothing changed since the review". */
+    const one = { filename: 'assets/hero.png', status: 'modified', sha: 'aaa111' };
+    const two = { filename: 'assets/hero.png', status: 'modified', sha: 'bbb222' };
+
+    expect(diffFingerprint([one])).not.toBe(diffFingerprint([two]));
+  });
+
+  it('does not treat a missing sha as equal to another missing sha', () => {
+    /* Two unknowns are not a match. They fingerprint identically here, which is why
+       check-reviewed treats an unreachable comparison as "different" before it gets this far —
+       asserted so that the weakness stays visible rather than being discovered later. */
+    const unknown = { filename: 'assets/hero.png', status: 'modified' };
+    expect(diffFingerprint([unknown])).toContain('binary:unknown');
+  });
+
+  it('reports an empty comparison distinctly from a one-file one', () => {
+    expect(diffFingerprint([])).toBe('');
+    expect(diffFingerprint([file()])).not.toBe('');
+  });
+});


### PR DESCRIPTION
Closes #140.

Branch protection requires a branch to be up to date, so **every open PR is rebased whenever `main` moves**. The freshness check from #137 then sees a head commit newer than its review and refuses — while CodeRabbit will not re-review, correctly, because a rebase with no content change gives it nothing new to read.

The PR is stuck between a gate wanting a review and a reviewer with no reason to produce one. #134 hit this twice in twenty minutes. Since every merge re-blocks every other open PR, this is the ordinary case, not an edge one.

### The fix

The date becomes the cheap check and the diff becomes the authority. `/compare/{base}...{head}` is three-dot, so it reports the difference from the merge base — the PR's own changes, without whatever the base branch has done since. When the newest review sits on a commit proposing the same effective diff as the head, the review still applies.

### Proved in both directions before wiring it in

Against #134's real commits:

| comparison | result |
|---|---|
| reviewed commit `7a244b9` vs its rebased self `a78211e` | 149,990 chars each, **identical** → rebase, review still applies |
| pre-serialisation `7025acf` vs head `a78211e` | 144,562 vs 149,990, **different** → real edit, review required |

So a rebase passes and an edit does not. That second row is the one that matters: a change to who may read invitation contact details must not ride in on an older review.

### `diffFingerprint` is its own module with its own suite

A false "same" here is a way to land unreviewed code — #128 with a new door — so the cases are weighted toward proving it reports **different** whenever it cannot be sure:

- a changed line, a moved file, a changed status (deleting and re-adding a file is not "no change")
- two binaries with no patch at all, which the `sha` fallback separates and an empty-string fallback would have silently merged into one
- file order, which the API does not promise, asserted *not* to affect the result — a fingerprint that depended on response ordering would report a rebase as an edit at random

It ships as `.mjs` with a `.d.mts` beside it rather than as TypeScript, because `check-reviewed.mjs` runs under plain `node` in CI with no build step or loader. The declaration is what lets the test import it without a `@ts-expect-error` — which would have switched off precisely the checking this change most needs.

### Also

Jest now runs `tools/**/*.test.ts`. The tools decide what merges and what lints; they are part of this repo rather than support scripts to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145VPJXGgJA9PWqeNXDr1DG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Pull request review checks now distinguish genuine content changes from rebase-only updates.
  - Review checks provide clearer feedback when a branch has been rebased without changing its effective diff.
  - Checks now treat incomplete or uncertain comparison data as requiring review.

- **Tests**
  - Expanded automated test discovery to include additional test locations and module formats.
  - Added coverage for comparing file changes consistently, including renamed, binary, reordered, and incomplete file data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->