### PR TITLE
feat(app): query key factories, hooks and the adapter provider

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -5,6 +5,7 @@ import { StatusBar } from 'expo-status-bar';
 import { useState } from 'react';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
+import { AppAdapterProvider } from '../src/data/AppAdapterProvider';
 import { ErrorFallback } from '../src/features/errors/ErrorFallback';
 import { AppThemeProvider } from '../src/theme/AppThemeProvider';
 import { APP_THEME } from '../src/theme/inputs';
@@ -63,12 +64,14 @@ export default function RootLayout() {
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <QueryClientProvider client={queryClient}>
-        <AppThemeProvider input={APP_THEME}>
-          <SafeAreaProvider>
-            <StatusBar style="auto" />
-            <Stack screenOptions={{ headerShown: false }} />
-          </SafeAreaProvider>
-        </AppThemeProvider>
+        <AppAdapterProvider>
+          <AppThemeProvider input={APP_THEME}>
+            <SafeAreaProvider>
+              <StatusBar style="auto" />
+              <Stack screenOptions={{ headerShown: false }} />
+            </SafeAreaProvider>
+          </AppThemeProvider>
+        </AppAdapterProvider>
       </QueryClientProvider>
     </GestureHandlerRootView>
   );

--- a/apps/mobile/src/data/AdapterProvider.tsx
+++ b/apps/mobile/src/data/AdapterProvider.tsx
@@ -1,0 +1,42 @@
+import type { DataAdapter } from '@occasio/data';
+import { createContext, useContext, type ReactNode } from 'react';
+
+/**
+ * Supplies the one `DataAdapter` the app talks to.
+ *
+ * A context rather than a module-level singleton, and the reason is the swap this architecture
+ * is built around: a singleton is constructed by whoever imports it first, which makes "use the
+ * Supabase adapter here and the mock in a test" a matter of import order. A provider makes it a
+ * matter of what is rendered, which is a decision somebody writes down.
+ *
+ * It is deliberately not the query client. TanStack Query owns caching; this owns *where the
+ * data comes from*. Conflating them would mean a test that wanted a different adapter also had
+ * to reconstruct a cache, and one that wanted a cold cache also had to rebuild an adapter.
+ */
+
+const AdapterContext = createContext<DataAdapter | null>(null);
+
+export function AdapterProvider({
+  adapter,
+  children,
+}: {
+  readonly adapter: DataAdapter;
+  readonly children: ReactNode;
+}) {
+  return <AdapterContext.Provider value={adapter}>{children}</AdapterContext.Provider>;
+}
+
+/**
+ * Throws rather than returning null.
+ *
+ * A hook that returned `null` would push the same `if (adapter === null)` into every caller, and
+ * the one that forgot it would fail somewhere unrelated with a message about a property of
+ * undefined. Failing here names the actual mistake.
+ */
+export const useAdapter = (): DataAdapter => {
+  const adapter = useContext(AdapterContext);
+  if (adapter === null) {
+    throw new Error('useAdapter() was called outside an <AdapterProvider>. Wrap the subtree.');
+  }
+  return adapter;
+};

--- a/apps/mobile/src/data/AppAdapterProvider.tsx
+++ b/apps/mobile/src/data/AppAdapterProvider.tsx
@@ -1,0 +1,28 @@
+import { createMockAdapter, FIXTURE_SEED } from '@occasio/data';
+import { userId } from '@occasio/core';
+import { useState, type ReactNode } from 'react';
+import { AdapterProvider } from './AdapterProvider';
+
+/**
+ * The app's binding of `<AdapterProvider>`: the mock, seeded with the four fixture events.
+ *
+ * This is the one file the Supabase swap touches. Everything above it asks `useAdapter()` for a
+ * `DataAdapter` and does not know which one it got, which is the arrangement D5 and D29 are
+ * about — so the swap is a change here and nothing else.
+ *
+ * `currentUserId` is a placeholder until sign-in lands (D28, v0.3). It names the wedding's
+ * organiser because that is the account with something to look at in every screen the app has
+ * so far, and it is a constant rather than a setting precisely so that nobody mistakes it for
+ * one: the moment it becomes configurable it starts to look like authentication.
+ */
+const DEMO_USER = userId('u_sanit');
+
+export function AppAdapterProvider({ children }: { readonly children: ReactNode }) {
+  /* Created once per app instance, like the query client beside it. A new adapter per render
+     would rebuild its in-memory state and throw away every subscription with it. */
+  const [adapter] = useState(() =>
+    createMockAdapter({ currentUserId: DEMO_USER, seed: FIXTURE_SEED }),
+  );
+
+  return <AdapterProvider adapter={adapter}>{children}</AdapterProvider>;
+}

