### PR TITLE
refactor(core): move the last three branded ids into core

### DIFF
--- a/packages/core/src/ids.ts
+++ b/packages/core/src/ids.ts
@@ -26,6 +26,9 @@ export type UnitId = Branded<'Unit'>;
 export type AssignmentId = Branded<'Assignment'>;
 export type MembershipId = Branded<'Membership'>;
 export type AnnouncementId = Branded<'Announcement'>;
+export type ApprovalRequestId = Branded<'ApprovalRequest'>;
+export type DeviceTokenId = Branded<'DeviceToken'>;
+export type NotificationDeliveryId = Branded<'NotificationDelivery'>;
 
 /*
  * The constructors below are the only place in the repo (with mappers.ts) where a raw string
@@ -45,3 +48,7 @@ export const unitId = (value: string): UnitId => value as UnitId;
 export const assignmentId = (value: string): AssignmentId => value as AssignmentId;
 export const membershipId = (value: string): MembershipId => value as MembershipId;
 export const announcementId = (value: string): AnnouncementId => value as AnnouncementId;
+export const approvalRequestId = (value: string): ApprovalRequestId => value as ApprovalRequestId;
+export const deviceTokenId = (value: string): DeviceTokenId => value as DeviceTokenId;
+export const notificationDeliveryId = (value: string): NotificationDeliveryId =>
+  value as NotificationDeliveryId;

--- a/packages/data/src/mappers.test.ts
+++ b/packages/data/src/mappers.test.ts
@@ -1,12 +1,15 @@
 import { describe, expect, it } from '@jest/globals';
 import {
   announcementId,
+  approvalRequestId,
   assignmentId,
   gossipPostId,
   mediaId,
   membershipId,
   personId,
   personaId,
+  deviceTokenId,
+  notificationDeliveryId,
   sessionId,
   taskId,
   tenantId,
@@ -18,10 +21,13 @@ import { themeInputFromPreset } from '@occasio/theme';
 import type { TenantConfig } from './config';
 import {
   toAnnouncement,
+  toApprovalRequest,
   toAssignment,
+  toDeviceToken,
   toGossipPost,
   toMediaAsset,
   toMembership,
+  toNotificationDelivery,
   toNotificationPreferences,
   toPerson,
   toPersona,
@@ -37,7 +43,10 @@ import {
 } from './mappers';
 import type {
   AnnouncementRow,
+  ApprovalRequestRow,
   AssignmentRow,
+  DeviceTokenRow,
+  NotificationDeliveryRow,
   GossipPostRow,
   MediaAssetRow,
   MembershipRow,
@@ -60,11 +69,11 @@ import type {
  * `created_at` where it meant `updated_at` is the most likely mistake in a file of forty renames,
  * and it is invisible to a test whose fixture uses the same timestamp twice.
  *
- * Three mappers have no sample here — `toApprovalRequest`, `toDeviceToken` and
- * `toNotificationDelivery`. Their branded ids have no constructor in `@occasio/core` yet, and
- * casting one into existence is a lint error everywhere but this package's `mappers.ts`. They are
- * covered structurally by `rows.test.ts` instead. See the PR: those three ids want moving into
- * core, which would let these tests be written the same way as the rest.
+ * Every mapper has a sample now. Three of them did not until #118: their branded ids lived in
+ * `rows.ts` with no constructor, and casting one into existence is a lint error everywhere but
+ * a `mappers.ts` — so they were covered structurally and the three most easily mistyped fields
+ * in the schema (`session_id`, `task_id` and `announcement_id`, all nullable, all on one row)
+ * had no runtime check at all.
  */
 
 const T = tenantId('santi-riyanks');
