### PR TITLE
fix(tools): a diff that is a subset of the reviewed one is still reviewed

### DIFF
--- a/tools/review/check-reviewed.mjs
+++ b/tools/review/check-reviewed.mjs
@@ -16,7 +16,7 @@
  *   requests also work, at a lower rate limit.
  */
 import { readFileSync } from 'node:fs';
-import { COMPARE_FILE_CAP, diffFingerprint, isDescribable } from './diffFingerprint.mjs';
+import { COMPARE_FILE_CAP, coversAllOf, diffEntries, isDescribable } from './diffFingerprint.mjs';
 
 /**
  * Exact logins, not a substring match.
@@ -179,7 +179,7 @@ const effectiveDiff = async (sha) => {
     /* A file with neither a patch nor a blob sha is a file this cannot describe. Both would
        serialise as `binary:unknown`, which is one unknown matching another. */
     if (!files.every(isDescribable)) return null;
-    return diffFingerprint(files);
+    return diffEntries(files);
   } catch {
     /* A force-pushed commit can fall out of reach. Unknown is not "unchanged". */
     return null;
@@ -204,13 +204,27 @@ const reviewedSha = [...reviews]
   .sort((a, b) => (a.submitted_at < b.submitted_at ? -1 : 1))
   .at(-1)?.commit_id;
 
+/**
+ * Whether everything the head proposes was part of what the review read.
+ *
+ * A subset rather than an equality, and the difference is not a convenience. A pull request
+ * whose base absorbed one of its files — `main` merged the same lockfile fix, say — proposes a
+ * strictly smaller change than the one that was reviewed, and dropping a file cannot introduce
+ * code nobody read. Equality refuses that, and CodeRabbit will not clear it either: asked to
+ * look again it answers "No files to review", because there is nothing new to read. The gate
+ * then wants a review that cannot be produced, which is a stuck pull request rather than a safe
+ * one.
+ *
+ * Any file whose patch differs is simply not in the reviewed set, so an edit still fails here.
+ */
 const sameDiffAsReviewed = async () => {
   if (reviewedSha === undefined || reviewedSha === prData.head.sha) return false;
   const [reviewedDiff, headDiff] = await Promise.all([
     effectiveDiff(reviewedSha),
     effectiveDiff(prData.head.sha),
   ]);
-  return reviewedDiff !== null && headDiff !== null && reviewedDiff === headDiff;
+  if (reviewedDiff === null || headDiff === null) return false;
+  return coversAllOf(reviewedDiff, headDiff);
 };
 /*
  * Fails closed. An absent timestamp is a reason to look rather than to pass, and treating one
@@ -237,7 +251,7 @@ console.log(`  last review : ${lastReviewAt ?? 'none'}`);
 console.log(`  head commit : ${prData.head.sha.slice(0, 7)} ${headAt ?? 'unknown'}`);
 if (rebasedOnly) {
   console.log(
-    `  rebase only : yes — same effective diff as the reviewed commit ${String(reviewedSha).slice(0, 7)}`,
+    `  rebase only : yes — every change is one the review of ${String(reviewedSha).slice(0, 7)} already read`,
   );
 }
 

--- a/tools/review/diffFingerprint.d.mts
+++ b/tools/review/diffFingerprint.d.mts
@@ -19,4 +19,6 @@ export type ComparedFile = {
 
 export declare const COMPARE_FILE_CAP: number;
 export declare const isDescribable: (file: ComparedFile) => boolean;
+export declare const diffEntries: (files: readonly ComparedFile[]) => string[];
+export declare const coversAllOf: (reviewed: readonly string[], head: readonly string[]) => boolean;
 export declare const diffFingerprint: (files: readonly ComparedFile[]) => string;

--- a/tools/review/diffFingerprint.mjs
+++ b/tools/review/diffFingerprint.mjs
@@ -35,10 +35,16 @@ export const COMPARE_FILE_CAP = 300;
 export const isDescribable = (file) => (file.patch ?? file.sha ?? null) !== null;
 
 /**
+ * One string per file, each identifying that file's change completely.
+ *
+ * Separate from the joined fingerprint because a comparison is sometimes a *subset* of another
+ * rather than equal to it — a pull request whose base absorbed one of its files still proposes
+ * only changes that were already read — and a single joined string cannot express that.
+ *
  * @param {{ filename?: string, previous_filename?: string, patch?: string, sha?: string, status?: string }[]} files
- * @returns {string}
+ * @returns {string[]}
  */
-export const diffFingerprint = (files) =>
+export const diffEntries = (files) =>
   files
     .map((file) => {
       const name = file.filename ?? '';
@@ -60,5 +66,31 @@ export const diffFingerprint = (files) =>
     })
     /* Sorted, because the API does not promise a stable file order between calls, and a
        fingerprint that depends on response ordering would report spurious differences. */
-    .sort()
-    .join('\n--\n');
+    .sort();
+
+/**
+ * @param {{ filename?: string, previous_filename?: string, patch?: string, sha?: string, status?: string }[]} files
+ * @returns {string}
+ */
+export const diffFingerprint = (files) => diffEntries(files).join('\n--\n');
+
+/**
+ * Whether every change in `head` appears in `reviewed`.
+ *
+ * The question the freshness check actually asks. Equality is too strict: a pull request whose
+ * base absorbed one of its files proposes strictly less than what was read, and dropping a file
+ * cannot introduce code nobody saw. A file whose patch changed is simply not in the reviewed
+ * set, so an edit still answers false.
+ *
+ * An empty `head` answers true, which is correct — a pull request that now proposes nothing has
+ * nothing unreviewed in it — and is why the caller checks that the comparison was complete
+ * before asking.
+ *
+ * @param {readonly string[]} reviewed
+ * @param {readonly string[]} head
+ * @returns {boolean}
+ */
+export const coversAllOf = (reviewed, head) => {
+  const seen = new Set(reviewed);
+  return head.every((entry) => seen.has(entry));
+};

--- a/tools/review/diffFingerprint.test.ts
+++ b/tools/review/diffFingerprint.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from '@jest/globals';
 import {
   COMPARE_FILE_CAP,
+  coversAllOf,
+  diffEntries,
   diffFingerprint,
   isDescribable,
   type ComparedFile,
@@ -129,5 +131,53 @@ describe('isDescribable', () => {
   it('accepts an empty patch, which is a real value', () => {
     /* A pure rename has an empty patch rather than no patch, and it is describable. */
     expect(isDescribable({ patch: '' })).toBe(true);
+  });
+});
+
+describe('coversAllOf', () => {
+  const a = 'a.ts\nnone\nmodified\n@@ -1 +1 @@';
+  const b = 'b.ts\nnone\nmodified\n@@ -2 +2 @@';
+  const bEdited = 'b.ts\nnone\nmodified\n@@ -2 +2 @@ different';
+
+  it('accepts an identical comparison', () => {
+    expect(coversAllOf([a, b], [a, b])).toBe(true);
+  });
+
+  it('accepts a head that dropped a file the review had read', () => {
+    /* The case this exists for: `main` absorbed one of the PR's files, so the PR now proposes
+       strictly less than what was reviewed. Dropping a file cannot introduce unread code, and
+       CodeRabbit will not re-review it — asked again, it answers "No files to review". */
+    expect(coversAllOf([a, b], [a])).toBe(true);
+  });
+
+  it('rejects a head that changed a file', () => {
+    /* The edit that must never ride in on an older review. */
+    expect(coversAllOf([a, b], [a, bEdited])).toBe(false);
+  });
+
+  it('rejects a head that added a file', () => {
+    expect(coversAllOf([a], [a, b])).toBe(false);
+  });
+
+  it('accepts an empty head, which proposes nothing', () => {
+    expect(coversAllOf([a, b], [])).toBe(true);
+  });
+
+  it('rejects everything when nothing was reviewed', () => {
+    expect(coversAllOf([], [a])).toBe(false);
+  });
+
+  it('works on the entries the fingerprint is built from', () => {
+    /* The two halves have to agree: `diffEntries` produces what `coversAllOf` compares, and a
+       change to either alone would silently stop the freshness check from meaning anything. */
+    const files: ComparedFile[] = [
+      { filename: 'a.ts', status: 'modified', patch: '@@ -1 +1 @@' },
+      { filename: 'b.ts', status: 'modified', patch: '@@ -2 +2 @@' },
+    ];
+    const entries = diffEntries(files);
+
+    expect(entries).toHaveLength(2);
+    expect(coversAllOf(entries, diffEntries(files.slice(0, 1)))).toBe(true);
+    expect(diffFingerprint(files)).toBe(entries.join('\n--\n'));
   });
 });


### PR DESCRIPTION
#134 has sat unmergeable for ninety minutes in a state that neither the gate nor the reviewer could resolve.

Its base absorbed one of its files — `main` merged the same `package-lock.json` fix independently — so after rebasing it proposes **strictly less** than what was reviewed. The equality check added in #141 called that a change and demanded a new review.

Asked directly, CodeRabbit declined:

> `@Sanitdhar` I will review the rebased head commit to refresh the review status.
> ⚠️ **Action not completed** — No files to review.
> Note: CodeRabbit is an incremental review system and does not re-review already reviewed commits.

Which is correct of it. There is nothing new to read. So the gate wanted a review that could not be produced, and the PR was **stuck rather than safe** — the failure mode #140 was about, one shape further along.

### Subset, not equality

Dropping a file cannot introduce code nobody read. The question the gate actually means to ask is: *is every change the head proposes one the review already covered?*

A file whose patch differs is simply not in the reviewed set, so an edit still fails. Verified in both directions against live PRs:

| PR | situation | result |
|---|---|---|
| #134 | base absorbed one file; remainder identical | **passes** — every entry was in the reviewed set |
| #125 | genuinely new commit (`release.yml` change) | **still refused** |

### The predicates are extracted and tested

`diffEntries` and `coversAllOf`, not inline expressions. Three findings in a row on this file landed on predicates whose only proof was that I had read them — a `null` that slipped past an `undefined` check, a truncated comparison reading as unchanged, an absent file list fingerprinting as the empty string. That is a clear enough pattern to stop repeating.

Seven cases, including a head that added a file, a head that changed one, an empty head, and the agreement between `diffEntries` and the `diffFingerprint` built from them. Checked by mutation: making the subset check permissive fails three of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145VPJXGgJA9PWqeNXDr1DG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Rebased pull requests can now be accepted when their current changes are fully covered by the previously reviewed changes.
  - Review status messages now clearly indicate when all current changes were already covered by an earlier review.

- **Tests**
  - Expanded coverage for matching, missing, changed and newly added file changes during review comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->