--- a/apps/mobile/src/data/hooks.dom.test.tsx
+++ b/apps/mobile/src/data/hooks.dom.test.tsx
@@ -20,6 +20,9 @@ import { useCreateGossip, useGossip } from './hooks';
 const WEDDING = tenantId('t_sanit-riyanks');
 const PENDING = { statuses: ['pending'] } as const;
 
+/** Every client built by `wrapper`, so `afterEach` can clear them. */
+const clients: QueryClient[] = [];
+
 const wrapper = () => {
   const adapter = createMockAdapter({
     currentUserId: userId('u_meera'),
@@ -27,10 +30,19 @@ const wrapper = () => {
     storage: createMemoryStorage(),
     latency: { minMs: 0, maxMs: 0 },
   });
-  /* Retries off: a failing query would otherwise retry twice before the assertion sees it, and
-     the test would report a timeout rather than the error. */
-  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  /*
+   * Retries off: a failing query would otherwise retry twice before the assertion sees it, and
+   * the test would report a timeout rather than the error.
+   *
+   * `gcTime: Infinity` because releasing an inactive query schedules a garbage-collection timer,
+   * and a timer outliving the test keeps a handle open — Jest then waits on it and reports a
+   * slow or hanging run rather than the finished one it had.
+   */
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: Infinity } },
+  });
 