@@ -671,5 +680,143 @@ describe('toNotificationPreferences', () => {
     ['both', { quiet_hours_start: null, quiet_hours_end: null }],
   ])('has no window without the %s, since it could not be evaluated', (_label, patch) => {
     expect(toNotificationPreferences({ ...row, ...patch }).quietHours).toBeNull();
+  });
+});
+
+describe('toApprovalRequest', () => {
+  const row: ApprovalRequestRow = {
+    id: approvalRequestId('ap_1'),
+    tenant_id: T,
+    status: 'pending',
+    requested_by: ADMIN,
+    requested_at: '2026-01-04T08:00:00Z',
+    reviewed_by: null,
+    reviewed_at: null,
+    note: 'First event on the platform.',
+    created_at: '2026-01-04T07:59:00Z',
+  };
+
+  it('renames every column and drops the one the domain does not carry', () => {
+    expect(toApprovalRequest(row)).toEqual({
+      id: approvalRequestId('ap_1'),
+      tenantId: T,
+      status: 'pending',
+      requestedBy: ADMIN,
+      requestedAt: '2026-01-04T08:00:00Z',
+      reviewedBy: null,
+      reviewedAt: null,
+      note: 'First event on the platform.',
+    });
+  });
+
+  it('carries a completed review through, with reviewer and time distinct from the request', () => {
+    /* `requested_at` and `reviewed_at` are the pair most likely to be crossed, and a fixture
+       reusing one timestamp could not tell. */
+    const reviewed = toApprovalRequest({
+      ...row,
+      status: 'approved',
+      reviewed_by: userId('u_super'),
+      reviewed_at: '2026-01-05T11:15:00Z',
+    });
+
+    expect(reviewed.requestedAt).toBe('2026-01-04T08:00:00Z');
+    expect(reviewed.reviewedAt).toBe('2026-01-05T11:15:00Z');
+    expect(reviewed.reviewedBy).toBe(userId('u_super'));
+  });
+});
+
+describe('toDeviceToken', () => {
+  const row: DeviceTokenRow = {
+    id: deviceTokenId('dt_1'),
+    user_id: ADMIN,
+    platform: 'ios',
+    token: 'ExponentPushToken[xxxxxx]',
+    last_seen_at: '2026-01-09T21:00:00Z',
+    revoked_at: null,
+    created_at: '2026-01-02T06:00:00Z',
+  };
+
+  it('renames every column and does not leak the created timestamp', () => {
+    expect(toDeviceToken(row)).toEqual({
+      id: deviceTokenId('dt_1'),
+      userId: ADMIN,
+      platform: 'ios',
+      token: 'ExponentPushToken[xxxxxx]',
+      lastSeenAt: '2026-01-09T21:00:00Z',
+      revokedAt: null,
+    });
+  });
+
+  it('keeps a revoked token revoked', () => {
+    /* A revoked token that mapped to `revokedAt: null` would be sent push notifications
+       forever, and the failure is silent at every layer above this one. */
+    expect(toDeviceToken({ ...row, revoked_at: '2026-02-01T00:00:00Z' }).revokedAt).toBe(
+      '2026-02-01T00:00:00Z',
+    );
+  });
+});
+
+describe('toNotificationDelivery', () => {
+  const row: NotificationDeliveryRow = {
+    id: notificationDeliveryId('nd_1'),
+    tenant_id: T,
+    user_id: ADMIN,
+    category: 'schedule',
+    channel: 'push',
+    dedupe_key: 'session:s_1:starting',
+    session_id: sessionId('s_1'),
+    task_id: null,
+    announcement_id: null,
+    status: 'sent',
+    failure_reason: null,
+    scheduled_for: '2026-02-14T09:30:00Z',
+    sent_at: '2026-02-14T09:30:04Z',
+    created_at: '2026-02-13T18:00:00Z',
+  };
+
+  it('renames every column, including the three nullable subject ids', () => {
+    expect(toNotificationDelivery(row)).toEqual({
+      id: notificationDeliveryId('nd_1'),
+      tenantId: T,
+      userId: ADMIN,
+      category: 'schedule',
+      channel: 'push',
+      dedupeKey: 'session:s_1:starting',
+      sessionId: sessionId('s_1'),
+      taskId: null,
+      announcementId: null,
+      status: 'sent',
+      failureReason: null,
+      scheduledFor: '2026-02-14T09:30:00Z',
+      sentAt: '2026-02-14T09:30:04Z',
+    });
+  });
+
+  it('does not confuse one subject id for another', () => {
+    /* Three nullable ids of the same shape on one row: the case a rename is most likely to get
+       wrong, and the one a single-subject fixture cannot detect. */
+    const forTask = toNotificationDelivery({
+      ...row,
+      session_id: null,
+      task_id: taskId('tk_9'),
+      category: 'tasks',
+    });
+
+    expect(forTask.taskId).toBe(taskId('tk_9'));
+    expect(forTask.sessionId).toBeNull();
+    expect(forTask.announcementId).toBeNull();
+  });
+
+  it('keeps the reason a delivery failed', () => {
+    const failed = toNotificationDelivery({
+      ...row,
+      status: 'failed',
+      sent_at: null,
+      failure_reason: 'DeviceNotRegistered',
+    });
+
+    expect(failed.status).toBe('failed');
+    expect(failed.failureReason).toBe('DeviceNotRegistered');
+    expect(failed.sentAt).toBeNull();
   });
 });

