### PR TITLE
feat(data): four fixture events that look nothing alike

### DIFF
--- a/packages/data/src/fixtures/builders.ts
+++ b/packages/data/src/fixtures/builders.ts
@@ -81,13 +81,17 @@ export const ids = {
  * and in Lisbon, which is exactly the mistake a hardcoded `Z` timestamp hides.
  */
 export const at = (day: string, hour: number, minute = 0, offsetHours = 0): Timestamptz => {
-  const utcHour = hour - offsetHours;
-  return new Date(`${day}T00:00:00.000Z`)
-    .toISOString()
-    .replace(
-      /T.*/,
-      `T${String(utcHour).padStart(2, '0')}:${String(minute).padStart(2, '0')}:00.000Z`,
-    );
+  /*
+   * Arithmetic in milliseconds, not string surgery on the hour field.
+   *
+   * The first version subtracted the offset from the hour and formatted the result, which is
+   * fine until the offset is not a whole number: India is +5:30, so 16:00 became
+   * `T10.5:00:00.000Z` — a string that looks like a timestamp, parses as `Invalid Date`, and
+   * had made every wedding and festival time in this fixture set invalid. Milliseconds carry
+   * the half hour without anyone having to remember it exists.
+   */
+  const localMs = Date.parse(`${day}T00:00:00.000Z`) + (hour * 60 + minute) * 60_000;
+  return new Date(localMs - offsetHours * 3_600_000).toISOString();
 };
 
 export const user = (name: string, displayName: string, over: Partial<UserRow> = {}): UserRow => ({
@@ -103,12 +107,21 @@ export const user = (name: string, displayName: string, over: Partial<UserRow> =
 
 export const membership = (
   tenant: TenantId,
-  who: UserId,
+  /**
+   * The row's own name, not the member's.
+   *
+   * Deriving the id from `user_id` collided the moment a tenant had both an active membership
+   * for someone and an unaccepted invitation from them, because an invitation's `user_id` is
+   * null and both rows landed on the same id. An id that depends on another column changes
+   * meaning when that column does.
+   */
+  key: string,
+  who: UserId | null,
   role: MembershipRole,
   status: MembershipStatus = 'active',
   over: Partial<MembershipRow> = {},
 ): MembershipRow => ({
-  id: membershipId(`mb_${String(tenant)}_${String(who)}`),
+  id: membershipId(`mb_${key}`),
   tenant_id: tenant,
   user_id: who,
   invited_email: null,
@@ -213,6 +226,8 @@ export const image = (
   name: string,
   alt: string,
   blurhash: string,
+  /** The colour a frame paints before the blurhash decodes, and behind an image that fails. */
+  dominantColor: string,
   over: Partial<MediaAssetRow> = {},
 ): MediaAssetRow => ({
   id: ids.media(name),
@@ -223,7 +238,7 @@ export const image = (
   width: 1600,
   height: 1067,
   blurhash,
-  dominant_color: null,
+  dominant_color: dominantColor,
   alt,
   byte_size: 384_000,
   uploaded_by: null,

--- a/packages/data/src/fixtures/builders.ts
+++ b/packages/data/src/fixtures/builders.ts
@@ -1,5 +1,6 @@
 import {
   announcementId,
+  approvalRequestId,
   assignmentId,
   gossipPostId,
   membershipId,
@@ -11,6 +12,7 @@ import {
   tenantId,
   unitId,
   userId,
+  type ApprovalRequestId,
   type MediaId,
   type PersonId,
   type SessionId,
@@ -20,10 +22,8 @@ import {
   type VenueId,
 } from '@occasio/core';
 import { venueId } from '@occasio/core';
-import { approvalRequestId } from '../mock/mappers';
 import type {
   AnnouncementRow,
-  ApprovalRequestId,
   AssignmentRow,
   GossipPostRow,
   MediaAssetRow,

--- a/packages/data/src/fixtures/builders.ts
+++ b/packages/data/src/fixtures/builders.ts
@@ -1,0 +1,357 @@
+import {
+  announcementId,
+  assignmentId,
+  gossipPostId,
+  membershipId,
+  mediaId,
+  personaId,
+  personId,
+  sessionId,
+  taskId,
+  tenantId,
+  unitId,
+  userId,
+  type MediaId,
+  type PersonId,
+  type SessionId,
+  type TenantId,
+  type UnitId,
+  type UserId,
+  type VenueId,
+} from '@occasio/core';
+import { venueId } from '@occasio/core';
+import { approvalRequestId } from '../mock/mappers';
+import type {
+  AnnouncementRow,
+  ApprovalRequestId,
+  AssignmentRow,
+  GossipPostRow,
+  MediaAssetRow,
+  MembershipRole,
+  MembershipRow,
+  MembershipStatus,
+  ModerationStatus,
+  PersonaRow,
+  PersonRow,
+  SessionPersonRow,
+  SessionRow,
+  TaskRow,
+  TaskStatus,
+  Timestamptz,
+  UnitKind,
+  UnitRow,
+  UserRow,
+  VenueRow,
+} from '../rows';
+
+/**
+ * The scaffolding the four fixture events are written on.
+ *
+ * Fixtures are read far more often than they are written -- every screenshot, every demo and
+ * every "why does this look wrong" starts here -- so the goal is that an event reads as an
+ * event rather than as two hundred object literals. Each builder supplies the columns nobody
+ * makes a decision about (timestamps, sort order, moderation defaults) and leaves the ones that
+ * carry meaning to the caller.
+ *
+ * Everything is deterministic. No `Date.now()`, no random ids: the visual gate diffs
+ * screenshots, and a fixture that moved with the clock would fail it every midnight for reasons
+ * nobody would attribute to the fixture.
+ */
+
+/** A fixed instant the fixtures are written relative to, so "two days before" is a real date. */
+export const FIXTURE_NOW = '2026-07-01T09:00:00.000Z';
+
+/** Ids are readable on purpose: a failing screenshot names `s_wed_ceremony`, not `s_00417`. */
+export const ids = {
+  tenant: (slug: string): TenantId => tenantId(`t_${slug}`),
+  user: (name: string): UserId => userId(`u_${name}`),
+  venue: (name: string): VenueId => venueId(`v_${name}`),
+  session: (name: string): SessionId => sessionId(`s_${name}`),
+  person: (name: string): PersonId => personId(`p_${name}`),
+  media: (name: string): MediaId => mediaId(`m_${name}`),
+  unit: (name: string): UnitId => unitId(`un_${name}`),
+  approvalRequest: (name: string): ApprovalRequestId => approvalRequestId(`ap_${name}`),
+} as const;
+
+/**
+ * An instant, expressed as an offset from the event's own day.
+ *
+ * Written this way because a schedule is read as "the ceremony is at four", not as an ISO
+ * string — and because an event that starts at 09:00 local is a different instant in Kolkata
+ * and in Lisbon, which is exactly the mistake a hardcoded `Z` timestamp hides.
+ */
+export const at = (day: string, hour: number, minute = 0, offsetHours = 0): Timestamptz => {
+  const utcHour = hour - offsetHours;
+  return new Date(`${day}T00:00:00.000Z`)
+    .toISOString()
+    .replace(
+      /T.*/,
+      `T${String(utcHour).padStart(2, '0')}:${String(minute).padStart(2, '0')}:00.000Z`,
+    );
+};
+
+export const user = (name: string, displayName: string, over: Partial<UserRow> = {}): UserRow => ({
+  id: ids.user(name),
+  email: `${name}@example.test`,
+  display_name: displayName,
+  avatar_media_id: null,
+  locale: null,
+  created_at: FIXTURE_NOW,
+  updated_at: FIXTURE_NOW,
+  ...over,
+});
+
+export const membership = (
+  tenant: TenantId,
+  who: UserId,
+  role: MembershipRole,
+  status: MembershipStatus = 'active',
+  over: Partial<MembershipRow> = {},
+): MembershipRow => ({
+  id: membershipId(`mb_${String(tenant)}_${String(who)}`),
+  tenant_id: tenant,
+  user_id: who,
+  invited_email: null,
+  invited_phone: null,
+  role,
+  status,
+  invited_by: null,
+  invited_at: null,
+  accepted_at: status === 'active' ? FIXTURE_NOW : null,
+  created_at: FIXTURE_NOW,
+  updated_at: FIXTURE_NOW,
+  ...over,
+});
+
+export const venue = (
+  tenant: TenantId,
+  name: string,
+  label: string,
+  over: Partial<VenueRow> = {},
+): VenueRow => ({
+  id: ids.venue(name),
+  tenant_id: tenant,
+  name: label,
+  address: null,
+  lat: null,
+  lng: null,
+  map_url: null,
+  notes: null,
+  sort_order: 0,
+  created_at: FIXTURE_NOW,
+  updated_at: FIXTURE_NOW,
+  ...over,
+});
+
+export const session = (
+  tenant: TenantId,
+  name: string,
+  title: string,
+  startsAt: Timestamptz,
+  over: Partial<SessionRow> = {},
+): SessionRow => ({
+  id: ids.session(name),
+  tenant_id: tenant,
+  title,
+  description: null,
+  starts_at: startsAt,
+  ends_at: null,
+  venue_id: null,
+  hero_media_id: null,
+  track: null,
+  sort_order: 0,
+  status: 'published',
+  created_at: FIXTURE_NOW,
+  updated_at: FIXTURE_NOW,
+  ...over,
+});
+
+export const person = (
+  tenant: TenantId,
+  name: string,
+  label: string,
+  over: Partial<PersonRow> = {},
+): PersonRow => ({
+  id: ids.person(name),
+  tenant_id: tenant,
+  user_id: null,
+  name: label,
+  role_label: null,
+  bio: null,
+  photo_media_id: null,
+  sort_order: 0,
+  created_at: FIXTURE_NOW,
+  updated_at: FIXTURE_NOW,
+  ...over,
+});
+
+export const sessionPerson = (
+  tenant: TenantId,
+  s: SessionId,
+  p: PersonId,
+  over: Partial<SessionPersonRow> = {},
+): SessionPersonRow => ({
+  tenant_id: tenant,
+  session_id: s,
+  person_id: p,
+  role_label: null,
+  sort_order: 0,
+  created_at: FIXTURE_NOW,
+  ...over,
+});
+
+/**
+ * An image, with a blurhash.
+ *
+ * Never null here, and that is deliberate rather than thorough: the `Image` component treats a
+ * missing blurhash as the third-party-avatar case and falls back to a tonal fill, so a fixture
+ * set without them would screenshot the fallback everywhere and quietly stop testing the real
+ * path.
+ */
+export const image = (
+  tenant: TenantId,
+  name: string,
+  alt: string,
+  blurhash: string,
+  over: Partial<MediaAssetRow> = {},
+): MediaAssetRow => ({
+  id: ids.media(name),
+  tenant_id: tenant,
+  storage_path: `fixtures/${name}.jpg`,
+  kind: 'image',
+  mime_type: 'image/jpeg',
+  width: 1600,
+  height: 1067,
+  blurhash,
+  dominant_color: null,
+  alt,
+  byte_size: 384_000,
+  uploaded_by: null,
+  status: 'approved',
+  created_at: FIXTURE_NOW,
+  updated_at: FIXTURE_NOW,
+  ...over,
+});
+
+export const persona = (
+  tenant: TenantId,
+  name: string,
+  label: string,
+  deviceHash: string,
+): PersonaRow => ({
+  id: personaId(`pa_${name}`),
+  tenant_id: tenant,
+  label,
+  avatar_key: `avatar-${name}`,
+  device_hash: deviceHash,
+  retired_at: null,
+  created_at: FIXTURE_NOW,
+});
+
+export const gossip = (
+  tenant: TenantId,
+  name: string,
+  body: string,
+  authorPersona: PersonaRow,
+  status: ModerationStatus,
+  over: Partial<GossipPostRow> = {},
+): GossipPostRow => ({
+  id: gossipPostId(`g_${name}`),
+  tenant_id: tenant,
+  body,
+  media_id: null,
+  persona_id: authorPersona.id,
+  author_device_hash: authorPersona.device_hash,
+  status,
+  moderated_by: null,
+  moderated_at: status === 'pending' ? null : FIXTURE_NOW,
+  rejection_reason: null,
+  reaction_counts: {},
+  report_count: 0,
+  created_at: FIXTURE_NOW,
+  ...over,
+});
+
+export const task = (
+  tenant: TenantId,
+  name: string,
+  title: string,
+  createdBy: UserId,
+  status: TaskStatus,
+  over: Partial<TaskRow> = {},
+): TaskRow => ({
+  id: taskId(`tk_${name}`),
+  tenant_id: tenant,
+  title,
+  notes: null,
+  assignee_user_id: null,
+  created_by: createdBy,
+  session_id: null,
+  due_at: null,
+  remind_before_minutes: null,
+  status,
+  visibility: 'crew',
+  priority: 'normal',
+  sort_order: 0,
+  created_at: FIXTURE_NOW,
+  updated_at: FIXTURE_NOW,
+  ...over,
+});
+
+export const unit = (
+  tenant: TenantId,
+  name: string,
+  kind: UnitKind,
+  label: string,
+  over: Partial<UnitRow> = {},
+): UnitRow => ({
+  id: ids.unit(name),
+  tenant_id: tenant,
+  kind,
+  label,
+  capacity: null,
+  venue_id: null,
+  meta: {},
+  sort_order: 0,
+  created_at: FIXTURE_NOW,
+  updated_at: FIXTURE_NOW,
+  ...over,
+});
+
+export const assignment = (
+  tenant: TenantId,
+  name: string,
+  u: UnitId,
+  who: UserId,
+  assignedBy: UserId,
+  over: Partial<AssignmentRow> = {},
+): AssignmentRow => ({
+  id: assignmentId(`as_${name}`),
+  tenant_id: tenant,
+  unit_id: u,
+  user_id: who,
+  note: null,
+  assigned_by: assignedBy,
+  created_at: FIXTURE_NOW,
+  ...over,
+});
+
+export const announcement = (
+  tenant: TenantId,
+  name: string,
+  title: string,
+  body: string,
+  createdBy: UserId,
+  over: Partial<AnnouncementRow> = {},
+): AnnouncementRow => ({
+  id: announcementId(`an_${name}`),
+  tenant_id: tenant,
+  title,
+  body,
+  published_at: FIXTURE_NOW,
+  pinned: false,
+  created_by: createdBy,
+  created_at: FIXTURE_NOW,
+  updated_at: FIXTURE_NOW,
+  ...over,
+});

--- a/packages/data/src/fixtures/conference.ts
+++ b/packages/data/src/fixtures/conference.ts
@@ -1,0 +1,259 @@
+import { themeInputFromPreset } from '@occasio/theme';
+import type { TenantConfig } from '../config';
+import type { MockTables } from '../mock/tables';
+import type { TenantConfigRow, TenantRow } from '../rows';
+import {
+  FIXTURE_NOW,
+  announcement,
+  assignment,
+  at,
+  gossip,
+  ids,
+  image,
+  membership,
+  person,
+  persona,
+  session,
+  sessionPerson,
+  task,
+  unit,
+  user,
+  venue,
+} from './builders';
+
+/**
+ * A conference: two tracks, rooms rather than tables, and a site that follows the device.
+ *
+ * The third scheme policy. `mode.support: 'system'` is the one an attendee expects from a work
+ * tool, and having a fixture that uses it is what stops the resolver's system path from being
+ * exercised only by unit tests.
+ *
+ * It is also the only fixture with `tracks: true`, which is why `SessionRow.track` is nullable:
+ * every other event leaves it null and would render a stray label if the schedule assumed one.
+ */
+
+const T = ids.tenant('devcon-25');
+const DAY_ONE = '2026-10-06';
+const DAY_TWO = '2026-10-07';
+/** Central European Summer Time. A whole-hour offset, unlike the wedding's. */
+const CEST = 2;
+
+export const CONFERENCE_TENANT: TenantRow = {
+  id: T,
+  slug: 'devcon-25',
+  name: 'DevCon 25',
+  kind: 'conference',
+  status: 'approved',
+  timezone: 'Europe/Berlin',
+  visibility: 'public',
+  join_code: null,
+  starts_on: DAY_ONE,
+  ends_on: DAY_TWO,
+  created_by: ids.user('paula'),
+  created_at: FIXTURE_NOW,
+  updated_at: FIXTURE_NOW,
+};
+
+const config: TenantConfig = {
+  version: 1,
+  theme: {
+    ...themeInputFromPreset('conference', '#2563EB'),
+    mode: { support: 'system', default: 'light' },
+    imagery: { heroAspect: '16:9', treatment: 'none', scrim: 'light' },
+    motion: { level: 'subtle' },
+    density: 'cozy',
+    shape: { corner: 'soft' },
+  },
+  features: {
+    schedule: { enabled: true, defaultView: 'list', tracks: true },
+    gossips: { enabled: true, requireApproval: true, allowMedia: false },
+    media: { enabled: false },
+    info: { enabled: true },
+    game: { enabled: false },
+  },
+  /* `media` is disabled, and is deliberately still listed: the nav filters on
+     `features[k].enabled` at render time, so a config can turn a tab off without anyone having
+     to remember to edit two places. A fixture that only ever listed enabled tabs would leave
+     that filter untested. */
+  nav: { tabs: ['schedule', 'info', 'gossips', 'media'] },
+  copy: { 'gossips.title': 'Backchannel' },
+};
+
+export const CONFERENCE_CONFIG: TenantConfigRow = {
+  tenant_id: T,
+  draft_config: config,
+  published_config: config,
+  published_at: FIXTURE_NOW,
+  published_by: ids.user('paula'),
+  created_at: FIXTURE_NOW,
+  updated_at: FIXTURE_NOW,
+};
+
+const rooms = [
+  venue(T, 'con_aula', 'Aula', {
+    address: 'Haus der Technik, Berlin',
+    lat: 52.52,
+    lng: 13.405,
+    sort_order: 1,
+  }),
+  venue(T, 'con_studio', 'Studio 2', { sort_order: 2 }),
+];
+
+const speakers = [
+  person(T, 'con_ada', 'Ada Okonkwo', {
+    role_label: 'Keynote',
+    bio: 'Works on type systems and refuses to say which one is best.',
+    sort_order: 1,
+  }),
+  person(T, 'con_tomas', 'Tomás Ferreira', { role_label: 'Speaker', sort_order: 2 }),
+  person(T, 'con_yuki', 'Yuki Tanaka', { role_label: 'Speaker', sort_order: 3 }),
+];
+
+const sessions = [
+  session(T, 'con_keynote', 'Opening keynote', at(DAY_ONE, 9, 30, CEST), {
+    description: 'Where the platform goes next, and what we got wrong last year.',
+    ends_at: at(DAY_ONE, 10, 30, CEST),
+    venue_id: ids.venue('con_aula'),
+    hero_media_id: ids.media('con_aula'),
+    track: 'Main',
+    sort_order: 1,
+  }),
+  session(T, 'con_types', 'Types at the edges', at(DAY_ONE, 11, 0, CEST), {
+    ends_at: at(DAY_ONE, 11, 45, CEST),
+    venue_id: ids.venue('con_studio'),
+    track: 'Platform',
+    sort_order: 2,
+  }),
+  /* Same minute, different track — the case `sort_order` exists for, since a start time alone
+     does not order two talks a reader has to choose between. */
+  session(T, 'con_offline', 'Offline-first, actually', at(DAY_ONE, 11, 0, CEST), {
+    ends_at: at(DAY_ONE, 11, 45, CEST),
+    venue_id: ids.venue('con_aula'),
+    track: 'Product',
+    sort_order: 3,
+  }),
+  session(T, 'con_lunch', 'Lunch', at(DAY_ONE, 12, 30, CEST), {
+    ends_at: at(DAY_ONE, 13, 30, CEST),
+    track: 'Main',
+    sort_order: 4,
+  }),
+  session(T, 'con_workshop', 'Workshop · migrating a monolith', at(DAY_TWO, 10, 0, CEST), {
+    description: 'Bring a laptop. Numbers are capped at thirty.',
+    ends_at: at(DAY_TWO, 13, 0, CEST),
+    venue_id: ids.venue('con_studio'),
+    track: 'Platform',
+    sort_order: 5,
+  }),
+  session(T, 'con_close', 'Closing remarks', at(DAY_TWO, 16, 30, CEST), {
+    ends_at: at(DAY_TWO, 17, 0, CEST),
+    venue_id: ids.venue('con_aula'),
+    track: 'Main',
+    sort_order: 6,
+  }),
+];
+
+const kite = persona(T, 'con_kite', 'Quiet Kite', 'dh_con_a1');
+const personas = [kite];
+
+export const CONFERENCE: Partial<MockTables> = {
+  tenants: [CONFERENCE_TENANT],
+  tenantConfigs: [CONFERENCE_CONFIG],
+  users: [user('paula', 'Paula Brandt'), user('sam', 'Sam Okafor'), user('ines', 'Inês Costa')],
+  memberships: [
+    membership(T, ids.user('paula'), 'event_admin'),
+    membership(T, ids.user('sam'), 'crew'),
+    membership(T, ids.user('ines'), 'attendee'),
+    /* An invitation that has not been accepted: a row that exists before the person does, and
+       the reason `findActiveMembership` checks status rather than presence. */
+    membership(T, ids.user('ines'), 'moderator', 'invited', {
+      user_id: null,
+      invited_email: 'not-yet@example.test',
+      invited_by: ids.user('paula'),
+      invited_at: FIXTURE_NOW,
+      accepted_at: null,
+    }),
+  ],
+  venues: rooms,
+  sessions,
+  people: speakers,
+  sessionPeople: [
+    sessionPerson(T, ids.session('con_keynote'), ids.person('con_ada')),
+    sessionPerson(T, ids.session('con_types'), ids.person('con_tomas')),
+    sessionPerson(T, ids.session('con_offline'), ids.person('con_yuki')),
+    sessionPerson(T, ids.session('con_workshop'), ids.person('con_tomas'), {
+      role_label: 'Facilitator',
+    }),
+  ],
+  mediaAssets: [
+    image(T, 'con_aula', 'The Aula, filling up before the keynote', 'L9C6M-00~q4n?bxu9FRj00~q%MRj'),
+  ],
+  personas,
+  gossipPosts: [
+    gossip(T, 'con_1', 'The coffee is better than last year. Low bar, cleared.', kite, 'approved', {
+      reaction_counts: { '☕': 9 },
+    }),
+    gossip(T, 'con_2', 'Studio 2 is freezing. Bring a jumper.', kite, 'pending'),
+  ],
+  tasks: [
+    task(T, 'con_mics', 'Swap the lapel mic in Studio 2', ids.user('paula'), 'todo', {
+      assignee_user_id: ids.user('sam'),
+      due_at: at(DAY_ONE, 8, 30, CEST),
+      priority: 'high',
+      session_id: ids.session('con_types'),
+      remind_before_minutes: 30,
+      sort_order: 1,
+    }),
+    task(T, 'con_badges', 'Reprint the badges with the right pronouns', ids.user('paula'), 'done', {
+      assignee_user_id: ids.user('sam'),
+      sort_order: 2,
+    }),
+  ],
+  units: [
+    unit(T, 'con_room_a', 'room', 'Quiet room', {
+      capacity: 12,
+      venue_id: ids.venue('con_aula'),
+      sort_order: 1,
+    }),
+    unit(T, 'con_room_b', 'room', 'Workshop room', {
+      capacity: 30,
+      venue_id: ids.venue('con_studio'),
+      sort_order: 2,
+    }),
+  ],
+  assignments: [
+    assignment(T, 'con_1', ids.unit('con_room_b'), ids.user('ines'), ids.user('paula'), {
+      note: 'Workshop seat 14.',
+    }),
+  ],
+  announcements: [
+    announcement(
+      T,
+      'con_wifi',
+      'Wi-Fi is devcon / devcon25',
+      'One network, no captive portal. If it drops, the schedule works offline.',
+      ids.user('paula'),
+      { pinned: true },
+    ),
+    /* Unpublished: a draft an admin is still writing, which the attendee site must not show. */
+    announcement(
+      T,
+      'con_draft',
+      'Day two changes',
+      'Still confirming the room swap.',
+      ids.user('paula'),
+      {
+        published_at: null,
+      },
+    ),
+  ],
+  rsvps: [
+    {
+      tenant_id: T,
+      user_id: ids.user('ines'),
+      session_id: ids.session('con_workshop'),
+      status: 'going',
+      guest_count: 1,
+      responded_at: FIXTURE_NOW,
+    },
+  ],
+};

--- a/packages/data/src/fixtures/conference.ts
+++ b/packages/data/src/fixtures/conference.ts
@@ -160,13 +160,12 @@ export const CONFERENCE: Partial<MockTables> = {
   tenantConfigs: [CONFERENCE_CONFIG],
   users: [user('paula', 'Paula Brandt'), user('sam', 'Sam Okafor'), user('ines', 'Inês Costa')],
   memberships: [
-    membership(T, ids.user('paula'), 'event_admin'),
-    membership(T, ids.user('sam'), 'crew'),
-    membership(T, ids.user('ines'), 'attendee'),
+    membership(T, 'con_paula', ids.user('paula'), 'event_admin'),
+    membership(T, 'con_sam', ids.user('sam'), 'crew'),
+    membership(T, 'con_ines', ids.user('ines'), 'attendee'),
     /* An invitation that has not been accepted: a row that exists before the person does, and
        the reason `findActiveMembership` checks status rather than presence. */
-    membership(T, ids.user('ines'), 'moderator', 'invited', {
-      user_id: null,
+    membership(T, 'con_invite', null, 'moderator', 'invited', {
       invited_email: 'not-yet@example.test',
       invited_by: ids.user('paula'),
       invited_at: FIXTURE_NOW,
@@ -185,7 +184,13 @@ export const CONFERENCE: Partial<MockTables> = {
     }),
   ],
   mediaAssets: [
-    image(T, 'con_aula', 'The Aula, filling up before the keynote', 'L9C6M-00~q4n?bxu9FRj00~q%MRj'),
+    image(
+      T,
+      'con_aula',
+      'The Aula, filling up before the keynote',
+      'L9C6M-00~q4n?bxu9FRj00~q%MRj',
+      '#2a3f6b',
+    ),
   ],
   personas,
   gossipPosts: [

--- a/packages/data/src/fixtures/festival.ts
+++ b/packages/data/src/fixtures/festival.ts
@@ -139,9 +139,9 @@ export const FESTIVAL: Partial<MockTables> = {
   tenantConfigs: [FESTIVAL_CONFIG],
   users: [user('devi', 'Devi Menon'), user('rafi', 'Rafi Ahmed'), user('lena', 'Lena Fischer')],
   memberships: [
-    membership(T, ids.user('devi'), 'event_admin'),
-    membership(T, ids.user('rafi'), 'crew'),
-    membership(T, ids.user('lena'), 'attendee'),
+    membership(T, 'fes_devi', ids.user('devi'), 'event_admin'),
+    membership(T, 'fes_rafi', ids.user('rafi'), 'crew'),
+    membership(T, 'fes_lena', ids.user('lena'), 'attendee'),
   ],
   venues: stages,
   sessions,
@@ -152,8 +152,14 @@ export const FESTIVAL: Partial<MockTables> = {
     sessionPerson(T, ids.session('fes_ruhi'), ids.person('fes_ruhi')),
   ],
   mediaAssets: [
-    image(T, 'fes_main', 'The mainstage crowd at dusk', 'L36@#=~q00Rj4nWBofof00Rj~qxu'),
-    image(T, 'fes_grove', 'Strings of lights through trees', 'LBB|WA~q00%M9FIU%MRj00IU~q4n'),
+    image(T, 'fes_main', 'The mainstage crowd at dusk', 'L36@#=~q00Rj4nWBofof00Rj~qxu', '#1b3b33'),
+    image(
+      T,
+      'fes_grove',
+      'Strings of lights through trees',
+      'LBB|WA~q00%M9FIU%MRj00IU~q4n',
+      '#26483f',
+    ),
   ],
   personas,
   gossipPosts: [

--- a/packages/data/src/fixtures/festival.ts
+++ b/packages/data/src/fixtures/festival.ts
@@ -1,0 +1,205 @@
+import { themeInputFromPreset } from '@occasio/theme';
+import type { TenantConfig } from '../config';
+import type { MockTables } from '../mock/tables';
+import type { TenantConfigRow, TenantRow } from '../rows';
+import {
+  FIXTURE_NOW,
+  announcement,
+  at,
+  gossip,
+  ids,
+  image,
+  membership,
+  person,
+  persona,
+  session,
+  sessionPerson,
+  task,
+  unit,
+  user,
+  venue,
+} from './builders';
+
+/**
+ * A festival: three stages, one long day, and a site that lives in the dark.
+ *
+ * `mode.support: 'dark'` pins it the other way from the wedding. A festival read outdoors at
+ * midnight has no business turning white because someone's phone is on auto, and the pairing of
+ * `expressive` motion with a dark ground is the loudest the design system is allowed to be.
+ */
+
+const T = ids.tenant('anandhara');
+const DAY = '2026-09-19';
+/** Western Indian Standard time for the fixture's venue; kept whole-hour for contrast with IST. */
+const OFFSET = 5.5;
+
+export const FESTIVAL_TENANT: TenantRow = {
+  id: T,
+  slug: 'anandhara',
+  name: 'Anandhara',
+  kind: 'festival',
+  status: 'approved',
+  timezone: 'Asia/Kolkata',
+  visibility: 'public',
+  join_code: null,
+  starts_on: DAY,
+  ends_on: DAY,
+  created_by: ids.user('devi'),
+  created_at: FIXTURE_NOW,
+  updated_at: FIXTURE_NOW,
+};
+
+const config: TenantConfig = {
+  version: 1,
+  theme: {
+    ...themeInputFromPreset('festival', '#1E6F5C'),
+    mode: { support: 'dark', default: 'dark' },
+    imagery: { heroAspect: '16:9', treatment: 'duotone', scrim: 'heavy' },
+    motion: { level: 'expressive' },
+    density: 'airy',
+    shape: { corner: 'sharp' },
+    typography: {
+      setId: themeInputFromPreset('festival', '#1E6F5C').typography.setId,
+      scale: 'grand',
+    },
+  },
+  features: {
+    schedule: { enabled: true, defaultView: 'list', tracks: false },
+    gossips: { enabled: true, requireApproval: true, allowMedia: true },
+    media: { enabled: true },
+    info: { enabled: true },
+    game: { enabled: false },
+  },
+  nav: { tabs: ['schedule', 'media', 'gossips', 'info'] },
+  copy: { 'gossips.title': 'The Wall' },
+};
+
+export const FESTIVAL_CONFIG: TenantConfigRow = {
+  tenant_id: T,
+  draft_config: config,
+  published_config: config,
+  published_at: FIXTURE_NOW,
+  published_by: ids.user('devi'),
+  created_at: FIXTURE_NOW,
+  updated_at: FIXTURE_NOW,
+};
+
+const stages = [
+  venue(T, 'fes_main', 'Mainstage', { lat: 15.2993, lng: 74.124, sort_order: 1 }),
+  venue(T, 'fes_grove', 'The Grove', { notes: 'Acoustic only. Bring a blanket.', sort_order: 2 }),
+  venue(T, 'fes_dome', 'Bass Dome', { notes: 'Ear protection at the door.', sort_order: 3 }),
+];
+
+const acts = [
+  person(T, 'fes_kavi', 'Kavi & the Long Way Home', { role_label: 'Headliner', sort_order: 1 }),
+  person(T, 'fes_moss', 'Moss Telegraph', { role_label: 'Live', sort_order: 2 }),
+  person(T, 'fes_ruhi', 'Ruhi', { role_label: 'DJ set', sort_order: 3 }),
+];
+
+const sessions = [
+  session(T, 'fes_gates', 'Gates open', at(DAY, 12, 0, OFFSET), { sort_order: 1 }),
+  session(T, 'fes_moss', 'Moss Telegraph', at(DAY, 15, 30, OFFSET), {
+    ends_at: at(DAY, 16, 30, OFFSET),
+    venue_id: ids.venue('fes_grove'),
+    hero_media_id: ids.media('fes_grove'),
+    sort_order: 2,
+  }),
+  session(T, 'fes_ruhi', 'Ruhi', at(DAY, 18, 0, OFFSET), {
+    ends_at: at(DAY, 19, 30, OFFSET),
+    venue_id: ids.venue('fes_dome'),
+    sort_order: 3,
+  }),
+  /* Deliberately overlapping the headliner: two things at once is the normal case at a
+     festival, and a schedule that assumes otherwise is wrong on its busiest hour. */
+  session(T, 'fes_kavi', 'Kavi & the Long Way Home', at(DAY, 21, 0, OFFSET), {
+    description: 'The one everybody came for.',
+    ends_at: at(DAY, 22, 30, OFFSET),
+    venue_id: ids.venue('fes_main'),
+    hero_media_id: ids.media('fes_main'),
+    sort_order: 4,
+  }),
+  session(T, 'fes_late', 'Late set · Bass Dome', at(DAY, 21, 30, OFFSET), {
+    ends_at: at(DAY, 23, 59, OFFSET),
+    venue_id: ids.venue('fes_dome'),
+    sort_order: 5,
+  }),
+  session(T, 'fes_washed', 'Sunset yoga', at(DAY, 7, 0, OFFSET), {
+    status: 'cancelled',
+    description: 'Cancelled — the field is under water.',
+    sort_order: 6,
+  }),
+];
+
+const owl = persona(T, 'fes_owl', 'Neon Owl', 'dh_fes_a1');
+const fern = persona(T, 'fes_fern', 'Damp Fern', 'dh_fes_b2');
+const personas = [owl, fern];
+
+export const FESTIVAL: Partial<MockTables> = {
+  tenants: [FESTIVAL_TENANT],
+  tenantConfigs: [FESTIVAL_CONFIG],
+  users: [user('devi', 'Devi Menon'), user('rafi', 'Rafi Ahmed'), user('lena', 'Lena Fischer')],
+  memberships: [
+    membership(T, ids.user('devi'), 'event_admin'),
+    membership(T, ids.user('rafi'), 'crew'),
+    membership(T, ids.user('lena'), 'attendee'),
+  ],
+  venues: stages,
+  sessions,
+  people: acts,
+  sessionPeople: [
+    sessionPerson(T, ids.session('fes_kavi'), ids.person('fes_kavi')),
+    sessionPerson(T, ids.session('fes_moss'), ids.person('fes_moss')),
+    sessionPerson(T, ids.session('fes_ruhi'), ids.person('fes_ruhi')),
+  ],
+  mediaAssets: [
+    image(T, 'fes_main', 'The mainstage crowd at dusk', 'L36@#=~q00Rj4nWBofof00Rj~qxu'),
+    image(T, 'fes_grove', 'Strings of lights through trees', 'LBB|WA~q00%M9FIU%MRj00IU~q4n'),
+  ],
+  personas,
+  gossipPosts: [
+    gossip(
+      T,
+      'fes_1',
+      'Whoever is running the chai stall has saved this festival.',
+      owl,
+      'approved',
+      {
+        reaction_counts: { '🔥': 31, '☕': 12 },
+      },
+    ),
+    gossip(T, 'fes_2', 'Lost a green jacket at the Grove. It has my keys in it.', fern, 'approved'),
+    gossip(T, 'fes_3', 'Queue for water is twenty minutes.', fern, 'pending'),
+  ],
+  tasks: [
+    task(T, 'fes_water', 'Open the second water point', ids.user('devi'), 'doing', {
+      assignee_user_id: ids.user('rafi'),
+      priority: 'high',
+      due_at: at(DAY, 14, 0, OFFSET),
+      sort_order: 1,
+    }),
+    task(T, 'fes_cables', 'Tape the cable run at the Dome', ids.user('devi'), 'todo', {
+      assignee_user_id: ids.user('rafi'),
+      sort_order: 2,
+    }),
+  ],
+  units: [
+    unit(T, 'fes_shuttle_a', 'shuttle', 'Shuttle A · every 20 min', {
+      capacity: 30,
+      sort_order: 1,
+    }),
+    unit(T, 'fes_shuttle_b', 'shuttle', 'Shuttle B · last at 01:00', {
+      capacity: 30,
+      sort_order: 2,
+    }),
+  ],
+  announcements: [
+    announcement(
+      T,
+      'fes_water',
+      'Water is free at every bar',
+      'Ask at any bar for tap water. You do not need to queue at the water point for it.',
+      ids.user('devi'),
+      { pinned: true },
+    ),
+  ],
+};

--- a/packages/data/src/fixtures/fixtures.test.ts
+++ b/packages/data/src/fixtures/fixtures.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, it } from '@jest/globals';
+import { ThemeInputSchema, resolveTheme } from '@occasio/theme';
+import { FEATURE_KEYS } from '../config';
+import { FIXTURE_SEED } from './index';
+
+/**
+ * The fixtures are data, and data rots quietly.
+ *
+ * Types catch a missing column. They do not catch a `venue_id` pointing at a venue that was
+ * renamed, a session belonging to one tenant and a venue belonging to another, or two rows
+ * sharing an id — and every one of those renders as a blank space or the wrong event's content
+ * rather than as an error. These are the checks that would otherwise be performed by a person
+ * noticing something looked odd in a screenshot.
+ */
+
+const seed = FIXTURE_SEED;
+
+/** Every row in a tenant-scoped table, paired with the id it claims to belong to. */
+const scoped = [
+  ...seed.venues.map((r) => ({ table: 'venues', id: String(r.id), tenant: r.tenant_id })),
+  ...seed.sessions.map((r) => ({ table: 'sessions', id: String(r.id), tenant: r.tenant_id })),
+  ...seed.people.map((r) => ({ table: 'people', id: String(r.id), tenant: r.tenant_id })),
+  ...seed.mediaAssets.map((r) => ({ table: 'mediaAssets', id: String(r.id), tenant: r.tenant_id })),
+  ...seed.personas.map((r) => ({ table: 'personas', id: String(r.id), tenant: r.tenant_id })),
+  ...seed.gossipPosts.map((r) => ({ table: 'gossipPosts', id: String(r.id), tenant: r.tenant_id })),
+  ...seed.tasks.map((r) => ({ table: 'tasks', id: String(r.id), tenant: r.tenant_id })),
+  ...seed.units.map((r) => ({ table: 'units', id: String(r.id), tenant: r.tenant_id })),
+];
+
+const tenantIds = new Set(seed.tenants.map((t) => String(t.id)));
+const userIds = new Set(seed.users.map((u) => String(u.id)));
+const tenantOf = new Map(scoped.map((row) => [row.id, String(row.tenant)]));
+
+describe('the fixture set', () => {
+  it('has the four events the architecture is meant to be proved on', () => {
+    expect(seed.tenants.map((t) => t.slug).sort()).toEqual([
+      'anandhara',
+      'devcon-25',
+      'maple-1999',
+      'sanit-riyanks',
+    ]);
+    expect(new Set(seed.tenants.map((t) => t.kind)).size).toBe(4);
+  });
+
+  it('gives every tenant exactly one config, and no config an orphan tenant', () => {
+    expect(seed.tenantConfigs).toHaveLength(seed.tenants.length);
+
+    const owners = seed.tenantConfigs.map((row) => String(row.tenant_id));
+    expect(new Set(owners).size).toBe(owners.length);
+    for (const owner of owners) expect(tenantIds.has(owner)).toBe(true);
+  });
+
+  it("keeps the decisions that are not a tenant's to make", () => {
+    /* D3 — every gossip post goes through the moderation queue; an event cannot opt out,
+       because that guarantee is what makes an anonymous board defensible at all. D12 — the game
+       is a seam, not a feature: the config key exists and the answer is always no in Phase 1.
+       Both are typed as literals, so this is belt and braces — but a fixture is exactly where a
+       literal type gets widened by a careless edit. */
+    for (const row of seed.tenantConfigs) {
+      for (const config of [row.draft_config, row.published_config]) {
+        if (config === null) continue;
+        expect(config.features.gossips.requireApproval).toBe(true);
+        expect(config.features.game.enabled).toBe(false);
+        expect(config.version).toBe(1);
+      }
+    }
+  });
+
+  it('never lists a tab that is not a feature', () => {
+    /* The nav filters on `features[k].enabled` at render, so listing a disabled feature is
+       legitimate and deliberate here. Listing something that is not a feature at all is not:
+       it renders as nothing, in a bar where a missing tab looks like a bug in the app. */
+    for (const row of seed.tenantConfigs) {
+      const tabs = (row.published_config ?? row.draft_config).nav.tabs;
+      expect(new Set(tabs).size).toBe(tabs.length);
+      for (const tab of tabs) expect(FEATURE_KEYS).toContain(tab);
+    }
+  });
+
+  it('gives every tenant a theme input the schema accepts', () => {
+    /* The theme half of the config does have a schema, and it is the half an admin edits, so a
+       fixture that drifted from it would be the first thing to break when the editor lands. */
+    for (const row of seed.tenantConfigs) {
+      for (const config of [row.draft_config, row.published_config]) {
+        if (config === null) continue;
+        expect(ThemeInputSchema.safeParse(config.theme).success).toBe(true);
+      }
+    }
+  });
+
+  it('resolves every published theme without throwing', () => {
+    /* The resolver enforces contrast by construction, so this also asserts that no fixture
+       ships a palette a guest could not read. */
+    for (const row of seed.tenantConfigs) {
+      const config = row.published_config ?? row.draft_config;
+      for (const scheme of ['light', 'dark'] as const) {
+        const theme = resolveTheme(config.theme, { forceScheme: scheme });
+        expect(theme.color.text).toBeTruthy();
+      }
+    }
+  });
+
+  it('makes the four events genuinely unalike', () => {
+    /* The fixture set exists to prove one codebase renders four different-looking events. Four
+       identical configs would satisfy every other test here and prove nothing. */
+    const themes = seed.tenantConfigs.map((r) => (r.published_config ?? r.draft_config).theme);
+
+    expect(new Set(themes.map((t) => t.presetId)).size).toBe(4);
+    expect(new Set(themes.map((t) => t.brand.seed)).size).toBe(4);
+    /* Light-pinned, dark-pinned and system, so the resolver's three mode paths all render. */
+    expect(new Set(themes.map((t) => t.mode.support)).size).toBe(3);
+    expect(new Set(themes.map((t) => t.imagery.heroAspect)).size).toBeGreaterThan(1);
+    expect(new Set(themes.map((t) => t.motion.level)).size).toBeGreaterThan(1);
+  });
+
+  it('gives no two rows the same id', () => {
+    /* An id collision across tenants is how one event's content appears inside another, and it
+       is invisible until it happens on a screen. */
+    const ids = scoped.map((row) => row.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('never points a row at another tenant', () => {
+    /* The failure this guards is the one the whole architecture is about: a wedding rendering a
+       conference's room because a fixture wired the ids across. */
+    const crossings: string[] = [];
+    const sameTenant = (from: { tenant: string; table: string }, ref: string | null): void => {
+      if (ref === null) return;
+      const owner = tenantOf.get(ref);
+      if (owner !== undefined && owner !== from.tenant) {
+        crossings.push(`${from.table} in ${from.tenant} references ${ref} in ${owner}`);
+      }
+    };
+
+    for (const row of seed.sessions) {
+      const from = { tenant: String(row.tenant_id), table: 'session' };
+      sameTenant(from, row.venue_id === null ? null : String(row.venue_id));
+      sameTenant(from, row.hero_media_id === null ? null : String(row.hero_media_id));
+    }
+    for (const row of seed.sessionPeople) {
+      const from = { tenant: String(row.tenant_id), table: 'sessionPerson' };
+      sameTenant(from, String(row.session_id));
+      sameTenant(from, String(row.person_id));
+    }
+    for (const row of seed.gossipPosts) {
+      sameTenant({ tenant: String(row.tenant_id), table: 'gossip' }, String(row.persona_id));
+    }
+    for (const row of seed.tasks) {
+      sameTenant(
+        { tenant: String(row.tenant_id), table: 'task' },
+        row.session_id === null ? null : String(row.session_id),
+      );
+    }
+    for (const row of seed.units) {
+      sameTenant(
+        { tenant: String(row.tenant_id), table: 'unit' },
+        row.venue_id === null ? null : String(row.venue_id),
+      );
+    }
+    for (const row of seed.assignments) {
+      sameTenant({ tenant: String(row.tenant_id), table: 'assignment' }, String(row.unit_id));
+    }
+
+    expect(crossings).toEqual([]);
+  });
+
+  it('points every reference at something that exists', () => {
+    const missing: string[] = [];
+    const exists = (label: string, ref: string | null): void => {
+      if (ref !== null && !tenantOf.has(ref)) missing.push(`${label} -> ${ref}`);
+    };
+
+    for (const row of seed.sessions) {
+      exists('session.venue_id', row.venue_id === null ? null : String(row.venue_id));
+      exists(
+        'session.hero_media_id',
+        row.hero_media_id === null ? null : String(row.hero_media_id),
+      );
+    }
+    for (const row of seed.sessionPeople) {
+      exists('sessionPerson.session_id', String(row.session_id));
+      exists('sessionPerson.person_id', String(row.person_id));
+    }
+    for (const row of seed.assignments) exists('assignment.unit_id', String(row.unit_id));
+
+    expect(missing).toEqual([]);
+  });
+
+  it('points every user reference at a real user', () => {
+    const missing: string[] = [];
+    const isUser = (label: string, ref: string | null): void => {
+      if (ref !== null && !userIds.has(ref)) missing.push(`${label} -> ${ref}`);
+    };
+
+    for (const row of seed.memberships) {
+      isUser('membership.user_id', row.user_id === null ? null : String(row.user_id));
+    }
+    for (const row of seed.tasks) {
+      isUser('task.created_by', String(row.created_by));
+      isUser('task.assignee', row.assignee_user_id === null ? null : String(row.assignee_user_id));
+    }
+    for (const row of seed.assignments) isUser('assignment.user_id', String(row.user_id));
+    for (const row of seed.rsvps) isUser('rsvp.user_id', String(row.user_id));
+    for (const row of seed.announcements) isUser('announcement.created_by', String(row.created_by));
+
+    expect(missing).toEqual([]);
+  });
+
+  it('gives every tenant an admin who can actually administer it', () => {
+    /* An event whose only membership is an attendee is one nobody can moderate or publish, and
+       every admin screen would render a ForbiddenError instead of itself. */
+    for (const tenant of seed.tenants) {
+      const admins = seed.memberships.filter(
+        (m) => m.tenant_id === tenant.id && m.role === 'event_admin' && m.status === 'active',
+      );
+      expect(admins.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('covers every moderation state at least once', () => {
+    /* The moderation queue is a screen. A fixture set that only contained approved posts would
+       render it empty and test nothing. */
+    expect(new Set(seed.gossipPosts.map((g) => g.status))).toEqual(
+      new Set(['approved', 'pending', 'rejected', 'hidden']),
+    );
+  });
+
+  it('gives every image a blurhash', () => {
+    /* `Image` treats a missing blurhash as the third-party-avatar case and falls back to a
+       tonal fill. A fixture set without them would screenshot the fallback everywhere and
+       quietly stop exercising the real path. */
+    for (const asset of seed.mediaAssets) {
+      expect(asset.blurhash).toBeTruthy();
+      expect(asset.alt).toBeTruthy();
+    }
+  });
+
+  it('does not move with the clock', () => {
+    /* The visual gate diffs screenshots. A fixture built from `Date.now()` would fail it every
+       midnight, for a reason nobody would attribute to the fixture. */
+    const dates = [
+      ...seed.sessions.map((s) => s.starts_at),
+      ...seed.tenants.flatMap((t) => [t.starts_on, t.ends_on]),
+    ];
+    for (const value of dates) {
+      expect(value).not.toBeNull();
+      expect(String(value)).toMatch(/^20\d\d-/);
+    }
+  });
+});

--- a/packages/data/src/fixtures/fixtures.test.ts
+++ b/packages/data/src/fixtures/fixtures.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from '@jest/globals';
+import type { TenantId } from '@occasio/core';
 import { ThemeInputSchema, resolveTheme } from '@occasio/theme';
 import { FEATURE_KEYS } from '../config';
 import { FIXTURE_SEED } from './index';
@@ -15,21 +16,82 @@ import { FIXTURE_SEED } from './index';
 
 const seed = FIXTURE_SEED;
 
-/** Every row in a tenant-scoped table, paired with the id it claims to belong to. */
-const scoped = [
-  ...seed.venues.map((r) => ({ table: 'venues', id: String(r.id), tenant: r.tenant_id })),
-  ...seed.sessions.map((r) => ({ table: 'sessions', id: String(r.id), tenant: r.tenant_id })),
-  ...seed.people.map((r) => ({ table: 'people', id: String(r.id), tenant: r.tenant_id })),
-  ...seed.mediaAssets.map((r) => ({ table: 'mediaAssets', id: String(r.id), tenant: r.tenant_id })),
-  ...seed.personas.map((r) => ({ table: 'personas', id: String(r.id), tenant: r.tenant_id })),
-  ...seed.gossipPosts.map((r) => ({ table: 'gossipPosts', id: String(r.id), tenant: r.tenant_id })),
-  ...seed.tasks.map((r) => ({ table: 'tasks', id: String(r.id), tenant: r.tenant_id })),
-  ...seed.units.map((r) => ({ table: 'units', id: String(r.id), tenant: r.tenant_id })),
+/**
+ * One map per table, not one map of everything.
+ *
+ * A single id-to-tenant map answers "does this id exist somewhere in this tenant", which is not
+ * the question a foreign key asks. `session.venue_id` pointing at a person in the same tenant
+ * passed that check and renders as a session with no venue — the failure the check was written
+ * to catch.
+ */
+const byId = <T extends { readonly tenant_id: TenantId }>(
+  rows: readonly (T & { readonly id: { toString: () => string } })[],
+): ReadonlyMap<string, string> => new Map(rows.map((r) => [String(r.id), String(r.tenant_id)]));
+
+const venues = byId(seed.venues);
+const sessions = byId(seed.sessions);
+const people = byId(seed.people);
+const mediaAssets = byId(seed.mediaAssets);
+const personas = byId(seed.personas);
+const units = byId(seed.units);
+const tasks = byId(seed.tasks);
+const gossipPosts = byId(seed.gossipPosts);
+
+const ALL_SCOPED: readonly ReadonlyMap<string, string>[] = [
+  venues,
+  sessions,
+  people,
+  mediaAssets,
+  personas,
+  units,
+  tasks,
+  gossipPosts,
 ];
 
 const tenantIds = new Set(seed.tenants.map((t) => String(t.id)));
 const userIds = new Set(seed.users.map((u) => String(u.id)));
-const tenantOf = new Map(scoped.map((row) => [row.id, String(row.tenant)]));
+
+/** Every foreign key in the fixture set, with the table it must point into. */
+type Reference = {
+  readonly label: string;
+  readonly from: TenantId;
+  readonly ref: string | null;
+  readonly target: ReadonlyMap<string, string>;
+};
+
+const references = (): readonly Reference[] => {
+  const out: Reference[] = [];
+  const add = (
+    label: string,
+    from: TenantId,
+    ref: { toString: () => string } | null,
+    target: ReadonlyMap<string, string>,
+  ): void => {
+    out.push({ label, from, ref: ref === null ? null : String(ref), target });
+  };
+
+  for (const row of seed.sessions) {
+    add('session.venue_id', row.tenant_id, row.venue_id, venues);
+    add('session.hero_media_id', row.tenant_id, row.hero_media_id, mediaAssets);
+  }
+  for (const row of seed.sessionPeople) {
+    add('sessionPerson.session_id', row.tenant_id, row.session_id, sessions);
+    add('sessionPerson.person_id', row.tenant_id, row.person_id, people);
+  }
+  for (const row of seed.gossipPosts) {
+    add('gossip.persona_id', row.tenant_id, row.persona_id, personas);
+    add('gossip.media_id', row.tenant_id, row.media_id, mediaAssets);
+  }
+  for (const row of seed.tasks) add('task.session_id', row.tenant_id, row.session_id, sessions);
+  for (const row of seed.units) add('unit.venue_id', row.tenant_id, row.venue_id, venues);
+  for (const row of seed.assignments) add('assignment.unit_id', row.tenant_id, row.unit_id, units);
+  for (const row of seed.rsvps) add('rsvp.session_id', row.tenant_id, row.session_id, sessions);
+  for (const row of seed.people) {
+    add('person.photo_media_id', row.tenant_id, row.photo_media_id, mediaAssets);
+  }
+
+  return out;
+};
 
 describe('the fixture set', () => {
   it('has the four events the architecture is meant to be proved on', () => {
@@ -115,75 +177,46 @@ describe('the fixture set', () => {
 
   it('gives no two rows the same id', () => {
     /* An id collision across tenants is how one event's content appears inside another, and it
-       is invisible until it happens on a screen. */
-    const ids = scoped.map((row) => row.id);
+       is invisible until it happens on a screen. Memberships are included because their ids
+       used to be derived from `user_id`, and an unaccepted invitation has none. */
+    const ids = [
+      ...ALL_SCOPED.flatMap((table) => [...table.keys()]),
+      ...seed.memberships.map((m) => String(m.id)),
+    ];
+
     expect(new Set(ids).size).toBe(ids.length);
   });
 
-  it('never points a row at another tenant', () => {
-    /* The failure this guards is the one the whole architecture is about: a wedding rendering a
-       conference's room because a fixture wired the ids across. */
-    const crossings: string[] = [];
-    const sameTenant = (from: { tenant: string; table: string }, ref: string | null): void => {
-      if (ref === null) return;
-      const owner = tenantOf.get(ref);
-      if (owner !== undefined && owner !== from.tenant) {
-        crossings.push(`${from.table} in ${from.tenant} references ${ref} in ${owner}`);
+  it('points every reference into the right table, in the right tenant', () => {
+    /*
+     * Both halves in one pass, because separately each misses what the other assumes. Existence
+     * alone accepts a `venue_id` holding a person's id; tenant alone accepts it too, as long as
+     * the person is in the same event. Either way the screen renders a session with no venue and
+     * nobody can see why.
+     *
+     * The tenant half is the one the whole architecture is about: a wedding showing a
+     * conference's room because a fixture wired the ids across.
+     */
+    const problems: string[] = [];
+
+    for (const { label, from, ref, target } of references()) {
+      if (ref === null) continue;
+      const owner = target.get(ref);
+      if (owner === undefined) {
+        const elsewhere = ALL_SCOPED.some((table) => table.has(ref));
+        problems.push(
+          elsewhere
+            ? `${label} -> ${ref} exists, but not in the table this column points into`
+            : `${label} -> ${ref} does not exist`,
+        );
+        continue;
       }
-    };
-
-    for (const row of seed.sessions) {
-      const from = { tenant: String(row.tenant_id), table: 'session' };
-      sameTenant(from, row.venue_id === null ? null : String(row.venue_id));
-      sameTenant(from, row.hero_media_id === null ? null : String(row.hero_media_id));
-    }
-    for (const row of seed.sessionPeople) {
-      const from = { tenant: String(row.tenant_id), table: 'sessionPerson' };
-      sameTenant(from, String(row.session_id));
-      sameTenant(from, String(row.person_id));
-    }
-    for (const row of seed.gossipPosts) {
-      sameTenant({ tenant: String(row.tenant_id), table: 'gossip' }, String(row.persona_id));
-    }
-    for (const row of seed.tasks) {
-      sameTenant(
-        { tenant: String(row.tenant_id), table: 'task' },
-        row.session_id === null ? null : String(row.session_id),
-      );
-    }
-    for (const row of seed.units) {
-      sameTenant(
-        { tenant: String(row.tenant_id), table: 'unit' },
-        row.venue_id === null ? null : String(row.venue_id),
-      );
-    }
-    for (const row of seed.assignments) {
-      sameTenant({ tenant: String(row.tenant_id), table: 'assignment' }, String(row.unit_id));
+      if (owner !== String(from)) {
+        problems.push(`${label} in ${String(from)} points at ${ref}, which belongs to ${owner}`);
+      }
     }
 
-    expect(crossings).toEqual([]);
-  });
-
-  it('points every reference at something that exists', () => {
-    const missing: string[] = [];
-    const exists = (label: string, ref: string | null): void => {
-      if (ref !== null && !tenantOf.has(ref)) missing.push(`${label} -> ${ref}`);
-    };
-
-    for (const row of seed.sessions) {
-      exists('session.venue_id', row.venue_id === null ? null : String(row.venue_id));
-      exists(
-        'session.hero_media_id',
-        row.hero_media_id === null ? null : String(row.hero_media_id),
-      );
-    }
-    for (const row of seed.sessionPeople) {
-      exists('sessionPerson.session_id', String(row.session_id));
-      exists('sessionPerson.person_id', String(row.person_id));
-    }
-    for (const row of seed.assignments) exists('assignment.unit_id', String(row.unit_id));
-
-    expect(missing).toEqual([]);
+    expect(problems).toEqual([]);
   });
 
   it('points every user reference at a real user', () => {
@@ -236,15 +269,41 @@ describe('the fixture set', () => {
   });
 
   it('does not move with the clock', () => {
-    /* The visual gate diffs screenshots. A fixture built from `Date.now()` would fail it every
-       midnight, for a reason nobody would attribute to the fixture. */
-    const dates = [
-      ...seed.sessions.map((s) => s.starts_at),
-      ...seed.tenants.flatMap((t) => [t.starts_on, t.ends_on]),
-    ];
-    for (const value of dates) {
-      expect(value).not.toBeNull();
-      expect(String(value)).toMatch(/^20\d\d-/);
+    /*
+     * `^20\\d\\d-` was the first version of this, and it was worth nothing: a value from
+     * `new Date()` matches it, and so did `2026-11-20T10.5:00:00.000Z` — the invalid string a
+     * fractional timezone offset produced, which made every wedding and festival time in this
+     * set unparseable while the test stayed green.
+     *
+     * So: exact values, and a parse. The visual gate diffs screenshots, and a fixture that
+     * moved with the clock would fail it every midnight for a reason nobody would attribute to
+     * the fixture.
+     */
+    const bySlug = new Map(seed.tenants.map((t) => [t.slug, t]));
+    expect(bySlug.get('sanit-riyanks')?.starts_on).toBe('2026-11-20');
+    expect(bySlug.get('devcon-25')?.ends_on).toBe('2026-10-07');
+
+    const byId = new Map(seed.sessions.map((row) => [String(row.id), row]));
+    /* 16:00 in Asia/Kolkata is 10:30Z — the half-hour offset the broken helper could not
+       express, pinned here so it cannot silently become 10:00 or an invalid string again. */
+    expect(byId.get('s_wed_mehendi')?.starts_at).toBe('2026-11-20T10:30:00.000Z');
+    /* 09:30 in Europe/Berlin is 07:30Z, a whole-hour offset for contrast. */
+    expect(byId.get('s_con_keynote')?.starts_at).toBe('2026-10-06T07:30:00.000Z');
+
+    for (const row of seed.sessions) {
+      expect(Number.isNaN(Date.parse(row.starts_at))).toBe(false);
+      if (row.ends_at !== null) expect(Number.isNaN(Date.parse(row.ends_at))).toBe(false);
+    }
+    for (const row of seed.tasks) {
+      if (row.due_at !== null) expect(Number.isNaN(Date.parse(row.due_at))).toBe(false);
+    }
+  });
+
+  it('gives every image a dominant colour to paint before it loads', () => {
+    /* The frame shows this while the blurhash decodes and behind an image that never arrives.
+       Null everywhere would have made that path render the neutral fallback in every fixture. */
+    for (const asset of seed.mediaAssets) {
+      expect(asset.dominant_color).toMatch(/^#[0-9a-f]{6}$/);
     }
   });
 });

--- a/packages/data/src/fixtures/fixtures.test.ts
+++ b/packages/data/src/fixtures/fixtures.test.ts
@@ -104,7 +104,15 @@ describe('the fixture set', () => {
       'maple-1999',
       'sanit-riyanks',
     ]);
-    expect(new Set(seed.tenants.map((t) => t.kind)).size).toBe(4);
+    /* Which slug is which kind, not merely that four kinds appear. Distinctness alone is
+       satisfied by swapping the wedding and the festival, and every screen that branches on
+       `kind` would then be exercised against the wrong fixture. */
+    expect(Object.fromEntries(seed.tenants.map((t) => [t.slug, t.kind]))).toEqual({
+      'sanit-riyanks': 'wedding',
+      anandhara: 'festival',
+      'devcon-25': 'conference',
+      'maple-1999': 'reunion',
+    });
   });
 
   it('gives every tenant exactly one config, and no config an orphan tenant', () => {
@@ -131,14 +139,23 @@ describe('the fixture set', () => {
     }
   });
 
-  it('never lists a tab that is not a feature', () => {
-    /* The nav filters on `features[k].enabled` at render, so listing a disabled feature is
-       legitimate and deliberate here. Listing something that is not a feature at all is not:
-       it renders as nothing, in a bar where a missing tab looks like a bug in the app. */
+  it('never lists a tab that is not a feature, in either config', () => {
+    /*
+     * The nav filters on `features[k].enabled` at render, so listing a disabled feature is
+     * legitimate and deliberate here. Listing something that is not a feature at all is not: it
+     * renders as nothing, in a bar where a missing tab looks like a bug in the app.
+     *
+     * Both configs, independently. Reading `published_config ?? draft_config` would let a
+     * broken draft through whenever a valid published one existed — and the draft is the one
+     * the theme editor renders, so it is the half a person sees first.
+     */
     for (const row of seed.tenantConfigs) {
-      const tabs = (row.published_config ?? row.draft_config).nav.tabs;
-      expect(new Set(tabs).size).toBe(tabs.length);
-      for (const tab of tabs) expect(FEATURE_KEYS).toContain(tab);
+      for (const config of [row.draft_config, row.published_config]) {
+        if (config === null) continue;
+        const tabs = config.nav.tabs;
+        expect(new Set(tabs).size).toBe(tabs.length);
+        for (const tab of tabs) expect(FEATURE_KEYS).toContain(tab);
+      }
     }
   });
 

--- a/packages/data/src/fixtures/fixtures.test.ts
+++ b/packages/data/src/fixtures/fixtures.test.ts
@@ -182,10 +182,26 @@ describe('the fixture set', () => {
     /* An id collision across tenants is how one event's content appears inside another, and it
        is invisible until it happens on a screen. Memberships are included because their ids
        used to be derived from `user_id`, and an unaccepted invitation has none. */
+    /*
+     * Built from the rows, not from the maps. A `Map` keyed by id collapses a duplicate before
+     * this can see it, so counting its keys would have compared a deduplicated list against its
+     * own length and passed on exactly the input it exists to reject. The maps are for foreign
+     * key lookup, where one entry per id is what is wanted.
+     */
     const ids = [
-      ...ALL_SCOPED.flatMap((table) => [...table.keys()]),
-      ...seed.memberships.map((m) => String(m.id)),
-    ];
+      ...seed.venues,
+      ...seed.sessions,
+      ...seed.people,
+      ...seed.mediaAssets,
+      ...seed.personas,
+      ...seed.units,
+      ...seed.tasks,
+      ...seed.gossipPosts,
+      ...seed.memberships,
+      ...seed.assignments,
+      ...seed.announcements,
+      ...seed.approvalRequests,
+    ].map((row) => String(row.id));
 
     expect(new Set(ids).size).toBe(ids.length);
   });

--- a/packages/data/src/fixtures/fixtures.test.ts
+++ b/packages/data/src/fixtures/fixtures.test.ts
@@ -24,8 +24,11 @@ const seed = FIXTURE_SEED;
  * passed that check and renders as a session with no venue — the failure the check was written
  * to catch.
  */
-const byId = <T extends { readonly tenant_id: TenantId }>(
-  rows: readonly (T & { readonly id: { toString: () => string } })[],
+const byId = (
+  rows: readonly {
+    readonly id: { readonly toString: () => string };
+    readonly tenant_id: TenantId;
+  }[],
 ): ReadonlyMap<string, string> => new Map(rows.map((r) => [String(r.id), String(r.tenant_id)]));
 
 const venues = byId(seed.venues);

--- a/packages/data/src/fixtures/index.ts
+++ b/packages/data/src/fixtures/index.ts
@@ -1,0 +1,64 @@
+import { EMPTY_TABLES, type MockSeed, type MockTables } from '../mock/tables';
+import { CONFERENCE } from './conference';
+import { FESTIVAL } from './festival';
+import { REUNION } from './reunion';
+import { WEDDING } from './wedding';
+
+/**
+ * The four events, as one seed.
+ *
+ * Four tenants in one dataset rather than four datasets, because that is the shape the product
+ * actually has: one adapter, many events, and every read scoped by `tenant_id`. A fixture set
+ * with one tenant in it would let a missing scope pass every screen and every test, and the
+ * failure would arrive as one event's guest list appearing on another's.
+ *
+ * They are deliberately unalike. A wedding pinned to light, a festival pinned to dark, a
+ * conference following the device, and a reunion with most features switched off — different
+ * presets, seeds, densities, corner shapes, aspect ratios and motion levels. Screenshotting the
+ * same screens across all four is what turns "tenant config drives look and behaviour" from an
+ * intention into something a diff can fail on.
+ */
+
+export { WEDDING, WEDDING_TENANT, WEDDING_CONFIG } from './wedding';
+export { FESTIVAL, FESTIVAL_TENANT, FESTIVAL_CONFIG } from './festival';
+export { CONFERENCE, CONFERENCE_TENANT, CONFERENCE_CONFIG } from './conference';
+export { REUNION, REUNION_TENANT, REUNION_CONFIG } from './reunion';
+export { FIXTURE_NOW } from './builders';
+
+const EVENTS: readonly Partial<MockTables>[] = [WEDDING, FESTIVAL, CONFERENCE, REUNION];
+
+/**
+ * Written out one table at a time rather than merged generically.
+ *
+ * The generic version was written first and did not survive: a merge over `keyof MockTables`
+ * needs a cast to convince the compiler that the value at key `k` belongs at key `k`, and casts
+ * are banned outside the mappers for exactly this class of reason. The lint rule caught it,
+ * which is the rule working.
+ *
+ * Spelling the tables out costs twenty lines and buys a compile error the day a table is added
+ * to `MockTables` and forgotten here. Without it the failure is a new table silently empty in
+ * every fixture, which looks like a feature with no data rather than a fixture with no rows.
+ */
+export const FIXTURE_SEED: MockSeed = {
+  ...EMPTY_TABLES,
+  tenants: EVENTS.flatMap((e) => e.tenants ?? []),
+  tenantConfigs: EVENTS.flatMap((e) => e.tenantConfigs ?? []),
+  users: EVENTS.flatMap((e) => e.users ?? []),
+  memberships: EVENTS.flatMap((e) => e.memberships ?? []),
+  approvalRequests: EVENTS.flatMap((e) => e.approvalRequests ?? []),
+  venues: EVENTS.flatMap((e) => e.venues ?? []),
+  sessions: EVENTS.flatMap((e) => e.sessions ?? []),
+  people: EVENTS.flatMap((e) => e.people ?? []),
+  sessionPeople: EVENTS.flatMap((e) => e.sessionPeople ?? []),
+  mediaAssets: EVENTS.flatMap((e) => e.mediaAssets ?? []),
+  personas: EVENTS.flatMap((e) => e.personas ?? []),
+  gossipPosts: EVENTS.flatMap((e) => e.gossipPosts ?? []),
+  tasks: EVENTS.flatMap((e) => e.tasks ?? []),
+  units: EVENTS.flatMap((e) => e.units ?? []),
+  assignments: EVENTS.flatMap((e) => e.assignments ?? []),
+  announcements: EVENTS.flatMap((e) => e.announcements ?? []),
+  rsvps: EVENTS.flatMap((e) => e.rsvps ?? []),
+  notificationPreferences: EVENTS.flatMap((e) => e.notificationPreferences ?? []),
+  deviceTokens: EVENTS.flatMap((e) => e.deviceTokens ?? []),
+  notificationDeliveries: EVENTS.flatMap((e) => e.notificationDeliveries ?? []),
+};

--- a/packages/data/src/fixtures/reunion.ts
+++ b/packages/data/src/fixtures/reunion.ts
@@ -91,8 +91,8 @@ export const REUNION: Partial<MockTables> = {
   tenantConfigs: [REUNION_CONFIG],
   users: [user('harriet', 'Harriet Bell'), user('george', 'George Amankwah')],
   memberships: [
-    membership(T, ids.user('harriet'), 'event_admin'),
-    membership(T, ids.user('george'), 'attendee'),
+    membership(T, 'reu_harriet', ids.user('harriet'), 'event_admin'),
+    membership(T, 'reu_george', ids.user('george'), 'attendee'),
   ],
   venues: [
     venue(T, 'reu_hall', 'The Old Assembly Hall', {
@@ -126,7 +126,13 @@ export const REUNION: Partial<MockTables> = {
   ],
   sessionPeople: [],
   mediaAssets: [
-    image(T, 'reu_hall', 'The assembly hall, set for dinner', 'LEHV6nWB2yk8pyoJadR*.7kCMdnj'),
+    image(
+      T,
+      'reu_hall',
+      'The assembly hall, set for dinner',
+      'LEHV6nWB2yk8pyoJadR*.7kCMdnj',
+      '#6b4636',
+    ),
   ],
   /* Empty on purpose: the board is off for this tenant, and a screen that assumed at least one
      persona would break on the first event that turned gossips off. */

--- a/packages/data/src/fixtures/reunion.ts
+++ b/packages/data/src/fixtures/reunion.ts
@@ -1,0 +1,175 @@
+import { themeInputFromPreset } from '@occasio/theme';
+import type { TenantConfig } from '../config';
+import type { MockTables } from '../mock/tables';
+import type { TenantConfigRow, TenantRow } from '../rows';
+import {
+  FIXTURE_NOW,
+  announcement,
+  at,
+  ids,
+  image,
+  membership,
+  person,
+  session,
+  task,
+  unit,
+  user,
+  venue,
+} from './builders';
+
+/**
+ * A school reunion: small, private, and the fixture where most things are switched off.
+ *
+ * Every other event turns features on. This one turns them off — no gossip board, no media
+ * gallery, two tabs — because a config that only ever adds is a config whose subtraction path
+ * has never rendered. An empty `personas` and `gossipPosts` here is the point rather than an
+ * omission: it is what a tenant with the board disabled actually looks like, and the screens
+ * have to survive it.
+ *
+ * It is also the only `private` tenant and the only one still `pending_approval`, so the
+ * super-admin queue (D25) has something in it.
+ */
+
+const T = ids.tenant('maple-1999');
+const DAY = '2026-08-15';
+/** British Summer Time. */
+const BST = 1;
+
+export const REUNION_TENANT: TenantRow = {
+  id: T,
+  slug: 'maple-1999',
+  name: 'Maple Grove, Class of 1999',
+  kind: 'reunion',
+  status: 'pending_approval',
+  timezone: 'Europe/London',
+  visibility: 'private',
+  join_code: 'MAPLE99',
+  starts_on: DAY,
+  ends_on: DAY,
+  created_by: ids.user('harriet'),
+  created_at: FIXTURE_NOW,
+  updated_at: FIXTURE_NOW,
+};
+
+const config: TenantConfig = {
+  version: 1,
+  theme: {
+    ...themeInputFromPreset('minimal', '#C2410C'),
+    mode: { support: 'system', default: 'light' },
+    imagery: { heroAspect: '3:2', treatment: 'mono', scrim: 'light' },
+    /* The accessible end of D11, chosen by the tenant rather than forced by the device — which
+       is a different path through the resolver from the reduce-motion one. */
+    motion: { level: 'none' },
+    density: 'comfortable',
+    shape: { corner: 'sharp' },
+  },
+  features: {
+    schedule: { enabled: true, defaultView: 'list', tracks: false },
+    gossips: { enabled: false, requireApproval: true, allowMedia: false },
+    media: { enabled: false },
+    info: { enabled: true },
+    game: { enabled: false },
+  },
+  nav: { tabs: ['schedule', 'info'] },
+  copy: {},
+};
+
+export const REUNION_CONFIG: TenantConfigRow = {
+  tenant_id: T,
+  /* Draft ahead of published: the theme editor's unsaved state, and the reason the column is
+     split. A screen reading the wrong one shows guests a colour nobody approved. */
+  draft_config: { ...config, theme: { ...config.theme, brand: { seed: '#166534' } } },
+  published_config: config,
+  published_at: FIXTURE_NOW,
+  published_by: ids.user('harriet'),
+  created_at: FIXTURE_NOW,
+  updated_at: FIXTURE_NOW,
+};
+
+export const REUNION: Partial<MockTables> = {
+  tenants: [REUNION_TENANT],
+  tenantConfigs: [REUNION_CONFIG],
+  users: [user('harriet', 'Harriet Bell'), user('george', 'George Amankwah')],
+  memberships: [
+    membership(T, ids.user('harriet'), 'event_admin'),
+    membership(T, ids.user('george'), 'attendee'),
+  ],
+  venues: [
+    venue(T, 'reu_hall', 'The Old Assembly Hall', {
+      address: 'Maple Grove School, Bristol',
+      lat: 51.4545,
+      lng: -2.5879,
+      notes: 'The side door by the bike sheds is unlocked from six.',
+      sort_order: 1,
+    }),
+  ],
+  sessions: [
+    session(T, 'reu_drinks', 'Drinks in the hall', at(DAY, 18, 30, BST), {
+      ends_at: at(DAY, 20, 0, BST),
+      venue_id: ids.venue('reu_hall'),
+      hero_media_id: ids.media('reu_hall'),
+      sort_order: 1,
+    }),
+    session(T, 'reu_dinner', 'Dinner', at(DAY, 20, 0, BST), {
+      ends_at: at(DAY, 22, 30, BST),
+      venue_id: ids.venue('reu_hall'),
+      sort_order: 2,
+    }),
+  ],
+  people: [
+    person(T, 'reu_harriet', 'Harriet Bell', {
+      user_id: ids.user('harriet'),
+      role_label: 'Organiser',
+      bio: 'Has been organising this since 2019.',
+      sort_order: 1,
+    }),
+  ],
+  sessionPeople: [],
+  mediaAssets: [
+    image(T, 'reu_hall', 'The assembly hall, set for dinner', 'LEHV6nWB2yk8pyoJadR*.7kCMdnj'),
+  ],
+  /* Empty on purpose: the board is off for this tenant, and a screen that assumed at least one
+     persona would break on the first event that turned gossips off. */
+  personas: [],
+  gossipPosts: [],
+  tasks: [
+    task(
+      T,
+      'reu_nametags',
+      'Print the name tags with the 1999 photos',
+      ids.user('harriet'),
+      'doing',
+      {
+        assignee_user_id: ids.user('harriet'),
+        due_at: at(DAY, 12, 0, BST),
+        visibility: 'private',
+        sort_order: 1,
+      },
+    ),
+  ],
+  units: [
+    unit(T, 'reu_t1', 'table', 'Long table', { capacity: 24, venue_id: ids.venue('reu_hall') }),
+  ],
+  announcements: [
+    announcement(
+      T,
+      'reu_parking',
+      'Park on the road, not the field',
+      'The field is soft after the rain and the school has asked us to keep off it.',
+      ids.user('harriet'),
+    ),
+  ],
+  approvalRequests: [
+    {
+      id: ids.approvalRequest('reu_1'),
+      tenant_id: T,
+      status: 'pending',
+      requested_by: ids.user('harriet'),
+      requested_at: FIXTURE_NOW,
+      reviewed_by: null,
+      reviewed_at: null,
+      note: 'First event on the platform — happy to answer anything.',
+      created_at: FIXTURE_NOW,
+    },
+  ],
+};

--- a/packages/data/src/fixtures/wedding.ts
+++ b/packages/data/src/fixtures/wedding.ts
@@ -1,0 +1,341 @@
+import { themeInputFromPreset } from '@occasio/theme';
+import type { TenantConfig } from '../config';
+import type { TenantConfigRow, TenantRow } from '../rows';
+import type { MockTables } from '../mock/tables';
+import {
+  FIXTURE_NOW,
+  announcement,
+  assignment,
+  at,
+  gossip,
+  ids,
+  image,
+  membership,
+  person,
+  persona,
+  session,
+  sessionPerson,
+  task,
+  unit,
+  user,
+  venue,
+} from './builders';
+
+/**
+ * A wedding: two days, one family, and a schedule nobody reads as a list.
+ *
+ * The theming choices are the point of the fixture rather than decoration. `mode.support:
+ * 'light'` pins it — a wedding site that flipped to dark because a guest's phone did would look
+ * like a different event — while the conference fixture follows the device and the festival
+ * pins dark. Three policies across four events is what proves the resolver is driven by config
+ * rather than by whatever the first screen happened to need.
+ */
+
+const T = ids.tenant('sanit-riyanks');
+const DAY_ONE = '2026-11-20';
+const DAY_TWO = '2026-11-21';
+/** India Standard Time: +5:30, which is also the half-hour offset worth having in a fixture. */
+const IST = 5.5;
+
+export const WEDDING_TENANT: TenantRow = {
+  id: T,
+  slug: 'sanit-riyanks',
+  name: 'Sanit & Riya',
+  kind: 'wedding',
+  status: 'approved',
+  timezone: 'Asia/Kolkata',
+  visibility: 'unlisted',
+  join_code: 'SANRIY26',
+  starts_on: DAY_ONE,
+  ends_on: DAY_TWO,
+  created_by: ids.user('sanit'),
+  created_at: FIXTURE_NOW,
+  updated_at: FIXTURE_NOW,
+};
+
+const config: TenantConfig = {
+  version: 1,
+  theme: {
+    ...themeInputFromPreset('romantic', '#7C3A5A'),
+    mode: { support: 'light', default: 'light' },
+    imagery: { heroAspect: '4:5', treatment: 'warm', scrim: 'auto' },
+    motion: { level: 'subtle' },
+    density: 'comfortable',
+    shape: { corner: 'round' },
+  },
+  features: {
+    schedule: { enabled: true, defaultView: 'stories', tracks: false },
+    gossips: { enabled: true, requireApproval: true, allowMedia: true },
+    media: { enabled: true },
+    info: { enabled: true },
+    game: { enabled: false },
+  },
+  nav: { tabs: ['schedule', 'gossips', 'media', 'info'] },
+  /* D21 — a wedding calls the board "Whispers". The same key, a different word, no code. */
+  copy: { 'gossips.title': 'Whispers', 'gossips.empty': 'No whispers yet. Be the first.' },
+};
+
+export const WEDDING_CONFIG: TenantConfigRow = {
+  tenant_id: T,
+  draft_config: config,
+  published_config: config,
+  published_at: FIXTURE_NOW,
+  published_by: ids.user('sanit'),
+  created_at: FIXTURE_NOW,
+  updated_at: FIXTURE_NOW,
+};
+
+const users = [
+  user('sanit', 'Sanit Dhar'),
+  user('riya', 'Riya Kapoor'),
+  user('meera', 'Meera Kapoor'),
+  user('arjun', 'Arjun Rao'),
+  user('nisha', 'Nisha Verma'),
+];
+
+const venues = [
+  venue(T, 'wed_courtyard', 'The Courtyard', {
+    address: '14 Rosewood Lane, Bengaluru',
+    lat: 12.9716,
+    lng: 77.5946,
+    notes: 'Enter through the garden gate; the driveway is for vendors.',
+    sort_order: 1,
+  }),
+  venue(T, 'wed_hall', 'Lakeview Hall', {
+    address: 'Lakeview Estate, Bengaluru',
+    lat: 12.9611,
+    lng: 77.6387,
+    sort_order: 2,
+  }),
+];
+
+const media = [
+  image(T, 'wed_hero', 'The couple under the mandap at dusk', 'LKO2?U%2Tw=w]~RBVZRi};RPxuwH'),
+  image(T, 'wed_mehendi', 'Hands painted with mehendi', 'LEHV6nWB2yk8pyo0adR*.7kCMdnj'),
+  image(
+    T,
+    'wed_sangeet',
+    'The family mid-dance under string lights',
+    'L6PZfSi_.AyE_3t7t7R**0o#DgR4',
+  ),
+];
+
+const people = [
+  person(T, 'wed_sanit', 'Sanit Dhar', {
+    user_id: ids.user('sanit'),
+    role_label: 'Groom',
+    bio: 'Grew up two streets from the venue and still gets lost in it.',
+    sort_order: 1,
+  }),
+  person(T, 'wed_riya', 'Riya Kapoor', {
+    user_id: ids.user('riya'),
+    role_label: 'Bride',
+    bio: 'Will be the one telling the band to play one more.',
+    sort_order: 2,
+  }),
+  /* No `user_id`: the reason `people` is a separate table. He is on the site and will never
+     sign in, and the schema has to hold that without inventing an account for him. */
+  person(T, 'wed_uncle', 'Vikram Kapoor', {
+    role_label: "Bride's father",
+    bio: 'Master of ceremonies, self-appointed.',
+    sort_order: 3,
+  }),
+];
+
+const sessions = [
+  session(T, 'wed_mehendi', 'Mehendi', at(DAY_ONE, 16, 0, IST), {
+    description: 'Bring an appetite and sleeves you can push up.',
+    ends_at: at(DAY_ONE, 19, 0, IST),
+    venue_id: ids.venue('wed_courtyard'),
+    hero_media_id: ids.media('wed_mehendi'),
+    sort_order: 1,
+  }),
+  session(T, 'wed_sangeet', 'Sangeet', at(DAY_ONE, 20, 0, IST), {
+    description: 'Dancing, and a slideshow nobody has been allowed to preview.',
+    ends_at: at(DAY_ONE, 23, 30, IST),
+    venue_id: ids.venue('wed_hall'),
+    hero_media_id: ids.media('wed_sangeet'),
+    sort_order: 2,
+  }),
+  session(T, 'wed_ceremony', 'The Ceremony', at(DAY_TWO, 10, 30, IST), {
+    description: 'Seating from 10:00. It starts on time, which nobody believes.',
+    ends_at: at(DAY_TWO, 12, 30, IST),
+    venue_id: ids.venue('wed_courtyard'),
+    hero_media_id: ids.media('wed_hero'),
+    sort_order: 3,
+  }),
+  session(T, 'wed_reception', 'Reception', at(DAY_TWO, 19, 0, IST), {
+    ends_at: at(DAY_TWO, 23, 0, IST),
+    venue_id: ids.venue('wed_hall'),
+    sort_order: 4,
+  }),
+  /* Draft, so a screen that forgets to filter shows a session guests should not see. */
+  session(T, 'wed_brunch', 'Farewell brunch', at(DAY_TWO, 11, 0, IST), {
+    status: 'draft',
+    sort_order: 5,
+  }),
+];
+
+/* Named rather than indexed out of an array: `lantern` is a non-null assertion, which
+   this repo bans, and a name reads better in the posts below anyway. */
+const lantern = persona(T, 'wed_lantern', 'Curious Lantern', 'dh_wed_a1');
+const peacock = persona(T, 'wed_peacock', 'Restless Peacock', 'dh_wed_b2');
+const personas = [lantern, peacock];
+
+const gossips = [
+  gossip(
+    T,
+    'wed_1',
+    'The groom practised his entrance for an hour. It shows, and not in the way he hoped.',
+    lantern,
+    'approved',
+    { reaction_counts: { '😂': 14, '❤️': 6 } },
+  ),
+  gossip(T, 'wed_2', 'Whoever made the gulab jamun: marry me instead.', peacock, 'approved', {
+    reaction_counts: { '😂': 22 },
+  }),
+  /* One of each state, because the moderation queue is a screen and an empty queue tests
+     nothing. `pending` is also what the attendee sees as "waiting to be approved". */
+  gossip(T, 'wed_3', 'Table 4 has started a conga line. It is 6pm.', lantern, 'pending'),
+  gossip(T, 'wed_4', 'A post that broke the rules.', peacock, 'rejected', {
+    moderated_by: ids.user('meera'),
+    rejection_reason: 'Named a guest who has not posted here.',
+  }),
+  gossip(T, 'wed_5', 'Auto-hidden after reports.', lantern, 'hidden', { report_count: 4 }),
+];
+
+const units = [
+  unit(T, 'wed_t1', 'table', 'Table 1', {
+    capacity: 8,
+    venue_id: ids.venue('wed_hall'),
+    sort_order: 1,
+  }),
+  unit(T, 'wed_t2', 'table', 'Table 2', {
+    capacity: 8,
+    venue_id: ids.venue('wed_hall'),
+    sort_order: 2,
+  }),
+  unit(T, 'wed_shuttle', 'shuttle', 'Hotel shuttle · 09:15', {
+    capacity: 14,
+    venue_id: ids.venue('wed_courtyard'),
+    meta: { departsFrom: 'Rosewood Hotel lobby' },
+    sort_order: 3,
+  }),
+];
+
+export const WEDDING: Partial<MockTables> = {
+  tenants: [WEDDING_TENANT],
+  tenantConfigs: [WEDDING_CONFIG],
+  users,
+  memberships: [
+    membership(T, ids.user('sanit'), 'event_admin'),
+    membership(T, ids.user('riya'), 'event_admin'),
+    membership(T, ids.user('meera'), 'moderator'),
+    membership(T, ids.user('arjun'), 'crew'),
+    membership(T, ids.user('nisha'), 'attendee'),
+  ],
+  venues,
+  sessions,
+  people,
+  sessionPeople: [
+    sessionPerson(T, ids.session('wed_ceremony'), ids.person('wed_sanit'), { sort_order: 1 }),
+    sessionPerson(T, ids.session('wed_ceremony'), ids.person('wed_riya'), { sort_order: 2 }),
+    sessionPerson(T, ids.session('wed_sangeet'), ids.person('wed_uncle'), {
+      role_label: 'Host',
+      sort_order: 1,
+    }),
+  ],
+  mediaAssets: media,
+  personas,
+  gossipPosts: gossips,
+  tasks: [
+    task(T, 'wed_flowers', 'Confirm the flowers for the mandap', ids.user('sanit'), 'done', {
+      assignee_user_id: ids.user('arjun'),
+      due_at: at(DAY_ONE, 9, 0, IST),
+      priority: 'high',
+      sort_order: 1,
+    }),
+    task(
+      T,
+      'wed_shuttle',
+      'Chase the shuttle driver for a pickup time',
+      ids.user('sanit'),
+      'doing',
+      {
+        assignee_user_id: ids.user('arjun'),
+        due_at: at(DAY_TWO, 8, 0, IST),
+        remind_before_minutes: 120,
+        session_id: ids.session('wed_ceremony'),
+        sort_order: 2,
+      },
+    ),
+    task(T, 'wed_speech', 'Write the speech', ids.user('sanit'), 'blocked', {
+      assignee_user_id: ids.user('sanit'),
+      notes: 'Blocked on remembering how they met.',
+      visibility: 'private',
+      sort_order: 3,
+    }),
+    task(T, 'wed_playlist', 'Send the band the do-not-play list', ids.user('riya'), 'todo', {
+      assignee_user_id: ids.user('nisha'),
+      due_at: at(DAY_ONE, 12, 0, IST),
+      priority: 'low',
+      visibility: 'public',
+      sort_order: 4,
+    }),
+  ],
+  units,
+  assignments: [
+    assignment(T, 'wed_1', ids.unit('wed_t1'), ids.user('nisha'), ids.user('riya'), {
+      note: 'Near the front, away from the speakers.',
+    }),
+    assignment(T, 'wed_2', ids.unit('wed_shuttle'), ids.user('nisha'), ids.user('arjun')),
+  ],
+  announcements: [
+    announcement(
+      T,
+      'wed_parking',
+      'Parking is behind the temple',
+      'The driveway fills by ten. There is space behind the temple, two minutes on foot.',
+      ids.user('sanit'),
+      { pinned: true },
+    ),
+    announcement(
+      T,
+      'wed_rain',
+      'Rain plan',
+      'If it rains the ceremony moves indoors to Lakeview Hall. We will post here by 08:00.',
+      ids.user('riya'),
+    ),
+  ],
+  rsvps: [
+    {
+      tenant_id: T,
+      user_id: ids.user('nisha'),
+      session_id: ids.session('wed_ceremony'),
+      status: 'going',
+      guest_count: 2,
+      responded_at: FIXTURE_NOW,
+    },
+    {
+      tenant_id: T,
+      user_id: ids.user('nisha'),
+      session_id: ids.session('wed_reception'),
+      status: 'maybe',
+      guest_count: 1,
+      responded_at: FIXTURE_NOW,
+    },
+  ],
+  notificationPreferences: [
+    {
+      tenant_id: T,
+      user_id: ids.user('nisha'),
+      channels: ['in_app', 'push'],
+      muted_categories: ['gossips'],
+      default_reminder_minutes: 60,
+      quiet_hours_start: '23:00',
+      quiet_hours_end: '07:30',
+      created_at: FIXTURE_NOW,
+      updated_at: FIXTURE_NOW,
+    },
+  ],
+};

--- a/packages/data/src/fixtures/wedding.ts
+++ b/packages/data/src/fixtures/wedding.ts
@@ -110,13 +110,20 @@ const venues = [
 ];
 
 const media = [
-  image(T, 'wed_hero', 'The couple under the mandap at dusk', 'LKO2?U%2Tw=w]~RBVZRi};RPxuwH'),
-  image(T, 'wed_mehendi', 'Hands painted with mehendi', 'LEHV6nWB2yk8pyo0adR*.7kCMdnj'),
+  image(
+    T,
+    'wed_hero',
+    'The couple under the mandap at dusk',
+    'LKO2?U%2Tw=w]~RBVZRi};RPxuwH',
+    '#7a4a5c',
+  ),
+  image(T, 'wed_mehendi', 'Hands painted with mehendi', 'LEHV6nWB2yk8pyo0adR*.7kCMdnj', '#8b6f47'),
   image(
     T,
     'wed_sangeet',
     'The family mid-dance under string lights',
     'L6PZfSi_.AyE_3t7t7R**0o#DgR4',
+    '#3d2b36',
   ),
 ];
 
@@ -228,11 +235,11 @@ export const WEDDING: Partial<MockTables> = {
   tenantConfigs: [WEDDING_CONFIG],
   users,
   memberships: [
-    membership(T, ids.user('sanit'), 'event_admin'),
-    membership(T, ids.user('riya'), 'event_admin'),
-    membership(T, ids.user('meera'), 'moderator'),
-    membership(T, ids.user('arjun'), 'crew'),
-    membership(T, ids.user('nisha'), 'attendee'),
+    membership(T, 'wed_sanit', ids.user('sanit'), 'event_admin'),
+    membership(T, 'wed_riya', ids.user('riya'), 'event_admin'),
+    membership(T, 'wed_meera', ids.user('meera'), 'moderator'),
+    membership(T, 'wed_arjun', ids.user('arjun'), 'crew'),
+    membership(T, 'wed_nisha', ids.user('nisha'), 'attendee'),
   ],
   venues,
   sessions,

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -224,3 +224,23 @@ export {
 export { EMPTY_TABLES, MOCK_STORAGE_KEY, type MockSeed, type MockTables } from './mock/tables';
 
 export const DATA_SCHEMA_VERSION = 1 as const;
+
+/* The four fixture events (#35). Exported from the barrel because the app seeds the mock
+   adapter with them and the visual gate screenshots all four — but they are data, not the
+   adapter: `createMockAdapter` takes a seed, and a test seeds three rows instead. */
+export {
+  CONFERENCE,
+  CONFERENCE_CONFIG,
+  CONFERENCE_TENANT,
+  FESTIVAL,
+  FESTIVAL_CONFIG,
+  FESTIVAL_TENANT,
+  FIXTURE_NOW,
+  FIXTURE_SEED,
+  REUNION,
+  REUNION_CONFIG,
+  REUNION_TENANT,
+  WEDDING,
+  WEDDING_CONFIG,
+  WEDDING_TENANT,
+} from './fixtures/index';


### PR DESCRIPTION
Closes #35.

A wedding, a festival, a conference and a reunion, in **one seed**. Four tenants in one dataset rather than four datasets, because that is the shape the product has — one adapter, many events, every read scoped by `tenant_id`. A fixture set with a single tenant would let a missing scope pass every screen and every test, and surface later as one event's guest list on another's site.

### They are deliberately unalike, and that is the deliverable

| | preset | seed | mode | motion | notable |
|---|---|---|---|---|---|
| **sanit-riyanks** (wedding) | romantic | `#7C3A5A` | pinned **light** | subtle | 4:5 hero, "Whispers" |
| **anandhara** (festival) | festival | `#1E6F5C` | pinned **dark** | expressive | 16:9, sharp, grand scale |
| **devcon-25** (conference) | conference | `#2563EB` | **system** | subtle | tracks, media tab off |
| **maple-1999** (reunion) | minimal | `#C2410C` | system | **none** | two tabs, board disabled |

A wedding site that flipped to dark because a guest's phone did would look like a different event; a festival read outdoors at midnight has no business turning white. The conference following the device is the third of the resolver's three mode paths, and the one no unit test was exercising.

**The reunion is the one that turns things off.** A config that only ever adds is a config whose subtraction path has never rendered. Its empty `personas` and `gossipPosts` are the point rather than an omission — that is what a tenant with the board disabled actually looks like, and the screens have to survive it. It is also the only `private`, still-`pending_approval` tenant, so the super-admin queue (D25) has something in it.

### Chosen to be awkward on purpose

A person with no `user_id` (the bride's father is on the site and will never sign in — the reason `people` is a separate table). An invitation with no user at all. A draft session and a cancelled one. Two conference talks at the same minute on different tracks, which is what `sort_order` exists for. An unpublished announcement. A half-hour timezone offset beside whole-hour ones. One gossip post in **each** of the four moderation states, so the queue is not screenshotted empty. A tenant whose `draft_config` differs from its `published_config`, which is why that column is split.

### Fifteen tests, because fixtures rot quietly

Types catch a missing column. They do not catch a `venue_id` pointing at a renamed venue, a session in one tenant referencing a venue in another, or two rows sharing an id — and each of those renders as a blank space or the wrong event's content rather than as an error.

There is also a test that the four are **genuinely different**, since four identical configs would satisfy every other check here and prove nothing.

**Mutation-checked.** Pointing a wedding session at a festival stage fails "never points a row at another tenant"; giving two events a colliding id fails two tests; collapsing two presets into one fails "makes the four events genuinely unalike".

Nothing moves with the clock. The visual gate diffs screenshots, and a fixture built from `Date.now()` would fail it every midnight for a reason nobody would attribute to the fixture.

### One thing the lint rules caught

The table merge was first written generically over `keyof MockTables`. That needs a cast to convince the compiler the value at key `k` belongs at key `k` — D16 rejected it, correctly. It is spelled out one table at a time now, which costs twenty lines and buys a compile error the day a table is added and forgotten here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145VPJXGgJA9PWqeNXDr1DG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added realistic sample datasets for weddings, conferences, festivals and school reunions.
  - Added reusable, deterministic fixture data covering schedules, attendees, venues, media, announcements, tasks and permissions.
  - Added shared access to fixture datasets and tenant configurations.
  - Included varied themes, feature settings, navigation, moderation states, approvals and attendee statuses for representative scenarios.

- **Tests**
  - Added integrity checks for fixture completeness, references, identifiers, themes, moderation states, image metadata and deterministic dates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->