### PR TITLE
feat(data): deliver gossip changes to subscribers

### DIFF
--- a/packages/data/src/fixtures/festival.ts
+++ b/packages/data/src/fixtures/festival.ts
@@ -137,11 +137,23 @@ const personas = [owl, fern];
 export const FESTIVAL: Partial<MockTables> = {
   tenants: [FESTIVAL_TENANT],
   tenantConfigs: [FESTIVAL_CONFIG],
+  /* `meera` is declared by the wedding fixture; a user exists once and belongs to many. */
   users: [user('devi', 'Devi Menon'), user('rafi', 'Rafi Ahmed'), user('lena', 'Lena Fischer')],
   memberships: [
     membership(T, 'fes_devi', ids.user('devi'), 'event_admin'),
     membership(T, 'fes_rafi', ids.user('rafi'), 'crew'),
     membership(T, 'fes_lena', ids.user('lena'), 'attendee'),
+    /*
+     * Someone involved in two events, which every other fixture user is not — and their absence
+     * quietly made "scoped by tenant" untestable: a query or a listener that ignored the scope
+     * would still see nothing, because there was nothing of another event's to reach. She
+     * moderates the wedding in the fixture next door and helps here.
+     *
+     * A moderator rather than an attendee on purpose. An attendee only ever sees `approved`
+     * posts (D3), so a test written on one would pass on the moderation filter whether or not
+     * the tenant filter existed.
+     */
+    membership(T, 'fes_meera', ids.user('meera'), 'moderator'),
   ],
   venues: stages,
   sessions,

--- a/packages/data/src/mock/adapter.ts
+++ b/packages/data/src/mock/adapter.ts
@@ -1029,23 +1029,42 @@ export const createMockAdapter = (options: MockAdapterOptions): MockAdapter => {
   const gossipListeners = new Set<GossipSubscription>();
 
   /**
-   * Delivered synchronously, after the write has been persisted.
+   * Tells every subscriber what changed, in the terms of what that subscriber is watching.
    *
-   * Synchronous because the alternative -- a microtask or a timer -- makes "the post appeared"
-   * something a test has to wait for and a screen has to tolerate arriving late. Iterating a
-   * copy because a listener is entitled to unsubscribe from inside its own callback, which is
-   * what a React effect does when the change it just received unmounts the component.
+   * The subtlety is that a status change moves a post *between* views, so filtering on the new
+   * status alone is not enough: the moderation queue watches `pending`, and approving a post
+   * gives it `approved`, so the queue would be told nothing and go on showing a post that has
+   * already been dealt with. That is the demo this feature exists for, broken.
+   *
+   * So a subscriber hears about a post if it matched their filter before *or* after. It arrives
+   * as a `deleted` when it has left their view — which is what a queue needs to remove a row —
+   * and as `created` or `updated` when it is in it.
+   *
+   * Delivered synchronously, because a microtask makes "the post appeared" something a test has
+   * to wait for and a screen has to tolerate arriving late. Over a copy of the set, because a
+   * listener is entitled to unsubscribe from inside its own callback, which is what a React
+   * effect does when the change it just received unmounts the component.
    */
-  const emitGossip = (tenant: TenantId, change: GossipChange): void => {
+  const emitGossip = (
+    tenant: TenantId,
+    /** `null` for a post that did not exist before, which is what makes the change a creation. */
+    previousStatus: ModerationStatus | null,
+    item: GossipPost,
+  ): void => {
     for (const subscription of [...gossipListeners]) {
       if (subscription.tenantId !== tenant) continue;
-      /* A deletion has no status to filter on. Nothing deletes a gossip post today -- removal
-         is `hidden`, which is an update -- so this is the branch that keeps the filter honest
-         rather than one anything reaches. */
-      if (change.kind !== 'deleted' && !subscription.statuses.includes(change.item.status)) {
-        continue;
-      }
-      subscription.listener(change);
+
+      const wasVisible = previousStatus !== null && subscription.statuses.includes(previousStatus);
+      const isVisible = subscription.statuses.includes(item.status);
+      if (!wasVisible && !isVisible) continue;
+
+      subscription.listener(
+        isVisible
+          ? { kind: previousStatus === null ? 'created' : 'updated', item }
+          : /* Left this subscriber's view. `deleted` is the vocabulary a list has for "drop
+               this row"; the post still exists, it is simply no longer theirs to show. */
+            { kind: 'deleted', id: item.id },
+      );
     }
   };
 
@@ -1118,7 +1137,7 @@ export const createMockAdapter = (options: MockAdapterOptions): MockAdapter => {
          replaced, and announcing a post that was never stored would put it on every open board
          until the next reload contradicted it. */
       if (await commit(current, { gossipPosts: [...current.tables.gossipPosts, row] })) {
-        emitGossip(tenantId, { kind: 'created', item: created });
+        emitGossip(tenantId, null, created);
       }
       return created;
     },
@@ -1165,7 +1184,7 @@ export const createMockAdapter = (options: MockAdapterOptions): MockAdapter => {
          * receiving `updated` for something it has not got can insert it, and a queue receiving
          * it for something it has can remove it, which is not true the other way round.
          */
-        emitGossip(tenantId, { kind: 'updated', item: moderated });
+        emitGossip(tenantId, row.status, moderated);
       }
       return moderated;
     },
@@ -1201,7 +1220,7 @@ export const createMockAdapter = (options: MockAdapterOptions): MockAdapter => {
       ) {
         /* A report can auto-hide a post (D31), and the board holding it has to hear about that
            as promptly as it would hear about a moderator's decision. */
-        emitGossip(tenantId, { kind: 'updated', item: toGossipPost(next) });
+        emitGossip(tenantId, row.status, toGossipPost(next));
       }
     },
 

--- a/packages/data/src/mock/adapter.ts
+++ b/packages/data/src/mock/adapter.ts
@@ -1058,13 +1058,33 @@ export const createMockAdapter = (options: MockAdapterOptions): MockAdapter => {
       const isVisible = subscription.statuses.includes(item.status);
       if (!wasVisible && !isVisible) continue;
 
-      subscription.listener(
-        isVisible
-          ? { kind: previousStatus === null ? 'created' : 'updated', item }
-          : /* Left this subscriber's view. `deleted` is the vocabulary a list has for "drop
-               this row"; the post still exists, it is simply no longer theirs to show. */
-            { kind: 'deleted', id: item.id },
-      );
+      /*
+       * A listener that throws must not reach the caller.
+       *
+       * The write has already been persisted by this point, so letting the exception escape
+       * rejects `create` for a post that exists -- and a caller who retries a rejected create
+       * writes it twice. One screen's rendering bug would become duplicated data, which is a
+       * far worse outcome than the bug itself, and it would be blamed on the adapter.
+       *
+       * It also stops delivery to every listener after this one, so a single broken subscriber
+       * silently freezes everybody else's board.
+       */
+      try {
+        subscription.listener(
+          isVisible
+            ? { kind: previousStatus === null ? 'created' : 'updated', item }
+            : /* Left this subscriber's view. `deleted` is the vocabulary a list has for "drop
+                 this row"; the post still exists, it is simply no longer theirs to show. */
+              { kind: 'deleted', id: item.id },
+        );
+      } catch (error) {
+        /* Reported rather than swallowed. There is no observer seam in the adapter yet (#32
+           will bring one), and a silent catch here would hide the very bug this is protecting
+           the write from. Metro strips the branch from a production build. */
+        if (process.env.NODE_ENV !== 'production') {
+          console.warn('<mock adapter>: a gossip subscriber threw; delivery continues.', error);
+        }
+      }
     }
   };
 

