### PR TITLE
fix(tools): compare the lines an edit changes, not the context it sits in

### DIFF
--- a/tools/review/diffFingerprint.mjs
+++ b/tools/review/diffFingerprint.mjs
@@ -19,6 +19,29 @@
 export const COMPARE_FILE_CAP = 300;
 
 /**
+ * The lines a patch adds and removes, without the context around them.
+ *
+ * A rebase does not change an edit, but it does change where the edit sits: replay a branch onto
+ * a main that has moved and the same three added lines arrive with different surrounding
+ * context and different hunk headers. Comparing the raw patch then reports a change that a
+ * reviewer would not see, and the pull request is stuck asking for a review of nothing — which
+ * is where #144 spent an afternoon and eight rebases.
+ *
+ * What this gives up is the ability to notice the same edit applied somewhere else in the same
+ * file. That is a real gap and a narrow one: it needs identical added and removed lines at a
+ * different location, with no other file differing. The alternative is a gate that a rebase
+ * defeats, which is worse, because the answer to it is a human deciding to merge anyway.
+ *
+ * @param {string} patch
+ * @returns {string}
+ */
+const changedLines = (patch) =>
+  patch
+    .split('\n')
+    .filter((line) => /^[+-]/.test(line) && !/^(\+\+\+|---)/.test(line))
+    .join('\n');
+
+/**
  * Whether a file carries enough to tell one version of it from another.
  *
  * A file with neither a patch nor a blob sha serialises to `binary:unknown`, and so does every
@@ -59,7 +82,8 @@ export const diffEntries = (files) =>
        * version from another. Falling back to the empty string instead would make every binary
        * change invisible here — two different images would fingerprint identically.
        */
-      const body = file.patch ?? `binary:${file.sha ?? 'unknown'}`;
+      const body =
+        file.patch === undefined ? `binary:${file.sha ?? 'unknown'}` : changedLines(file.patch);
       /* The status matters on its own: deleting a file and adding it back with the same
          contents is not the same change as leaving it alone. */
       return `${name}\n${from}\n${file.status ?? 'unknown'}\n${body}`;

--- a/tools/review/diffFingerprint.mjs
+++ b/tools/review/diffFingerprint.mjs
@@ -35,11 +35,22 @@ export const COMPARE_FILE_CAP = 300;
  * @param {string} patch
  * @returns {string}
  */
-const changedLines = (patch) =>
-  patch
-    .split('\n')
-    .filter((line) => /^[+-]/.test(line) && !/^(\+\+\+|---)/.test(line))
-    .join('\n');
+const changedLines = (patch) => {
+  /*
+   * File headers are recognised by position, not by prefix.
+   *
+   * `+++` and `---` introduce the two filenames, and they appear only before the first hunk.
+   * Filtering on the prefix instead also discarded a line adding `++counter;` — encoded as
+   * `+++counter;` — and one removing `--counter;`. Dropping a changed line is the fail-open
+   * direction: two different patches fingerprint the same, and the gate reports a review that
+   * never happened.
+   */
+  const lines = patch.split('\n');
+  const firstHunk = lines.findIndex((line) => line.startsWith('@@'));
+  const body = firstHunk === -1 ? lines : lines.slice(firstHunk);
+
+  return body.filter((line) => line.startsWith('+') || line.startsWith('-')).join('\n');
+};
 
 /**
  * Whether a file carries enough to tell one version of it from another.
@@ -83,7 +94,11 @@ export const diffEntries = (files) =>
        * change invisible here — two different images would fingerprint identically.
        */
       const body =
-        file.patch === undefined ? `binary:${file.sha ?? 'unknown'}` : changedLines(file.patch);
+        /* Nullish: `patch` arrives as `null` for a binary file as readily as absent, and
+           splitting null would throw inside the comparison rather than answer it. */
+        (file.patch ?? null) === null
+          ? `binary:${file.sha ?? 'unknown'}`
+          : changedLines(String(file.patch));
       /* The status matters on its own: deleting a file and adding it back with the same
          contents is not the same change as leaving it alone. */
       return `${name}\n${from}\n${file.status ?? 'unknown'}\n${body}`;