--- a/packages/data/src/mock/adapter.ts
+++ b/packages/data/src/mock/adapter.ts
@@ -1,5 +1,6 @@
 import {
   announcementId as toAnnouncementId,
+  approvalRequestId,
   assignmentId as toAssignmentId,
   gossipPostId as toGossipPostId,
   membershipId as toMembershipId,
@@ -121,7 +122,7 @@ import {
   type Random,
   type Sleep,
 } from './latency';
-import { approvalRequestId, cloneJson as clone, parseSnapshot, serialiseSnapshot } from './mappers';
+import { cloneJson as clone, parseSnapshot, serialiseSnapshot } from './mappers';
 import { numericKey, paginate, timestampKey } from './paging';
 import type { MockStorage } from './storage';
 import {

--- a/packages/data/src/mock/index.ts
+++ b/packages/data/src/mock/index.ts
@@ -38,7 +38,7 @@ export {
   type Sleep,
 } from './latency';
 
-export { approvalRequestId, parseSnapshot, serialiseSnapshot } from './mappers';
+export { parseSnapshot, serialiseSnapshot } from './mappers';
 
 export {
   decodeCursor,

--- a/packages/data/src/mock/mappers.ts
+++ b/packages/data/src/mock/mappers.ts
@@ -1,4 +1,3 @@
-import type { ApprovalRequestId } from '../rows';
 import {
   MOCK_SNAPSHOT_VERSION,
   type MockSnapshot,
@@ -16,20 +15,13 @@ import {
  *  1. `parseSnapshot` turns the JSON string a browser handed back into `MockTables`. `JSON.parse`
  *     returns `any`; without a checked door into the type system, every read after it is an
  *     unsafe access the linter is right to reject.
- *  2. `approvalRequestId` brands a string as an `ApprovalRequestId`. That id is declared in
- *     `rows.ts` rather than `@occasio/core` (see the note there), so unlike the other thirteen it
- *     has no constructor in `ids.ts` to borrow. When it moves into core, this goes with it.
+ *  2. `cloneJson` copies a document by round-tripping it through JSON, which means typing the
+ *     result of `JSON.parse` — the same door, for the same reason.
  *
  * The root `mappers.ts` explains why this exemption exists at all: it is the seam where database
  * output becomes checked data, and the eslint config grants it to `packages/data/src/**\/mappers.ts`
  * precisely so each adapter has one.
  */
-
-/**
- * Brands a string as an `ApprovalRequestId`. Mirrors the constructors in `@occasio/core/ids` and
- * moves there with the type.
- */
-export const approvalRequestId = (value: string): ApprovalRequestId => value as ApprovalRequestId;
 
 /* ---------------------------------------------------------------------------------------------
  * Snapshot parsing

--- a/packages/data/src/rows.ts
+++ b/packages/data/src/rows.ts
@@ -1,10 +1,12 @@
 import type {
   AnnouncementId,
+  ApprovalRequestId,
   AssignmentId,
-  Branded,
+  DeviceTokenId,
   GossipPostId,
   MediaId,
   MembershipId,
+  NotificationDeliveryId,
   PersonId,
   PersonaId,
   SessionId,
@@ -62,17 +64,14 @@ export type IanaTimeZone = string;
 export type JsonObject = Readonly<Record<string, unknown>>;
 
 /* ---------------------------------------------------------------------------------------------
- * Ids that do not exist in @occasio/core yet
+ * Ids
  *
- * The other thirteen ids live in `packages/core/src/ids.ts` and belong there. These three are
- * declared here only because the rows that need them arrive with this change; they are plain
- * `Branded` aliases over the same machinery, so moving them into core later is a cut-and-paste
- * with no call-site changes. See the PR discussion.
+ * All sixteen live in `packages/core/src/ids.ts`. These three are re-exported rather than
+ * imported-and-forgotten because the row types below name them, and a reader following
+ * `ApprovalRequestRow.id` should land somewhere that says where the type comes from.
  * ------------------------------------------------------------------------------------------- */
 
-export type ApprovalRequestId = Branded<'ApprovalRequest'>;
-export type DeviceTokenId = Branded<'DeviceToken'>;
-export type NotificationDeliveryId = Branded<'NotificationDelivery'>;
+export type { ApprovalRequestId, DeviceTokenId, NotificationDeliveryId } from '@occasio/core';
 
 /* ---------------------------------------------------------------------------------------------
  * Enumerations


### PR DESCRIPTION
Closes #118.

`ApprovalRequestId`, `DeviceTokenId` and `NotificationDeliveryId` lived in `packages/data/src/rows.ts` rather than beside the other thirteen, because the agent that added them was working in a `packages/data/**` lane. They move to `ids.ts` with constructors; `rows.ts` re-exports the types so a reader following `ApprovalRequestRow.id` still lands somewhere that says where they come from.

`mock/mappers.ts` had its own `approvalRequestId` for exactly one reason — a constructor needs a cast, and casts are legal only in `ids.ts` and a `mappers.ts`. That duplicate is gone.

### The consequence was worse than the untidiness

Three mappers had **no runtime sample**, because they could not be given one without a constructor. They were covered structurally instead.

`NotificationDeliveryRow` carries three nullable subject ids of the same shape — `session_id`, `task_id`, `announcement_id` — on one row. That is precisely the arrangement a forty-line rename gets wrong, and nothing checked it.

All three mappers have samples now, including one that fails if two of those ids are crossed, one that asserts a revoked device token stays revoked (a mapping to `null` there would send push notifications to a revoked device forever, silently), and one that keeps `requested_at` and `reviewed_at` distinct.

**Mutation-checked:** swapping `task_id` for `session_id` in the mapper fails two of the new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145VPJXGgJA9PWqeNXDr1DG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Standardised identifier handling for approval requests, device tokens and notification deliveries across the application.
  - Improved consistency when sharing and reusing these identifiers between core and data components.
  - No changes to user-facing functionality or workflows.

- **Tests**
  - Expanded runtime coverage for data mapping, including nullable fields, renamed fields, timestamps, subject identifiers, revoked tokens and failed delivery reasons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->