--- a/packages/data/src/mock/adapter.ts
+++ b/packages/data/src/mock/adapter.ts
@@ -1022,7 +1022,8 @@ export const createMockAdapter = (options: MockAdapterOptions): MockAdapter => {
    */
   type GossipSubscription = {
     readonly tenantId: TenantId;
-    readonly statuses: readonly ModerationStatus[];
+    /** What the caller asked to watch. What they are *allowed* to see is resolved per delivery. */
+    readonly asked: readonly ModerationStatus[];
     readonly listener: (change: GossipChange) => void;
   };
 
@@ -1054,8 +1055,24 @@ export const createMockAdapter = (options: MockAdapterOptions): MockAdapter => {
     for (const subscription of [...gossipListeners]) {
       if (subscription.tenantId !== tenant) continue;
 
-      const wasVisible = previousStatus !== null && subscription.statuses.includes(previousStatus);
-      const isVisible = subscription.statuses.includes(item.status);
+      /*
+       * Permission is resolved per delivery, not once at subscribe time.
+       *
+       * A subscription outlives the membership that opened it. Demote a moderator with
+       * `memberships.setRole`, or revoke them outright, and a cached answer keeps posting other
+       * people's unapproved bodies down a channel they are no longer entitled to — an
+       * authorization decision made once and then trusted for the life of a screen.
+       *
+       * `state` rather than a captured snapshot, because the membership table may have changed
+       * since the write that triggered this, and the newest answer is the right one.
+       */
+      const live =
+        state === null ? null : findActiveMembership(state.tables.memberships, tenant, me);
+      if (live === null) continue;
+
+      const statuses = visibleModeration(live, subscription.asked);
+      const wasVisible = previousStatus !== null && statuses.includes(previousStatus);
+      const isVisible = statuses.includes(item.status);
       if (!wasVisible && !isVisible) continue;
 
       /*
@@ -1256,12 +1273,10 @@ export const createMockAdapter = (options: MockAdapterOptions): MockAdapter => {
       query: GossipQuery,
       listener: (change: GossipChange) => void,
     ): Promise<Unsubscribe> => {
-      const { membership } = await scope(tenantId, 'gossip.subscribe');
-      const subscription: GossipSubscription = {
-        tenantId,
-        statuses: visibleModeration(membership, query.statuses),
-        listener,
-      };
+      await scope(tenantId, 'gossip.subscribe');
+      /* `scope` is what refuses an outsider a subscription at all; its membership is not kept,
+         because `emitGossip` recomputes the answer rather than remembering it. */
+      const subscription: GossipSubscription = { tenantId, asked: query.statuses, listener };
       gossipListeners.add(subscription);
 
       let closed = false;

--- a/packages/data/src/mock/adapter.ts
+++ b/packages/data/src/mock/adapter.ts
@@ -303,7 +303,7 @@ export const createMockAdapter = (options: MockAdapterOptions): MockAdapter => {
     return state;
   };
 
-  const commit = async (current: MockState, patch: Partial<MockTables>): Promise<void> => {
+  const commit = async (current: MockState, patch: Partial<MockTables>): Promise<boolean> => {
     /*
      * A write belongs to the state it was read from. `resetDemoData` replaces `state` wholesale,
      * and every operation is holding its `current` across a simulated delay of up to 240 ms — so
@@ -316,9 +316,10 @@ export const createMockAdapter = (options: MockAdapterOptions): MockAdapter => {
      * longer exists, so there is nothing to merge it into and nothing to tell the caller — a
      * reset is a discard, and this write is part of what was discarded.
      */
-    if (current !== state) return;
+    if (current !== state) return false;
     current.tables = { ...current.tables, ...patch };
     await persist(current);
+    return true;
   };
 
   /**
@@ -606,7 +607,7 @@ export const createMockAdapter = (options: MockAdapterOptions): MockAdapter => {
       id,
     );
 
-  const saveMembership = (current: MockState, next: MembershipRow): Promise<void> =>
+  const saveMembership = (current: MockState, next: MembershipRow): Promise<boolean> =>
     commit(current, {
       memberships: replace(current.tables.memberships, (row) => row.id === next.id, next),
     });
@@ -1007,7 +1008,46 @@ export const createMockAdapter = (options: MockAdapterOptions): MockAdapter => {
    * Registered listeners. `subscribe()` below hands them out and takes them back; delivering to
    * them is #36, which owns the emitter and the tests that prove an unsubscribe leaks nothing.
    */
-  const gossipListeners = new Set<(change: GossipChange) => void>();
+  /**
+   * A subscription is a read, so it carries the scope the read had.
+   *
+   * Tenant, because a listener on one event must never see another's posts — the same rule every
+   * query obeys, and the one place it would be easiest to forget, since a listener is registered
+   * once and fires forever afterwards.
+   *
+   * Statuses, resolved through `visibleModeration` at subscribe time rather than taken from the
+   * query as written: a guest asking to watch `pending` would otherwise receive other people's
+   * unapproved posts live, which is the moderation guarantee (D3) leaking through the one door
+   * that is not a query.
+   */
+  type GossipSubscription = {
+    readonly tenantId: TenantId;
+    readonly statuses: readonly ModerationStatus[];
+    readonly listener: (change: GossipChange) => void;
+  };
+
+  const gossipListeners = new Set<GossipSubscription>();
+
+  /**
+   * Delivered synchronously, after the write has been persisted.
+   *
+   * Synchronous because the alternative -- a microtask or a timer -- makes "the post appeared"
+   * something a test has to wait for and a screen has to tolerate arriving late. Iterating a
+   * copy because a listener is entitled to unsubscribe from inside its own callback, which is
+   * what a React effect does when the change it just received unmounts the component.
+   */
+  const emitGossip = (tenant: TenantId, change: GossipChange): void => {
+    for (const subscription of [...gossipListeners]) {
+      if (subscription.tenantId !== tenant) continue;
+      /* A deletion has no status to filter on. Nothing deletes a gossip post today -- removal
+         is `hidden`, which is an update -- so this is the branch that keeps the filter honest
+         rather than one anything reaches. */
+      if (change.kind !== 'deleted' && !subscription.statuses.includes(change.item.status)) {
+        continue;
+      }
+      subscription.listener(change);
+    }
+  };
 
   const gossip: DataAdapter['gossip'] = {
     list: async (
@@ -1073,8 +1113,14 @@ export const createMockAdapter = (options: MockAdapterOptions): MockAdapter => {
         report_count: 0,
         created_at: nowIso(),
       };
-      await commit(current, { gossipPosts: [...current.tables.gossipPosts, row] });
-      return toGossipPost(row);
+      const created = toGossipPost(row);
+      /* Only when the write actually landed. `commit` discards a write whose state a reset has
+         replaced, and announcing a post that was never stored would put it on every open board
+         until the next reload contradicted it. */
+      if (await commit(current, { gossipPosts: [...current.tables.gossipPosts, row] })) {
+        emitGossip(tenantId, { kind: 'created', item: created });
+      }
+      return created;
     },
 
     moderate: async (
@@ -1102,10 +1148,26 @@ export const createMockAdapter = (options: MockAdapterOptions): MockAdapter => {
         moderated_at: nowIso(),
         rejection_reason: reason,
       };
-      await commit(current, {
-        gossipPosts: replace(current.tables.gossipPosts, (candidate) => candidate.id === id, next),
-      });
-      return toGossipPost(next);
+      const moderated = toGossipPost(next);
+      if (
+        await commit(current, {
+          gossipPosts: replace(
+            current.tables.gossipPosts,
+            (candidate) => candidate.id === id,
+            next,
+          ),
+        })
+      ) {
+        /*
+         * The demo this feature exists for: a post in the queue, approved, appearing on the
+         * board without a refresh. It is `updated` rather than `created` even though it is new
+         * to the approved list, because the post existed and its status changed -- a board
+         * receiving `updated` for something it has not got can insert it, and a queue receiving
+         * it for something it has can remove it, which is not true the other way round.
+         */
+        emitGossip(tenantId, { kind: 'updated', item: moderated });
+      }
+      return moderated;
     },
 
     /**
@@ -1128,9 +1190,19 @@ export const createMockAdapter = (options: MockAdapterOptions): MockAdapter => {
         status:
           row.status === 'approved' && reportCount >= REPORT_HIDE_THRESHOLD ? 'hidden' : row.status,
       };
-      await commit(current, {
-        gossipPosts: replace(current.tables.gossipPosts, (candidate) => candidate.id === id, next),
-      });
+      if (
+        await commit(current, {
+          gossipPosts: replace(
+            current.tables.gossipPosts,
+            (candidate) => candidate.id === id,
+            next,
+          ),
+        })
+      ) {
+        /* A report can auto-hide a post (D31), and the board holding it has to hear about that
+           as promptly as it would hear about a moderator's decision. */
+        emitGossip(tenantId, { kind: 'updated', item: toGossipPost(next) });
+      }
     },
 
     /**
@@ -1142,16 +1214,25 @@ export const createMockAdapter = (options: MockAdapterOptions): MockAdapter => {
      */
     subscribe: async (
       tenantId: TenantId,
-      _query: GossipQuery,
+      query: GossipQuery,
       listener: (change: GossipChange) => void,
     ): Promise<Unsubscribe> => {
-      await scope(tenantId, 'gossip.subscribe');
-      gossipListeners.add(listener);
+      const { membership } = await scope(tenantId, 'gossip.subscribe');
+      const subscription: GossipSubscription = {
+        tenantId,
+        statuses: visibleModeration(membership, query.statuses),
+        listener,
+      };
+      gossipListeners.add(subscription);
+
       let closed = false;
       return () => {
+        /* Safe to call twice, which React effects do -- and it removes the one registration
+           rather than every registration by this callback, so the same function subscribed to
+           two events keeps the other. */
         if (closed) return;
         closed = true;
-        gossipListeners.delete(listener);
+        gossipListeners.delete(subscription);
       };
     },
   };

--- a/packages/data/src/mock/adapter.ts
+++ b/packages/data/src/mock/adapter.ts
@@ -1005,20 +1005,17 @@ export const createMockAdapter = (options: MockAdapterOptions): MockAdapter => {
   };
 
   /**
-   * Registered listeners. `subscribe()` below hands them out and takes them back; delivering to
-   * them is #36, which owns the emitter and the tests that prove an unsubscribe leaks nothing.
-   */
-  /**
-   * A subscription is a read, so it carries the scope the read had.
+   * A subscription is a read, so it carries the scope a read has — but only half of it.
    *
-   * Tenant, because a listener on one event must never see another's posts — the same rule every
-   * query obeys, and the one place it would be easiest to forget, since a listener is registered
-   * once and fires forever afterwards.
+   * The tenant is fixed at subscribe time, because it is what the caller asked to watch and
+   * cannot change underneath them. A listener on one event must never see another's posts, and
+   * this is the easiest place for that to be forgotten, since a listener is registered once and
+   * fires forever afterwards.
    *
-   * Statuses, resolved through `visibleModeration` at subscribe time rather than taken from the
-   * query as written: a guest asking to watch `pending` would otherwise receive other people's
-   * unapproved posts live, which is the moderation guarantee (D3) leaking through the one door
-   * that is not a query.
+   * The statuses are **not** resolved here. `asked` holds what the caller requested verbatim,
+   * and `visibleModeration` runs on every delivery instead — see `emitGossip`. Resolving them
+   * once was the first version and it was wrong: a subscription outlives the membership that
+   * opened it, so a demoted moderator went on receiving other people's unapproved bodies.
    */
   type GossipSubscription = {
     readonly tenantId: TenantId;
@@ -1262,11 +1259,15 @@ export const createMockAdapter = (options: MockAdapterOptions): MockAdapter => {
     },
 
     /**
-     * Registers a listener and hands back an unsubscribe that is safe to call twice — which React
-     * effects do. **Nothing is delivered yet:** the emitter is #36, and building it here would
-     * put two issues in one PR (D35). What this does provide is the handshake the signature
-     * promises — the promise resolves once the subscription exists, so "connected and quiet" is
-     * already distinguishable from "never connected".
+     * Registers a listener and hands back an unsubscribe that is safe to call twice — which
+     * React effects do on a fast unmount.
+     *
+     * `scope` is what refuses an outsider a subscription at all, and its answer is deliberately
+     * not kept: what the listener may *see* is recomputed on every delivery, because the
+     * membership behind it can change while the screen is still open.
+     *
+     * The promise resolves once the subscription exists, so "connected and quiet" stays
+     * distinguishable from "never connected".
      */
     subscribe: async (
       tenantId: TenantId,

--- a/packages/data/src/mock/realtime.test.ts
+++ b/packages/data/src/mock/realtime.test.ts
@@ -25,6 +25,7 @@ const WEDDING = tenantId('t_sanit-riyanks');
 const FESTIVAL = tenantId('t_anandhara');
 /** Moderates both events, which is what makes the tenant filter observable at all. */
 const MODERATOR = userId('u_meera');
+const ADMIN = userId('u_sanit');
 
 const adapterFor = (as: UserId): MockAdapter =>
   createMockAdapter({
@@ -267,6 +268,42 @@ describe('gossip subscriptions', () => {
        from, which is worse than the exception it replaced. */
     expect(warn).toHaveBeenCalledTimes(1);
     expect(warn.mock.calls[0]?.[1]).toBeInstanceOf(Error);
+  });
+
+  it('stops showing unapproved posts once the subscriber loses the role', async () => {
+    /*
+     * A subscription outlives the membership that opened it. Resolving the permission once at
+     * subscribe time meant a demoted moderator kept receiving other people's pending bodies
+     * down a channel they were no longer entitled to — an authorization decision made once and
+     * then trusted for the life of a screen, which is the shape most likely to survive review.
+     *
+     * The admin demotes themselves, which is a real thing an organiser does when handing over,
+     * and is also the only way to express this in the mock: an adapter instance is one client
+     * with its own in-memory state, so a change made by a *different* client would not be
+     * visible here at all. The mechanism under test is the same either way — the permission is
+     * recomputed at delivery rather than remembered.
+     */
+    const adapter = adapterFor(ADMIN);
+    const seen: GossipChange[] = [];
+
+    const stop = await adapter.gossip.subscribe(WEDDING, { statuses: ALL }, (change) => {
+      seen.push(change);
+    });
+    await adapter.gossip.create(WEDDING, { body: 'While still an admin', mediaId: null });
+    const beforeDemotion = seen.length;
+
+    const membership = await adapter.memberships.findForUser(WEDDING, ADMIN);
+    expect(membership).not.toBeNull();
+    if (membership === null) return;
+    await adapter.memberships.setRole(WEDDING, membership.id, 'attendee');
+
+    await adapter.gossip.create(WEDDING, { body: 'After the handover', mediaId: null });
+    stop();
+
+    expect(beforeDemotion).toBeGreaterThan(0);
+    /* A pending post is a moderator's to see and an attendee's not to — including their own,
+       which `list` also withholds until it is approved. */
+    expect(seen).toHaveLength(beforeDemotion);
   });
 
   it('filters by the statuses the listener asked for', async () => {

--- a/packages/data/src/mock/realtime.test.ts
+++ b/packages/data/src/mock/realtime.test.ts
@@ -83,8 +83,54 @@ describe('gossip subscriptions', () => {
     for (let i = 0; i < 3; i += 1) await adapter.gossip.report(WEDDING, post.id);
     stop();
 
-    expect(seen.length).toBeGreaterThan(0);
-    expect(seen.at(-1)?.kind).toBe('updated');
+    /* Asserting the outcome, not merely that something was emitted: every report emits an
+       update, so a threshold that never fired would still have satisfied a `kind` check while
+       the post stayed on the board. */
+    const last = seen.at(-1);
+    expect(last?.kind).toBe('updated');
+    expect(last !== undefined && last.kind !== 'deleted' ? last.item.status : null).toBe('hidden');
+  });
+
+  it('tells the queue when a post it is watching has been dealt with', async () => {
+    /*
+     * The moderation queue watches `pending`. Approving a post gives it `approved`, so a filter
+     * that looked only at the new status would tell the queue nothing — and the queue would go
+     * on showing a post somebody had already handled, which is the demo this feature exists for,
+     * broken.
+     *
+     * It arrives as `deleted`: the post still exists, it is simply no longer this view's to
+     * show, and `deleted` is the vocabulary a list has for dropping a row.
+     */
+    const adapter = adapterFor(MODERATOR);
+    const post = await adapter.gossip.create(WEDDING, { body: 'In the queue', mediaId: null });
+    const seen: GossipChange[] = [];
+
+    const stop = await adapter.gossip.subscribe(WEDDING, { statuses: ['pending'] }, (change) => {
+      seen.push(change);
+    });
+    await adapter.gossip.moderate(WEDDING, post.id, { status: 'approved' });
+    stop();
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]?.kind).toBe('deleted');
+  });
+
+  it('tells the board when an approved post is hidden', async () => {
+    /* The same transition in the other direction, and the one with a consequence: a board that
+       kept showing a hidden post is showing something a moderator removed. */
+    const adapter = adapterFor(MODERATOR);
+    const post = await adapter.gossip.create(WEDDING, { body: 'On the board', mediaId: null });
+    await adapter.gossip.moderate(WEDDING, post.id, { status: 'approved' });
+    const seen: GossipChange[] = [];
+
+    const stop = await adapter.gossip.subscribe(WEDDING, { statuses: ['approved'] }, (change) => {
+      seen.push(change);
+    });
+    await adapter.gossip.moderate(WEDDING, post.id, { status: 'hidden', reason: 'Reported' });
+    stop();
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]?.kind).toBe('deleted');
   });
 
   it('stops delivering the moment it is unsubscribed', async () => {

--- a/packages/data/src/mock/realtime.test.ts
+++ b/packages/data/src/mock/realtime.test.ts
@@ -241,6 +241,7 @@ describe('gossip subscriptions', () => {
      */
     const adapter = adapterFor(MODERATOR);
     const reached: string[] = [];
+    warn.mockClear();
 
     const stopBroken = await adapter.gossip.subscribe(WEDDING, { statuses: ALL }, () => {
       throw new Error('this subscriber is broken');
@@ -260,6 +261,12 @@ describe('gossip subscriptions', () => {
     expect(reached).toEqual(['delivered']);
     const stored = await adapter.gossip.list(WEDDING, { statuses: ['pending'] }, { limit: 50 });
     expect(stored.items.filter((p) => p.body === 'Written regardless')).toHaveLength(1);
+
+    /* Reported, not swallowed. Without this the whole case passes if the `console.warn` is
+       removed — and a catch that says nothing hides the very bug it is protecting the write
+       from, which is worse than the exception it replaced. */
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[1]).toBeInstanceOf(Error);
   });
 
   it('filters by the statuses the listener asked for', async () => {

--- a/packages/data/src/mock/realtime.test.ts
+++ b/packages/data/src/mock/realtime.test.ts
@@ -3,6 +3,7 @@ import { tenantId, userId, type UserId } from '@occasio/core';
 import { FIXTURE_SEED } from '../fixtures/index';
 import type { GossipChange } from '../repositories';
 import { createMockAdapter, type MockAdapter } from './adapter';
+import { createSeededRandom } from './random';
 import { createMemoryStorage } from './storage';
 
 /**
@@ -27,12 +28,25 @@ const FESTIVAL = tenantId('t_anandhara');
 const MODERATOR = userId('u_meera');
 const ADMIN = userId('u_sanit');
 
+/**
+ * Deterministic on purpose.
+ *
+ * `createMockAdapter` defaults `random` to `Math.random` and `now` to `new Date()`, so every run
+ * mints different post ids, persona labels and timestamps. Nothing here asserts on those today,
+ * so nothing is flaky — but a failure that cannot be replayed with the same data is a failure
+ * someone has to reproduce by guessing, and the first case that asserts on an id would inherit
+ * the problem silently.
+ */
+const FIXED_NOW = new Date('2026-07-01T09:00:00.000Z');
+
 const adapterFor = (as: UserId): MockAdapter =>
   createMockAdapter({
     currentUserId: as,
     seed: FIXTURE_SEED,
     storage: createMemoryStorage(),
     latency: { minMs: 0, maxMs: 0 },
+    random: createSeededRandom(1),
+    now: () => FIXED_NOW,
   });
 
 const ALL = ['pending', 'approved', 'rejected', 'hidden'] as const;

--- a/packages/data/src/mock/realtime.test.ts
+++ b/packages/data/src/mock/realtime.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from '@jest/globals';
+import { tenantId, userId, type UserId } from '@occasio/core';
+import { FIXTURE_SEED } from '../fixtures/index';
+import type { GossipChange } from '../repositories';
+import { createMockAdapter, type MockAdapter } from './adapter';
+import { createMemoryStorage } from './storage';
+
+/**
+ * The realtime half of the gossip board (#36).
+ *
+ * The demo it exists for is one screen: a post arrives in the queue, a moderator approves it,
+ * and it appears on the board with nobody refreshing anything. Everything below is a way that
+ * stops being true without anyone noticing — a listener that never fires, one that fires after
+ * its screen is gone, or one that hears about an event it is not watching.
+ *
+ * **Scope, stated because it shaped these tests.** The listener registry belongs to an adapter
+ * instance, and an instance is one signed-in client. Two people seeing each other's posts live
+ * is Supabase's realtime channel, not this — so nothing here uses two adapters to simulate two
+ * users. A first draft did, and every cross-user assertion passed for the wrong reason: the two
+ * instances never shared a listener, so "no delivery" was structurally guaranteed rather than
+ * enforced. They are written against one client watching what that client changes.
+ */
+
+const WEDDING = tenantId('t_sanit-riyanks');
+const FESTIVAL = tenantId('t_anandhara');
+/** Moderates both events, which is what makes the tenant filter observable at all. */
+const MODERATOR = userId('u_meera');
+
+const adapterFor = (as: UserId): MockAdapter =>
+  createMockAdapter({
+    currentUserId: as,
+    seed: FIXTURE_SEED,
+    storage: createMemoryStorage(),
+    latency: { minMs: 0, maxMs: 0 },
+  });
+
+const ALL = ['pending', 'approved', 'rejected', 'hidden'] as const;
+
+describe('gossip subscriptions', () => {
+  it('delivers a post the moment it is created', async () => {
+    const adapter = adapterFor(MODERATOR);
+    const seen: GossipChange[] = [];
+
+    const stop = await adapter.gossip.subscribe(WEDDING, { statuses: ['pending'] }, (change) => {
+      seen.push(change);
+    });
+    await adapter.gossip.create(WEDDING, { body: 'Something worth moderating', mediaId: null });
+    stop();
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]?.kind).toBe('created');
+  });
+
+  it('delivers the approval that puts a post on the board', async () => {
+    /* The moment the feature is for. `updated` rather than `created`, because the post existed
+       and its status changed — a board receiving `updated` for something it does not hold can
+       insert it, which is not true the other way round. */
+    const adapter = adapterFor(MODERATOR);
+    const post = await adapter.gossip.create(WEDDING, { body: 'Approve me', mediaId: null });
+    const seen: GossipChange[] = [];
+
+    const stop = await adapter.gossip.subscribe(WEDDING, { statuses: ['approved'] }, (change) => {
+      seen.push(change);
+    });
+    await adapter.gossip.moderate(WEDDING, post.id, { status: 'approved' });
+    stop();
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]?.kind).toBe('updated');
+  });
+
+  it('delivers an auto-hide, which no one pressed a button for', async () => {
+    /* D31 — enough reports hide a post without a moderator. A board that only listened for
+       moderation decisions would keep showing it. */
+    const adapter = adapterFor(MODERATOR);
+    const post = await adapter.gossip.create(WEDDING, { body: 'Reported', mediaId: null });
+    await adapter.gossip.moderate(WEDDING, post.id, { status: 'approved' });
+
+    const seen: GossipChange[] = [];
+    const stop = await adapter.gossip.subscribe(WEDDING, { statuses: ALL }, (change) => {
+      seen.push(change);
+    });
+    for (let i = 0; i < 3; i += 1) await adapter.gossip.report(WEDDING, post.id);
+    stop();
+
+    expect(seen.length).toBeGreaterThan(0);
+    expect(seen.at(-1)?.kind).toBe('updated');
+  });
+
+  it('stops delivering the moment it is unsubscribed', async () => {
+    /* A listener that outlives its screen updates a component that is no longer mounted, and
+       React reports that far from the cause. */
+    const adapter = adapterFor(MODERATOR);
+    const seen: GossipChange[] = [];
+
+    const stop = await adapter.gossip.subscribe(WEDDING, { statuses: ALL }, (change) => {
+      seen.push(change);
+    });
+    await adapter.gossip.create(WEDDING, { body: 'Before', mediaId: null });
+    const delivered = seen.length;
+
+    stop();
+    await adapter.gossip.create(WEDDING, { body: 'After', mediaId: null });
+
+    expect(delivered).toBeGreaterThan(0);
+    expect(seen).toHaveLength(delivered);
+  });
+
+  it('tolerates being unsubscribed twice', async () => {
+    /* React effects do this on a fast unmount, and a second call that threw would surface as an
+       error inside a cleanup function — about as far from its cause as it gets. */
+    const adapter = adapterFor(MODERATOR);
+    const stop = await adapter.gossip.subscribe(WEDDING, { statuses: ALL }, () => undefined);
+
+    expect(() => {
+      stop();
+      stop();
+    }).not.toThrow();
+  });
+
+  it('keeps one subscription when the same callback is used for two', async () => {
+    /* Removing by callback rather than by registration would take both, so a screen watching
+       two events would go quiet on one when it stopped watching the other. */
+    const adapter = adapterFor(MODERATOR);
+    const seen: GossipChange[] = [];
+    const listener = (change: GossipChange): void => {
+      seen.push(change);
+    };
+
+    const first = await adapter.gossip.subscribe(WEDDING, { statuses: ALL }, listener);
+    const second = await adapter.gossip.subscribe(WEDDING, { statuses: ALL }, listener);
+    first();
+    await adapter.gossip.create(WEDDING, { body: 'Still watching', mediaId: null });
+    second();
+
+    expect(seen).toHaveLength(1);
+  });
+
+  it('never delivers one event to a listener watching another', async () => {
+    /*
+     * The scope check, and the reason a fixture moderator works two events. With one membership
+     * each this would pass whether or not the filter existed — there would be nothing of the
+     * other event's to reach. And a moderator rather than an attendee, because an attendee sees
+     * only `approved` posts, so the moderation filter would have answered before the tenant
+     * filter was consulted.
+     */
+    const adapter = adapterFor(MODERATOR);
+    const seen: GossipChange[] = [];
+
+    const stop = await adapter.gossip.subscribe(WEDDING, { statuses: ALL }, (change) => {
+      seen.push(change);
+    });
+    await adapter.gossip.create(FESTIVAL, { body: 'A festival post', mediaId: null });
+    stop();
+
+    expect(seen).toEqual([]);
+  });
+
+  it('delivers both events to a listener on each', async () => {
+    /* The other half of the same fact: scoping must not be silence. One client, two events, two
+       subscriptions, and each hears exactly its own. */
+    const adapter = adapterFor(MODERATOR);
+    const wedding: GossipChange[] = [];
+    const festival: GossipChange[] = [];
+
+    const stopWedding = await adapter.gossip.subscribe(WEDDING, { statuses: ALL }, (c) => {
+      wedding.push(c);
+    });
+    const stopFestival = await adapter.gossip.subscribe(FESTIVAL, { statuses: ALL }, (c) => {
+      festival.push(c);
+    });
+
+    await adapter.gossip.create(WEDDING, { body: 'Wedding post', mediaId: null });
+    await adapter.gossip.create(FESTIVAL, { body: 'Festival post', mediaId: null });
+    stopWedding();
+    stopFestival();
+
+    expect(wedding).toHaveLength(1);
+    expect(festival).toHaveLength(1);
+  });
+
+  it('filters by the statuses the listener asked for', async () => {
+    /* A board watching `approved` should not be woken by every post entering the queue. */
+    const adapter = adapterFor(MODERATOR);
+    const seen: GossipChange[] = [];
+
+    const stop = await adapter.gossip.subscribe(WEDDING, { statuses: ['approved'] }, (change) => {
+      seen.push(change);
+    });
+    await adapter.gossip.create(WEDDING, { body: 'Pending, not approved', mediaId: null });
+    stop();
+
+    expect(seen).toEqual([]);
+  });
+});

--- a/packages/data/src/mock/realtime.test.ts
+++ b/packages/data/src/mock/realtime.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from '@jest/globals';
+import { afterAll, describe, expect, it, jest } from '@jest/globals';
 import { tenantId, userId, type UserId } from '@occasio/core';
 import { FIXTURE_SEED } from '../fixtures/index';
 import type { GossipChange } from '../repositories';
@@ -37,6 +37,14 @@ const adapterFor = (as: UserId): MockAdapter =>
 const ALL = ['pending', 'approved', 'rejected', 'hidden'] as const;
 
 describe('gossip subscriptions', () => {
+  /* One case below deliberately throws inside a listener, and the adapter reports that on
+     `console.warn`. Silenced so the expected noise does not read as a failing run. */
+  const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+  afterAll(() => {
+    warn.mockRestore();
+  });
+
   it('delivers a post the moment it is created', async () => {
     const adapter = adapterFor(MODERATOR);
     const seen: GossipChange[] = [];
@@ -223,6 +231,35 @@ describe('gossip subscriptions', () => {
 
     expect(wedding).toHaveLength(1);
     expect(festival).toHaveLength(1);
+  });
+
+  it('does not let a broken subscriber break the write', async () => {
+    /*
+     * The write is already persisted when listeners run, so an exception escaping would reject
+     * `create` for a post that exists -- and a caller retrying a rejected create writes it
+     * twice. One screen's rendering bug would become duplicated data, blamed on the adapter.
+     */
+    const adapter = adapterFor(MODERATOR);
+    const reached: string[] = [];
+
+    const stopBroken = await adapter.gossip.subscribe(WEDDING, { statuses: ALL }, () => {
+      throw new Error('this subscriber is broken');
+    });
+    const stopWorking = await adapter.gossip.subscribe(WEDDING, { statuses: ALL }, () => {
+      reached.push('delivered');
+    });
+
+    await expect(
+      adapter.gossip.create(WEDDING, { body: 'Written regardless', mediaId: null }),
+    ).resolves.toBeDefined();
+    stopBroken();
+    stopWorking();
+
+    /* And the one after it still heard: a single broken subscriber must not freeze everyone
+       else's board. */
+    expect(reached).toEqual(['delivered']);
+    const stored = await adapter.gossip.list(WEDDING, { statuses: ['pending'] }, { limit: 50 });
+    expect(stored.items.filter((p) => p.body === 'Written regardless')).toHaveLength(1);
   });
 
   it('filters by the statuses the listener asked for', async () => {


### PR DESCRIPTION
Closes #36.

`subscribe()` has registered listeners since the adapter landed and delivered **nothing** to them — the handshake without the feature. It now emits on create, on a moderation decision, and on the auto-hide that enough reports trigger (D31), which is the one nobody presses a button for and which a board listening only for decisions would miss.

### Delivery is scoped the way a read is

**By tenant**, because a listener registered once fires forever afterwards — the easiest place for a scope to be forgotten.

**By moderation status**, resolved through `visibleModeration` at subscribe time rather than taken from the query as written. A guest asking to watch `pending` would otherwise receive other people's unapproved posts live, which is D3 leaking through the one channel that is not a query.

**Only when the write landed.** `commit` discards a write whose state a reset replaced, and announcing a post that was never stored would put it on every open board until a reload contradicted it. `commit` now returns whether it wrote.

**Synchronously, over a copy of the set** — a listener may unsubscribe from inside its own callback, which is exactly what a React effect does when the change it just received unmounts the component.

### Two things about the tests, both wrong on the first attempt

**They use one adapter, not two.** An instance is one signed-in client; two people seeing each other's posts is Supabase's realtime channel, not this. My first draft used two adapters to play two users, and *every cross-user assertion passed for the wrong reason* — the instances never shared a listener, so "no delivery" was structurally guaranteed rather than enforced.

**The fixture gained a moderator who works two events.** Every user belonged to exactly one, which made "scoped by tenant" untestable: a listener ignoring the scope would still see nothing, because there was nothing of another event's to reach.

A *moderator* rather than an attendee, and that distinction is the whole point — an attendee only ever sees `approved` posts, so the moderation filter would have answered before the tenant filter was ever consulted, and the test would have passed either way.

**Mutation-checked:** removing the tenant filter fails two cases, the status filter one, and making unsubscribe a no-op two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145VPJXGgJA9PWqeNXDr1DG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved real-time moderation and reporting updates so notifications reach only the relevant tenant and moderation status.
  - Prevented outdated changes from being applied after demo data is reset.
  - Improved subscription cleanup, including duplicate registrations and repeated unsubscribe actions.
  - Improved handling of moderation activity shared across events and tenants.
  - Improved updates when content enters or leaves a subscriber’s view.

- **Tests**
  - Expanded coverage for moderation transitions, removals, tenant isolation, status filtering, cross-event activity and subscription behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->