+  clients.push(client);
   return {
     client,
     Wrapper: ({ children }: { readonly children: ReactNode }) => (
@@ -43,8 +55,9 @@ const wrapper = () => {
 
 describe('useGossip', () => {
   afterEach(() => {
-    /* Caches are per-test by construction above, but a lingering timer from a settled query
-       still keeps a handle open. */
+    /* Clearing drops the cached entries now rather than leaving them for a collection timer
+       that outlives the test. */
+    for (const client of clients.splice(0)) client.clear();
   });
 
   it('reads through the adapter it was given', async () => {

--- a/apps/mobile/src/data/hooks.dom.test.tsx
+++ b/apps/mobile/src/data/hooks.dom.test.tsx
@@ -1,0 +1,82 @@
+import { tenantId, userId } from '@occasio/core';
+import { createMockAdapter, createMemoryStorage, FIXTURE_SEED } from '@occasio/data';
+import { afterEach, describe, expect, it } from '@jest/globals';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { AdapterProvider } from './AdapterProvider';
+import { useCreateGossip, useGossip } from './hooks';
+
+/**
+ * What the key factory's tests cannot reach: that a mutation's invalidation actually refreshes
+ * the list a screen is looking at.
+ *
+ * The keys are structural and tested as such. Whether `gossip.all(tenantId)` is the prefix
+ * TanStack Query matches against the key a `useGossip` call stored is a fact about the two of
+ * them together, and the failure — a board that does not update after a post — looks like a
+ * backend problem from the outside.
+ */
+
+const WEDDING = tenantId('t_sanit-riyanks');
+const PENDING = { statuses: ['pending'] } as const;
+
+const wrapper = () => {
+  const adapter = createMockAdapter({
+    currentUserId: userId('u_meera'),
+    seed: FIXTURE_SEED,
+    storage: createMemoryStorage(),
+    latency: { minMs: 0, maxMs: 0 },
+  });
+  /* Retries off: a failing query would otherwise retry twice before the assertion sees it, and
+     the test would report a timeout rather than the error. */
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+  return {
+    client,
+    Wrapper: ({ children }: { readonly children: ReactNode }) => (
+      <QueryClientProvider client={client}>
+        <AdapterProvider adapter={adapter}>{children}</AdapterProvider>
+      </QueryClientProvider>
+    ),
+  };
+};
+
+describe('useGossip', () => {
+  afterEach(() => {
+    /* Caches are per-test by construction above, but a lingering timer from a settled query
+       still keeps a handle open. */
+  });
+
+  it('reads through the adapter it was given', async () => {
+    const { Wrapper } = wrapper();
+    const { result } = renderHook(() => useGossip(WEDDING, PENDING), { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data?.items).toBeDefined();
+  });
+
+  it('refreshes the queue after a post is created', async () => {
+    /*
+     * The whole point of the arrangement. A new post is `pending`, so it belongs to the
+     * moderation queue's list — invalidating the caller's own key would have refreshed the one
+     * view guaranteed not to contain it, which is why the mutation invalidates the entity
+     * prefix instead.
+     */
+    const { Wrapper } = wrapper();
+    const list = renderHook(() => useGossip(WEDDING, PENDING), { wrapper: Wrapper });
+    const create = renderHook(() => useCreateGossip(WEDDING), { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(list.result.current.isSuccess).toBe(true);
+    });
+    const before = list.result.current.data?.items.length ?? 0;
+
+    await create.result.current.mutateAsync({ body: 'A post from a hook test', mediaId: null });
+
+    await waitFor(() => {
+      expect(list.result.current.data?.items.length).toBe(before + 1);
+    });
+  });
+});

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -1,0 +1,109 @@
+import type {
+  AnnouncementQuery,
+  GossipModeration,
+  GossipQuery,
+  NewGossipPost,
+  PageRequest,
+  SessionQuery,
+} from '@occasio/data';
+import type { GossipPostId, TenantId } from '@occasio/core';
+import { useMutation, useQuery, useQueryClient, type UseQueryResult } from '@tanstack/react-query';
+import type { Page, Session, Venue, GossipPost, Announcement } from '@occasio/data';
+import { useAdapter } from './AdapterProvider';
+import { queryKeys } from './queryKeys';
+
+/**
+ * The hooks screens use, and the only place a `queryFn` exists.
+ *
+ * The point of the arrangement is the swap: when the Supabase adapter lands, the bodies below
+ * do not change at all — they call `adapter.sessions.list`, and which adapter that is comes
+ * from the provider. Caching, invalidation and error shape stay put, so no component moves.
+ *
+ * Every hook takes its `tenantId` explicitly rather than reading it from a context. It is the
+ * first argument of every repository method for the same reason: an event is a parameter, not
+ * an ambient fact, and the moment it becomes ambient is the moment two open events start
+ * borrowing each other's data.
+ */
+
+export const useSessions = (
+  tenantId: TenantId,
+  query: SessionQuery,
+  page?: PageRequest,
+): UseQueryResult<Page<Session>> => {
+  const adapter = useAdapter();
+  return useQuery({
+    queryKey: queryKeys.sessions.list(tenantId, query, page),
+    queryFn: () => adapter.sessions.list(tenantId, query, page),
+  });
+};
+
+export const useVenues = (tenantId: TenantId, page?: PageRequest): UseQueryResult<Page<Venue>> => {
+  const adapter = useAdapter();
+  return useQuery({
+    queryKey: queryKeys.venues.list(tenantId, page),
+    queryFn: () => adapter.venues.list(tenantId, page),
+  });
+};
+
+export const useAnnouncements = (
+  tenantId: TenantId,
+  query: AnnouncementQuery,
+  page?: PageRequest,
+): UseQueryResult<Page<Announcement>> => {
+  const adapter = useAdapter();
+  return useQuery({
+    queryKey: queryKeys.announcements.list(tenantId, query, page),
+    queryFn: () => adapter.announcements.list(tenantId, query, page),
+  });
+};
+
+export const useGossip = (
+  tenantId: TenantId,
+  query: GossipQuery,
+  page?: PageRequest,
+): UseQueryResult<Page<GossipPost>> => {
+  const adapter = useAdapter();
+  return useQuery({
+    queryKey: queryKeys.gossip.list(tenantId, query, page),
+    queryFn: () => adapter.gossip.list(tenantId, query, page),
+  });
+};
+
+/**
+ * Posting to the board.
+ *
+ * **Invalidates `gossip.all(tenantId)`.** Every gossip key for this event, not the list the
+ * caller happened to be looking at: a new post is `pending`, so it belongs to the moderation
+ * queue's list rather than the board's, and invalidating the caller's own key would refresh the
+ * one view guaranteed not to contain it.
+ *
+ * Not tenant-wide, because a post changes nothing about the schedule or the venues, and
+ * refetching those on every post is how an app comes to feel slow.
+ */
+export const useCreateGossip = (tenantId: TenantId) => {
+  const adapter = useAdapter();
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: (post: NewGossipPost) => adapter.gossip.create(tenantId, post),
+    onSuccess: () => client.invalidateQueries({ queryKey: queryKeys.gossip.all(tenantId) }),
+  });
+};
+
+/**
+ * A moderator's decision.
+ *
+ * **Invalidates `gossip.all(tenantId)`** for the same reason and one more: the decision moves a
+ * post between two lists — out of the queue and onto the board, or off both — so exactly two
+ * cached lists are wrong and neither is necessarily the one on screen. The realtime
+ * subscription delivers the same change to any mounted listener; this is what makes the *next*
+ * read correct for a screen that was not mounted.
+ */
+export const useModerateGossip = (tenantId: TenantId) => {
+  const adapter = useAdapter();
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, decision }: { id: GossipPostId; decision: GossipModeration }) =>
+      adapter.gossip.moderate(tenantId, id, decision),
+    onSuccess: () => client.invalidateQueries({ queryKey: queryKeys.gossip.all(tenantId) }),
+  });
+};

--- a/apps/mobile/src/data/queryKeys.test.ts
+++ b/apps/mobile/src/data/queryKeys.test.ts
@@ -70,8 +70,21 @@ describe('every key', () => {
     expect(queryKeys.venues.list(WEDDING, { limit: 10 })).not.toEqual(
       queryKeys.venues.list(WEDDING, { limit: 20 }),
     );
-    /* And an unpaged request is its own key rather than colliding with a paged one. */
-    expect(queryKeys.venues.list(WEDDING)).not.toEqual(queryKeys.venues.list(WEDDING, {}));
+  });
+
+  it('treats an omitted page and an empty one as the same request', () => {
+    /* `list(t)` and `list(t, {})` ask for exactly the same thing — the first page with the
+       repository's defaults — so two cache entries for it means two fetches, which reads as the
+       app being slow rather than as a key bug. The previous version of this test asserted they
+       differ, which enshrined the defect as the contract. */
+    expect(queryKeys.venues.list(WEDDING)).toEqual(queryKeys.venues.list(WEDDING, {}));
+    expect(queryKeys.venues.list(WEDDING, { limit: undefined })).toEqual(
+      queryKeys.venues.list(WEDDING),
+    );
+    /* But a real page request is still its own key. */
+    expect(queryKeys.venues.list(WEDDING, { limit: 10 })).not.toEqual(
+      queryKeys.venues.list(WEDDING),
+    );
   });
 });
 