--- a/tools/review/diffFingerprint.test.ts
+++ b/tools/review/diffFingerprint.test.ts
@@ -56,11 +56,15 @@ describe('diffFingerprint', () => {
      * line is the fail-open direction: two different patches fingerprint the same, and the gate
      * reports a review that never happened.
      */
-    const increments = file({ patch: '@@ -1,2 +1,3 @@\n const a = 1;\n+++counter;' });
-    const decrements = file({ patch: '@@ -1,2 +1,3 @@\n const a = 1;\n+--counter;' });
+    const added = file({ patch: '@@ -1,2 +1,3 @@\n const a = 1;\n+++counter;' });
+    const removed = file({ patch: '@@ -1,3 +1,2 @@\n const a = 1;\n---counter;' });
 
-    expect(diffFingerprint([increments])).not.toBe(diffFingerprint([decrements]));
-    expect(diffFingerprint([increments])).toContain('++counter;');
+    /* Each encoding checked on its own, because comparing the two to each other passes for a
+       regression that drops one of them -- which is what the first version of this test did:
+       both its fixtures were *added* lines, so nothing exercised `---`. */
+    expect(diffFingerprint([added])).toContain('++counter;');
+    expect(diffFingerprint([removed])).toContain('--counter;');
+    expect(diffFingerprint([added])).not.toBe(diffFingerprint([removed]));
   });
 
   it('still drops the filename headers themselves', () => {

--- a/tools/review/diffFingerprint.test.ts
+++ b/tools/review/diffFingerprint.test.ts
@@ -49,6 +49,40 @@ describe('diffFingerprint', () => {
     expect(diffFingerprint([before])).toBe(diffFingerprint([rebased]));
   });
 
+  it('keeps a changed line that begins with a plus or a minus', () => {
+    /*
+     * `++counter;` added is encoded `+++counter;`, and `--counter;` removed is `---counter;`.
+     * A filter that recognised file headers by prefix dropped both — and dropping a changed
+     * line is the fail-open direction: two different patches fingerprint the same, and the gate
+     * reports a review that never happened.
+     */
+    const increments = file({ patch: '@@ -1,2 +1,3 @@\n const a = 1;\n+++counter;' });
+    const decrements = file({ patch: '@@ -1,2 +1,3 @@\n const a = 1;\n+--counter;' });
+
+    expect(diffFingerprint([increments])).not.toBe(diffFingerprint([decrements]));
+    expect(diffFingerprint([increments])).toContain('++counter;');
+  });
+
+  it('still drops the filename headers themselves', () => {
+    /* They precede the first hunk, which is how they are told apart now. Keeping them would
+       make a rename look like a content change. */
+    const withHeaders = file({
+      patch: '--- a/src/x.ts\n+++ b/src/x.ts\n@@ -1 +1 @@\n-old\n+new',
+    });
+    const withoutHeaders = file({ patch: '@@ -1 +1 @@\n-old\n+new' });
+
+    expect(diffFingerprint([withHeaders])).toBe(diffFingerprint([withoutHeaders]));
+  });
+
+  it('does not throw on a null patch', () => {
+    /* `patch` arrives as `null` for a binary file as readily as absent, and splitting null
+       would throw inside the comparison rather than answer it. */
+    const binary = { filename: 'assets/hero.png', status: 'modified', patch: null, sha: 'abc' };
+
+    expect(() => diffFingerprint([binary])).not.toThrow();
+    expect(diffFingerprint([binary])).toContain('binary:abc');
+  });
+
   it('still notices a different line arriving in the same place', () => {
     /* The property the rule above must not cost: what was added is still compared. */
     const added = file({ patch: '@@ -1,3 +1,4 @@\n const a = 1;\n+const added = 2;' });

--- a/tools/review/diffFingerprint.test.ts
+++ b/tools/review/diffFingerprint.test.ts
@@ -33,6 +33,37 @@ describe('diffFingerprint', () => {
     expect(diffFingerprint([a, b])).toBe(diffFingerprint([b, a]));
   });
 
+  it('ignores the context a rebase moves an edit into', () => {
+    /*
+     * The same edit replayed onto a moved base arrives with different surrounding context and a
+     * different hunk header. Comparing the raw patch reported a change no reviewer would see,
+     * and left the pull request asking for a review of nothing — eight rebases on #144.
+     */
+    const before = file({
+      patch: '@@ -1,3 +1,4 @@\n const a = 1;\n+const added = 2;\n const b = 3;',
+    });
+    const rebased = file({
+      patch: '@@ -40,3 +40,4 @@\n const x = 9;\n+const added = 2;\n const y = 10;',
+    });
+
+    expect(diffFingerprint([before])).toBe(diffFingerprint([rebased]));
+  });
+
+  it('still notices a different line arriving in the same place', () => {
+    /* The property the rule above must not cost: what was added is still compared. */
+    const added = file({ patch: '@@ -1,3 +1,4 @@\n const a = 1;\n+const added = 2;' });
+    const other = file({ patch: '@@ -1,3 +1,4 @@\n const a = 1;\n+const different = 2;' });
+
+    expect(diffFingerprint([added])).not.toBe(diffFingerprint([other]));
+  });
+
+  it('notices a removal that the added lines alone would hide', () => {
+    const removes = file({ patch: '@@ -1,3 +1,2 @@\n const a = 1;\n-const gone = 2;' });
+    const keeps = file({ patch: '@@ -1,3 +1,3 @@\n const a = 1;\n const gone = 2;' });
+
+    expect(diffFingerprint([removes])).not.toBe(diffFingerprint([keeps]));
+  });
+
   it('changes when a single line of a patch changes', () => {
     expect(diffFingerprint([file()])).not.toBe(
       diffFingerprint([file({ patch: '@@ -1 +1 @@\n-old\n+newer' })]),


### PR DESCRIPTION
#144 has spent an afternoon and **eight rebases** unmergeable.

Its content was reviewed once and never changed. Each rebase replayed the same edit onto a moved `main`, producing different surrounding context and different hunk headers — and the fingerprint called that a change. CodeRabbit would not re-review it (there was nothing new to read), so the gate was asking for a review that could not arrive.

That is the **third distinct reason** this has happened: a pure rebase (#140), a lockfile-only commit under an excluded path (#147), and now context drift. Each was a different way for the gate's idea of "the diff" to disagree with the reviewer's.

### The fix

Compare only the lines a patch adds and removes. That is what a reviewer reads; the context is where those lines happen to sit, and a rebase moves it without touching the edit.

### What it gives up

The same edit applied at a *different place in the same file* now fingerprints identically. That needs identical added and removed lines, at a different location, with no other file differing — narrow, but real, and worth stating rather than discovering later.

The alternative is a gate that a rebase defeats. Its practical answer is somebody deciding to merge anyway, which is precisely the failure this file exists to prevent (#128).

### Tests

- a rebased hunk (same `+` line, different context and header) matches
- a *different* added line in the same place still differs
- a removal still differs from a no-op — comparing additions alone would have hidden it

**Mutation-checked:** comparing the raw patch again fails the first. Verified live: #144 now reports `rebase only: yes`, while #152 is still judged on its real commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145VPJXGgJA9PWqeNXDr1DG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Diff fingerprints are now stable when patch hunk locations or surrounding context changes.
  - Added and removed lines remain significant, while unchanged context, hunk headers and filenames no longer affect textual patch fingerprints.
  - Binary, null and undefined patches continue to use consistent fallback fingerprints.

- **Tests**
  - Added regression coverage for rebased patches, hunk headers, filenames, binary patches, and distinguishing added or removed content from unchanged context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->