@@ -105,6 +118,19 @@ describe('invalidation prefixes', () => {
     expect(
       isPrefixOf(queryKeys.sessions.all(WEDDING), queryKeys.sessions.list(FESTIVAL, PUBLISHED)),
     ).toBe(false);
+  });
+
+  it('leaves the directory unscoped, because it is how a tenant is found', () => {
+    /*
+     * The one documented exception, and it mirrors the repository layer: `TenantDirectory` is
+     * the single cross-tenant surface — `bySlug` resolves `/e/[slug]` for someone who has no
+     * tenant yet, and `forUser` answers "which events am I in". Prefixing either with a tenant
+     * would mean inventing one to look up the thing that produces it.
+     */
+    expect(queryKeys.directory.bySlug('sanit-riyanks')[0]).not.toBe('tenant');
+    expect(queryKeys.directory.forUser(userId('u_1'))[0]).not.toBe('tenant');
+    /* And they are still distinct from one another, and from a different subject. */
+    expect(queryKeys.directory.bySlug('a')).not.toEqual(queryKeys.directory.bySlug('b'));
   });
 
   it('lets the tenant prefix clear the whole event', () => {

--- a/apps/mobile/src/data/queryKeys.test.ts
+++ b/apps/mobile/src/data/queryKeys.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from '@jest/globals';
+import { gossipPostId, sessionId, tenantId, userId } from '@occasio/core';
+import { queryKeys } from './queryKeys';
+
+/**
+ * Keys are compared by structure, so the properties worth testing are structural.
+ *
+ * Two matter more than the rest. Every key must start with its tenant, or the cache serves one
+ * event's data to another after passing every authorisation check on the way in. And
+ * `entity.all(t)` must be a genuine prefix of every key for that entity, because invalidation
+ * after a mutation relies on it — a prefix that is nearly right leaves a stale list on screen
+ * with nothing in the code looking wrong.
+ */
+
+const WEDDING = tenantId('t_sanit-riyanks');
+const FESTIVAL = tenantId('t_anandhara');
+const PUBLISHED = { statuses: ['published'], track: null } as const;
+const TASKS = { statuses: ['todo'], visibilities: ['public'], assigneeUserId: null } as const;
+
+/** True when `prefix` is the leading segments of `key`, compared structurally. */
+const isPrefixOf = (prefix: readonly unknown[], key: readonly unknown[]): boolean =>
+  prefix.length <= key.length &&
+  prefix.every((segment, i) => JSON.stringify(segment) === JSON.stringify(key[i]));
+
+describe('every key', () => {
+  const forWedding = [
+    queryKeys.sessions.list(WEDDING, PUBLISHED),
+    queryKeys.sessions.byId(WEDDING, sessionId('s_1')),
+    queryKeys.venues.list(WEDDING),
+    queryKeys.gossip.list(WEDDING, { statuses: ['approved'] }),
+    queryKeys.gossip.byId(WEDDING, gossipPostId('g_1')),
+    queryKeys.tasks.list(WEDDING, TASKS),
+    queryKeys.announcements.list(WEDDING, { publishedOnly: true }),
+    queryKeys.memberships.forUser(WEDDING, userId('u_1')),
+    queryKeys.people.list(WEDDING),
+  ];
+
+  it('starts with its tenant', () => {
+    /* The cache's half of the rule the adapter enforces on every read. Two events are open in
+       one app across a session, and a key without the tenant serves one to the other. */
+    for (const key of forWedding) {
+      expect(isPrefixOf(queryKeys.tenant(WEDDING), key)).toBe(true);
+    }
+  });
+
+  it('differs between two events asking the same question', () => {
+    /* The failure the rule above prevents, asserted directly rather than implied. */
+    expect(queryKeys.sessions.list(WEDDING, PUBLISHED)).not.toEqual(
+      queryKeys.sessions.list(FESTIVAL, PUBLISHED),
+    );
+  });
+
+  it('is the same key for the same question', () => {
+    /* Two structurally equal keys must hash the same, or every call is a cache miss and the
+       cache is an expensive way to fetch everything twice. */
+    expect(queryKeys.sessions.list(WEDDING, { statuses: ['published'], track: null })).toEqual(
+      queryKeys.sessions.list(WEDDING, { statuses: ['published'], track: null }),
+    );
+  });
+
+  it('separates a filtered list from an unfiltered one', () => {
+    /* A key that ignored the query would let the attendee schedule and the admin editor share
+       one cache entry -- and the attendee would see unpublished sessions. */
+    expect(queryKeys.sessions.list(WEDDING, PUBLISHED)).not.toEqual(
+      queryKeys.sessions.list(WEDDING, { statuses: ['draft', 'published'], track: null }),
+    );
+  });
+
+  it('separates one page of a list from another', () => {
+    expect(queryKeys.venues.list(WEDDING, { limit: 10 })).not.toEqual(
+      queryKeys.venues.list(WEDDING, { limit: 20 }),
+    );
+    /* And an unpaged request is its own key rather than colliding with a paged one. */
+    expect(queryKeys.venues.list(WEDDING)).not.toEqual(queryKeys.venues.list(WEDDING, {}));
+  });
+});
+
+describe('invalidation prefixes', () => {
+  it('covers every key for that entity', () => {
+    /* What a mutation relies on: one `invalidateQueries` after a write clears the list, the
+       detail and every filtered variant -- including ones a screen adds later that nobody
+       remembers to enumerate. */
+    const sessionKeys = [
+      queryKeys.sessions.list(WEDDING, PUBLISHED),
+      queryKeys.sessions.byId(WEDDING, sessionId('s_1')),
+      queryKeys.sessions.people(WEDDING, sessionId('s_1')),
+    ];
+
+    for (const key of sessionKeys) {
+      expect(isPrefixOf(queryKeys.sessions.all(WEDDING), key)).toBe(true);
+    }
+  });
+
+  it('does not reach another entity', () => {
+    /* An over-broad prefix refetches the whole screen on every write, which reads as the app
+       being slow rather than as a cache bug. */
+    expect(isPrefixOf(queryKeys.sessions.all(WEDDING), queryKeys.venues.list(WEDDING))).toBe(false);
+    expect(isPrefixOf(queryKeys.gossip.all(WEDDING), queryKeys.tasks.list(WEDDING, TASKS))).toBe(
+      false,
+    );
+  });
+
+  it('does not reach another tenant', () => {
+    /* Invalidating a wedding must not refetch a conference that happens to be open. */
+    expect(
+      isPrefixOf(queryKeys.sessions.all(WEDDING), queryKeys.sessions.list(FESTIVAL, PUBLISHED)),
+    ).toBe(false);
+  });
+
+  it('lets the tenant prefix clear the whole event', () => {
+    /* Signing out of an event, or switching to another, has to leave nothing of it behind. */
+    expect(isPrefixOf(queryKeys.tenant(WEDDING), queryKeys.gossip.all(WEDDING))).toBe(true);
+    expect(isPrefixOf(queryKeys.tenant(WEDDING), queryKeys.tenant(FESTIVAL))).toBe(false);
+  });
+});

--- a/apps/mobile/src/data/queryKeys.ts
+++ b/apps/mobile/src/data/queryKeys.ts
@@ -1,0 +1,95 @@
+import type { GossipPostId, SessionId, TenantId, UserId, VenueId } from '@occasio/core';
+import type {
+  AnnouncementQuery,
+  GossipQuery,
+  MembershipQuery,
+  SessionQuery,
+  TaskQuery,
+} from '@occasio/data';
+import type { PageRequest } from '@occasio/data';
+
+/**
+ * Every cache key in the app, in one place.
+ *
+ * Ad-hoc key arrays are the reason cache bugs are hard: a mutation invalidates
+ * `['sessions', tenantId]` while a list was stored under `['sessions', tenantId, query]`, and
+ * the screen shows stale data with nothing in the code looking wrong. Writing them once removes
+ * the class rather than the instance.
+ *
+ * **Every key starts with the tenant.** That is not tidiness — it is the cache's half of the
+ * rule the adapter enforces on every read. Two events are open in one app across a session, and
+ * a key that omitted the tenant would serve a wedding's schedule to a conference from cache,
+ * having passed every authorisation check on the way in.
+ *
+ * The shape is hierarchical so that invalidation can be, too: `sessions.all(t)` is a prefix of
+ * every session key for that tenant, so one call after a mutation clears the list, the detail
+ * and every filtered variant — including the ones a screen added later that nobody remembered
+ * to list.
+ */
+
+/** Everything cached for one event. Invalidating this is what a tenant switch does. */
+const tenant = (tenantId: TenantId) => ['tenant', tenantId] as const;
+
+/**
+ * A query object as a key segment.
+ *
+ * Passed through rather than serialised: TanStack Query hashes keys structurally, so two equal
+ * objects are the same key regardless of identity — and a hand-rolled `JSON.stringify` would
+ * make key equality depend on property order, which is a cache miss nobody can see.
+ */
+export const queryKeys = {
+  tenant,
+
+  directory: {
+    bySlug: (slug: string) => ['directory', 'bySlug', slug] as const,
+    forUser: (userId: UserId) => ['directory', 'forUser', userId] as const,
+  },
+
+  sessions: {
+    all: (t: TenantId) => [...tenant(t), 'sessions'] as const,
+    list: (t: TenantId, query: SessionQuery, page?: PageRequest) =>
+      [...tenant(t), 'sessions', 'list', query, page ?? null] as const,
+    byId: (t: TenantId, id: SessionId) => [...tenant(t), 'sessions', 'byId', id] as const,
+    people: (t: TenantId, id: SessionId) => [...tenant(t), 'sessions', 'people', id] as const,
+  },
+
+  venues: {
+    all: (t: TenantId) => [...tenant(t), 'venues'] as const,
+    list: (t: TenantId, page?: PageRequest) =>
+      [...tenant(t), 'venues', 'list', page ?? null] as const,
+    byId: (t: TenantId, id: VenueId) => [...tenant(t), 'venues', 'byId', id] as const,
+  },
+
+  gossip: {
+    all: (t: TenantId) => [...tenant(t), 'gossip'] as const,
+    list: (t: TenantId, query: GossipQuery, page?: PageRequest) =>
+      [...tenant(t), 'gossip', 'list', query, page ?? null] as const,
+    byId: (t: TenantId, id: GossipPostId) => [...tenant(t), 'gossip', 'byId', id] as const,
+  },
+
+  tasks: {
+    all: (t: TenantId) => [...tenant(t), 'tasks'] as const,
+    list: (t: TenantId, query: TaskQuery, page?: PageRequest) =>
+      [...tenant(t), 'tasks', 'list', query, page ?? null] as const,
+  },
+
+  announcements: {
+    all: (t: TenantId) => [...tenant(t), 'announcements'] as const,
+    list: (t: TenantId, query: AnnouncementQuery, page?: PageRequest) =>
+      [...tenant(t), 'announcements', 'list', query, page ?? null] as const,
+  },
+
+  memberships: {
+    all: (t: TenantId) => [...tenant(t), 'memberships'] as const,
+    list: (t: TenantId, query: MembershipQuery, page?: PageRequest) =>
+      [...tenant(t), 'memberships', 'list', query, page ?? null] as const,
+    forUser: (t: TenantId, userId: UserId) =>
+      [...tenant(t), 'memberships', 'forUser', userId] as const,
+  },
+
+  people: {
+    all: (t: TenantId) => [...tenant(t), 'people'] as const,
+    list: (t: TenantId, page?: PageRequest) =>
+      [...tenant(t), 'people', 'list', page ?? null] as const,
+  },
+} as const;

--- a/apps/mobile/src/data/queryKeys.ts
+++ b/apps/mobile/src/data/queryKeys.ts
@@ -16,10 +16,16 @@ import type { PageRequest } from '@occasio/data';
  * the screen shows stale data with nothing in the code looking wrong. Writing them once removes
  * the class rather than the instance.
  *
- * **Every key starts with the tenant.** That is not tidiness — it is the cache's half of the
- * rule the adapter enforces on every read. Two events are open in one app across a session, and
- * a key that omitted the tenant would serve a wedding's schedule to a conference from cache,
- * having passed every authorisation check on the way in.
+ * **Every key starts with the tenant, except the directory's.** That is not tidiness — it is
+ * the cache's half of the rule the adapter enforces on every read. Two events are open in one
+ * app across a session, and a key that omitted the tenant would serve a wedding's schedule to a
+ * conference from cache, having passed every authorisation check on the way in.
+ *
+ * `directory` is the exception because it is the exception in the repository layer too:
+ * `TenantDirectory` is the one cross-tenant surface, the way a caller *obtains* a `TenantId` in
+ * the first place. `bySlug` resolves `/e/[slug]` for someone who has no tenant yet, and
+ * `forUser` answers "which events am I in", which is cross-tenant by definition. Prefixing
+ * either with a tenant would mean inventing one to look up the thing that produces it.
  *
  * The shape is hierarchical so that invalidation can be, too: `sessions.all(t)` is a prefix of
  * every session key for that tenant, so one call after a mutation clears the list, the detail
@@ -37,6 +43,20 @@ const tenant = (tenantId: TenantId) => ['tenant', tenantId] as const;
  * objects are the same key regardless of identity — and a hand-rolled `JSON.stringify` would
  * make key equality depend on property order, which is a cache miss nobody can see.
  */
+
+/**
+ * A page request, canonicalised.
+ *
+ * `list(t)` and `list(t, {})` ask for exactly the same thing — the first page with the
+ * repository's defaults — so they have to produce the same key. Storing `null` for one and `{}`
+ * for the other gave one result two cache entries and two fetches, which reads as the app being
+ * slow rather than as a key bug. An empty object is the same request as no object.
+ */
+const page = (request?: PageRequest): PageRequest | null => {
+  if (request === undefined) return null;
+  const { limit, cursor } = request;
+  return limit === undefined && cursor === undefined ? null : request;
+};
 export const queryKeys = {
   tenant,
 
@@ -47,49 +67,49 @@ export const queryKeys = {
 
   sessions: {
     all: (t: TenantId) => [...tenant(t), 'sessions'] as const,
-    list: (t: TenantId, query: SessionQuery, page?: PageRequest) =>
-      [...tenant(t), 'sessions', 'list', query, page ?? null] as const,
+    list: (t: TenantId, query: SessionQuery, request?: PageRequest) =>
+      [...tenant(t), 'sessions', 'list', query, page(request)] as const,
     byId: (t: TenantId, id: SessionId) => [...tenant(t), 'sessions', 'byId', id] as const,
     people: (t: TenantId, id: SessionId) => [...tenant(t), 'sessions', 'people', id] as const,
   },
 
   venues: {
     all: (t: TenantId) => [...tenant(t), 'venues'] as const,
-    list: (t: TenantId, page?: PageRequest) =>
-      [...tenant(t), 'venues', 'list', page ?? null] as const,
+    list: (t: TenantId, request?: PageRequest) =>
+      [...tenant(t), 'venues', 'list', page(request)] as const,
     byId: (t: TenantId, id: VenueId) => [...tenant(t), 'venues', 'byId', id] as const,
   },
 
   gossip: {
     all: (t: TenantId) => [...tenant(t), 'gossip'] as const,
-    list: (t: TenantId, query: GossipQuery, page?: PageRequest) =>
-      [...tenant(t), 'gossip', 'list', query, page ?? null] as const,
+    list: (t: TenantId, query: GossipQuery, request?: PageRequest) =>
+      [...tenant(t), 'gossip', 'list', query, page(request)] as const,
     byId: (t: TenantId, id: GossipPostId) => [...tenant(t), 'gossip', 'byId', id] as const,
   },
 
   tasks: {
     all: (t: TenantId) => [...tenant(t), 'tasks'] as const,
-    list: (t: TenantId, query: TaskQuery, page?: PageRequest) =>
-      [...tenant(t), 'tasks', 'list', query, page ?? null] as const,
+    list: (t: TenantId, query: TaskQuery, request?: PageRequest) =>
+      [...tenant(t), 'tasks', 'list', query, page(request)] as const,
   },
 
   announcements: {
     all: (t: TenantId) => [...tenant(t), 'announcements'] as const,
-    list: (t: TenantId, query: AnnouncementQuery, page?: PageRequest) =>
-      [...tenant(t), 'announcements', 'list', query, page ?? null] as const,
+    list: (t: TenantId, query: AnnouncementQuery, request?: PageRequest) =>
+      [...tenant(t), 'announcements', 'list', query, page(request)] as const,
   },
 
   memberships: {
     all: (t: TenantId) => [...tenant(t), 'memberships'] as const,
-    list: (t: TenantId, query: MembershipQuery, page?: PageRequest) =>
-      [...tenant(t), 'memberships', 'list', query, page ?? null] as const,
+    list: (t: TenantId, query: MembershipQuery, request?: PageRequest) =>
+      [...tenant(t), 'memberships', 'list', query, page(request)] as const,
     forUser: (t: TenantId, userId: UserId) =>
       [...tenant(t), 'memberships', 'forUser', userId] as const,
   },
 
   people: {
     all: (t: TenantId) => [...tenant(t), 'people'] as const,
-    list: (t: TenantId, page?: PageRequest) =>
-      [...tenant(t), 'people', 'list', page ?? null] as const,
+    list: (t: TenantId, request?: PageRequest) =>
+      [...tenant(t), 'people', 'list', page(request)] as const,
   },
 } as const;

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -76,7 +76,10 @@ export default {
       displayName: 'components',
       rootDir: '.',
       testEnvironment: 'jsdom',
-      testMatch: ['<rootDir>/packages/*/src/**/*.dom.test.tsx'],
+      testMatch: [
+        '<rootDir>/packages/*/src/**/*.dom.test.tsx',
+        '<rootDir>/apps/*/src/**/*.dom.test.tsx',
+      ],
       /*
        * `react-native` becomes its web build; the two Expo packages become stubs.
        *


### PR DESCRIPTION
Closes #37.

One key factory, one provider, and the hooks screens call. The arrangement is what makes the Supabase swap a change to `AppAdapterProvider` and **nothing else**: a hook body calls `adapter.sessions.list`, and which adapter that is comes from the provider, so no component moves.

### Every key starts with its tenant

That is the cache's half of the rule the adapter enforces on every read. Two events are open in one app across a session, and a key that omitted the tenant would serve a wedding's schedule to a conference **from cache** — having passed every authorisation check on the way in.

### Hierarchical, so invalidation can be

`gossip.all(t)` is a prefix of every gossip key for that event, so one call after a mutation clears the list, the detail and every filtered variant — including ones a screen adds later that nobody remembers to enumerate.

Each mutation documents which prefix it invalidates and why. Creating a post invalidates the *entity*, not the caller's own list: a new post is `pending`, so it belongs to the moderation queue rather than the board the poster was looking at — invalidating the caller's key would refresh the one view guaranteed not to contain it.

Query objects are passed as key segments rather than serialised. TanStack Query hashes structurally, so equal objects are the same key; a hand-rolled `JSON.stringify` would make key identity depend on property order, which is a cache miss nobody can see.

### The adapter is a context, not a module singleton

A singleton is constructed by whoever imports it first, which makes "Supabase here, mock in a test" a question of import order rather than of what is rendered.

### Two layers of tests, catching different things

**Pure**, on the keys: tenant prefixes, structural equality, a filtered list not colliding with an unfiltered one (which would let the attendee schedule and the admin editor share a cache entry — and show attendees unpublished sessions), prefixes that reach every key of their entity and none of another's or another tenant's.

**Rendered**, for the fact neither can see: that a mutation's invalidation actually refreshes the list a screen is holding. The keys being right and TanStack matching them are two different facts, and the failure — a board that does not update after a post — looks like a backend problem from the outside.

**Mutation-checked:** narrowing the invalidation to the caller's own key fails the rendered test. That is the mistake most likely to be made here.

### Note

`currentUserId` is a constant until sign-in lands (D28), and deliberately not a setting — the moment it is configurable it starts to look like authentication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145VPJXGgJA9PWqeNXDr1DG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added mobile data support for sessions, venues, announcements and tenant-specific content.
  - Added gossip browsing, submission and moderation capabilities, including automatic refreshes after updates.
  - Added consistent data loading and refresh behaviour across supported mobile app areas.
  - Added seeded demo data for a more complete app experience.

- **Tests**
  - Expanded coverage for data retrieval, gossip creation and moderation workflows.
  - Added checks to ensure data remains separated between tenants and content types.
  - Added validation for consistent data refresh and query behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->