### PR TITLE
feat(ui): Sheet, Field and Segmented

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16575,7 +16575,8 @@
         "expo-image": ">=57",
         "expo-linear-gradient": ">=57",
         "react": "^19.0.0",
-        "react-native": ">=0.78"
+        "react-native": ">=0.78",
+        "react-native-safe-area-context": ">=5"
       }
     },
     "tools/eslint-plugin-occasio": {

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -94,3 +94,11 @@ export {
   type Breakpoint,
   type BreakpointName,
 } from './layout/breakpoints';
+
+/* Inputs (#29). The composer, the theme editor and the preferences screens all need these
+   three; `fieldState` is exported because the decision it makes -- an error replaces the hint
+   rather than joining it -- is the same one a form-level summary has to make. */
+export { Field, type FieldProps } from './inputs/Field';
+export { Segmented, type SegmentedOption } from './inputs/Segmented';
+export { Sheet } from './inputs/Sheet';
+export { fieldAria, fieldMessage, type FieldMessage } from './inputs/fieldState';

--- a/packages/ui/src/inputs/Field.dom.test.tsx
+++ b/packages/ui/src/inputs/Field.dom.test.tsx
@@ -1,0 +1,73 @@
+import { themeInputFromPreset } from '@occasio/theme';
+import { describe, expect, it } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from '../theme/ThemeProvider';
+import { Field } from './Field';
+
+/**
+ * The wiring a screen reader depends on, which the pure tests cannot see.
+ *
+ * `fieldState` decides *what* to say; whether the message element actually exists and whether
+ * the input points at it are facts about the rendered tree. Getting them wrong produces a field
+ * that looks correct and is silent — the failure nobody notices without a screen reader.
+ */
+
+const THEME = themeInputFromPreset('conference', '#2563EB');
+
+const renderField = (props: Partial<Parameters<typeof Field>[0]> = {}) =>
+  render(
+    <ThemeProvider input={THEME} forceScheme="light">
+      <Field label="Email" value="" onChangeText={() => undefined} testID="field" {...props} />
+    </ThemeProvider>,
+  );
+
+const input = () => screen.getByLabelText('Email');
+
+describe('Field', () => {
+  it('labels the input with a real label, not a placeholder', () => {
+    /* A placeholder disappears the moment somebody types, so a form filled in with placeholders
+       cannot be checked before submitting — and it is not a name for the field at all. */
+    renderField({ placeholder: 'you@example.com' });
+
+    expect(input()).toBeTruthy();
+    expect(screen.getByText('Email')).toBeTruthy();
+  });
+
+  it('describes the input by its hint', () => {
+    renderField({ hint: 'We only use this for the seating plan' });
+
+    const described = input().getAttribute('aria-describedby');
+    expect(described).toBeTruthy();
+    expect(screen.getByText('We only use this for the seating plan')).toBeTruthy();
+  });
+
+  it('points at nothing when there is no message', () => {
+    /* `aria-describedby` naming an element that does not exist is worse than omitting it: the
+       reader announces nothing and the author believes a description is being read. */
+    renderField();
+
+    expect(input().getAttribute('aria-describedby')).toBeNull();
+  });
+
+  it('announces invalid, and replaces the hint with the error', () => {
+    renderField({ hint: 'Any format is fine', error: 'That is not an email address' });
+
+    expect(input().getAttribute('aria-invalid')).toBe('true');
+    expect(screen.getByText('That is not an email address')).toBeTruthy();
+    expect(screen.queryByText('Any format is fine')).toBeNull();
+  });
+
+  it('announces invalid even when there is no message to read', () => {
+    /* A required field left blank on submit: the validator knows it is wrong and has nothing
+       printable to say. Reading as valid there is the failure. */
+    renderField({ error: '' });
+
+    expect(input().getAttribute('aria-invalid')).toBe('true');
+  });
+
+  it('does not announce a valid field as invalid', () => {
+    renderField({ hint: 'Optional' });
+
+    expect(input().getAttribute('aria-invalid')).not.toBe('true');
+  });
+});

--- a/packages/ui/src/inputs/Field.dom.test.tsx
+++ b/packages/ui/src/inputs/Field.dom.test.tsx
@@ -36,9 +36,13 @@ describe('Field', () => {
   it('describes the input by its hint', () => {
     renderField({ hint: 'We only use this for the seating plan' });
 
+    /* The relationship, not merely that an id is present: a non-empty id pointing at something
+       else reads as a description while describing nothing. */
     const described = input().getAttribute('aria-describedby');
+    const message = screen.getByText('We only use this for the seating plan');
+
+    expect(described).toBe(message.getAttribute('id'));
     expect(described).toBeTruthy();
-    expect(screen.getByText('We only use this for the seating plan')).toBeTruthy();
   });
 
   it('points at nothing when there is no message', () => {
@@ -51,18 +55,22 @@ describe('Field', () => {
 
   it('announces invalid, and replaces the hint with the error', () => {
     renderField({ hint: 'Any format is fine', error: 'That is not an email address' });
+    const message = screen.getByText('That is not an email address');
 
     expect(input().getAttribute('aria-invalid')).toBe('true');
-    expect(screen.getByText('That is not an email address')).toBeTruthy();
+    expect(input().getAttribute('aria-describedby')).toBe(message.getAttribute('id'));
     expect(screen.queryByText('Any format is fine')).toBeNull();
   });
 
   it('announces invalid even when there is no message to read', () => {
     /* A required field left blank on submit: the validator knows it is wrong and has nothing
        printable to say. Reading as valid there is the failure. */
-    renderField({ error: '' });
+    renderField({ hint: 'Optional', error: '' });
 
     expect(input().getAttribute('aria-invalid')).toBe('true');
+    /* And the hint does not come back to fill the silence. */
+    expect(screen.queryByText('Optional')).toBeNull();
+    expect(input().getAttribute('aria-describedby')).toBeNull();
   });
 
   it('does not announce a valid field as invalid', () => {

--- a/packages/ui/src/inputs/Field.tsx
+++ b/packages/ui/src/inputs/Field.tsx
@@ -1,0 +1,123 @@
+import { useId, type ReactNode } from 'react';
+import { Text as RNText, TextInput, View } from 'react-native';
+import type { LayoutViewStyle } from '../components/layoutStyle';
+import { createStyles } from '../theme/createStyles';
+import { fieldAria, fieldMessage } from './fieldState';
+
+/**
+ * A labelled input, with the one line beneath it that a form actually needs.
+ *
+ * The label is a real label rather than a placeholder. A placeholder disappears the moment
+ * someone types, so a form filled in with placeholders is a form nobody can check before
+ * submitting — and it is invisible to a screen reader as a name for the field.
+ *
+ * Colour is never the only signal. An error changes the message text, the border and
+ * `aria-invalid`, because a red border alone is nothing to someone who cannot distinguish it
+ * from the resting one, and nothing at all to a screen reader.
+ */
+
+type Props = {
+  readonly label: string;
+  readonly value: string;
+  readonly onChangeText: (value: string) => void;
+  /** Advice for filling the field in. Replaced by an error rather than joined by one. */
+  readonly hint?: string | null | undefined;
+  /**
+   * The problem with what is currently in the field.
+   *
+   * An empty string still means invalid — it is what a validator produces when it knows the
+   * field is wrong and has nothing printable to say — so `null` and `undefined` are the only
+   * ways to say "this is fine".
+   */
+  readonly error?: string | null | undefined;
+  readonly placeholder?: string | undefined;
+  readonly multiline?: boolean;
+  readonly editable?: boolean;
+  readonly testID?: string | undefined;
+  readonly style?: LayoutViewStyle | undefined;
+};
+
+const useStyles = createStyles((t) => ({
+  root: { gap: t.space(1) },
+  label: { ...t.type.bodyStrong, color: t.color.text },
+  input: {
+    ...t.type.body,
+    color: t.color.text,
+    backgroundColor: t.color.surface,
+    borderWidth: t.border.standard,
+    borderColor: t.color.border,
+    borderRadius: t.radius.sm,
+    paddingHorizontal: t.space(3),
+    paddingVertical: t.space(2),
+  },
+  /* The invalid border is a *different* border, not a tinted one: it has to be distinguishable
+     from the resting state without relying on hue. */
+  inputInvalid: { borderColor: t.color.danger, borderWidth: t.border.standard * 2 },
+  inputDisabled: { backgroundColor: t.color.surfaceSunken, color: t.color.textMuted },
+  multiline: { minHeight: t.space(20), textAlignVertical: 'top' },
+  hint: { ...t.type.caption, color: t.color.textMuted },
+  error: { ...t.type.caption, color: t.color.danger },
+}));
+
+export function Field({
+  label,
+  value,
+  onChangeText,
+  hint,
+  error,
+  placeholder,
+  multiline = false,
+  editable = true,
+  testID,
+  style,
+}: Props) {
+  const styles = useStyles();
+  /* `useId` rather than a prop: the ids only exist to wire this field's own parts together, and
+     making the caller invent one is how two fields end up sharing a `describedby`. */
+  const id = useId();
+  const message = fieldMessage(hint, error);
+  const { labelId, messageId, describedBy } = fieldAria(id, message);
+
+  return (
+    <View style={[styles.root, style]} testID={testID}>
+      <RNText nativeID={labelId} style={styles.label}>
+        {label}
+      </RNText>
+
+      <TextInput
+        value={value}
+        onChangeText={onChangeText}
+        placeholder={placeholder}
+        editable={editable}
+        multiline={multiline}
+        aria-labelledby={labelId}
+        aria-describedby={describedBy}
+        /* Announced as invalid even when there is no message to read out — a required field
+           left empty has no text of its own and must still not read as fine. */
+        aria-invalid={message.invalid}
+        aria-disabled={!editable}
+        style={[
+          styles.input,
+          multiline ? styles.multiline : null,
+          message.invalid ? styles.inputInvalid : null,
+          editable ? null : styles.inputDisabled,
+        ]}
+      />
+
+      {message.text === null ? null : (
+        <RNText
+          nativeID={messageId}
+          style={message.tone === 'error' ? styles.error : styles.hint}
+          /* An error that appears after a form is submitted has to interrupt; a hint that was
+             always there must not. */
+          role={message.tone === 'error' ? 'alert' : undefined}
+        >
+          {message.text}
+        </RNText>
+      )}
+    </View>
+  );
+}
+
+export type FieldProps = Props;
+export type { ReactNode };

--- a/packages/ui/src/inputs/RovingGroup.tsx
+++ b/packages/ui/src/inputs/RovingGroup.tsx
@@ -1,0 +1,15 @@
+import type { RovingGroupProps } from './rovingGroupProps';
+
+/**
+ * Native (and the default): a pass-through.
+ *
+ * Arrow-key traversal of a radio group is a keyboard behaviour, and on iOS and Android the
+ * keyboard belongs to the platform: VoiceOver and TalkBack move between radios with their own
+ * gestures, which they can do because the roles are announced correctly. There is nothing for
+ * this component to add there, and a `View` wrapper would add a layout node for nothing.
+ *
+ * The web variant lives in RovingGroup.web.tsx; Metro and Jest both pick it automatically.
+ */
+export function RovingGroup({ children }: RovingGroupProps) {
+  return <>{children}</>;
+}

--- a/packages/ui/src/inputs/RovingGroup.web.tsx
+++ b/packages/ui/src/inputs/RovingGroup.web.tsx
@@ -1,0 +1,75 @@
+import { useRef, type CSSProperties, type KeyboardEvent } from 'react';
+import { nextIndexForKey } from './segmentedKeys';
+import type { RovingGroupProps } from './rovingGroupProps';
+
+/**
+ * Web: gives a radio group the keyboard behaviour its role promises.
+ *
+ * A `radiogroup` is one Tab stop, not one per option: Tab enters the group at the selected
+ * option and leaves the group entirely, and the arrow keys move within it. That is the whole
+ * reason to claim the role rather than render a row of buttons, and a group that claims it and
+ * ignores the arrow keys is worse than one that never claimed it — a keyboard user is told the
+ * behaviour is there and finds it is not.
+ *
+ * `display: contents` so the wrapper carries the handler without entering layout, the same
+ * trick ThemeScope.web.tsx uses for CSS variables. Key events bubble along the DOM tree rather
+ * than the layout tree, so the segments' keydowns arrive here regardless.
+ */
+
+const CONTENTS: CSSProperties = { display: 'contents' };
+
+/**
+ * Focus the nth radio under `root`.
+ *
+ * Read from the DOM rather than held as refs because that is where the answer is: the segments
+ * are rendered by react-native-web, and what takes focus is the element it produced. An
+ * `instanceof` check rather than a typed `querySelectorAll` — the narrowing is then real, and a
+ * node that turns out not to be focusable is skipped instead of throwing.
+ */
+const focusOption = (root: HTMLElement | null, index: number): void => {
+  if (root === null) return;
+  const node = root.querySelectorAll('[role="radio"]').item(index);
+  if (node instanceof HTMLElement) node.focus();
+};
+
+export function RovingGroup({
+  count,
+  index,
+  onMove,
+  disabled = false,
+  children,
+}: RovingGroupProps) {
+  const root = useRef<HTMLDivElement | null>(null);
+
+  const onKeyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
+    if (disabled) return;
+
+    const next = nextIndexForKey(event.key, index, count);
+    /* Null means the key is not ours. Leaving it alone is what keeps Tab leaving the group and
+       leaves the browser its own shortcuts; a widget that swallows every key is a focus trap. */
+    if (next === null) return;
+
+    /* Arrow keys scroll the page by default, which would drag the group off screen as somebody
+       moved through it. */
+    event.preventDefault();
+
+    /*
+     * Focus is moved by hand rather than left to the roving `tabIndex`. Which option carries
+     * `tabIndex={0}` decides where the *next* Tab lands; it does not move a caret already
+     * inside the group, so without this the selection would walk while focus stayed behind.
+     *
+     * Unconditionally, and before the change: every option is already mounted, so the element
+     * exists whether or not the selection moves, and `Home` pressed on the first option should
+     * still pull focus back to it. Focusing an element whose `tabIndex` is -1 is allowed — that
+     * attribute governs Tab, not `focus()` — and the re-render then makes it the Tab stop.
+     */
+    focusOption(root.current, next);
+    if (next !== index) onMove(next);
+  };
+
+  return (
+    <div ref={root} style={CONTENTS} onKeyDown={onKeyDown}>
+      {children}
+    </div>
+  );
+}

--- a/packages/ui/src/inputs/Segmented.dom.test.tsx
+++ b/packages/ui/src/inputs/Segmented.dom.test.tsx
@@ -1,0 +1,123 @@
+import { themeInputFromPreset } from '@occasio/theme';
+import { describe, expect, it, jest } from '@jest/globals';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { ThemeProvider } from '../theme/ThemeProvider';
+import { Segmented } from './Segmented';
+
+/**
+ * The keyboard half of the `radiogroup` contract, which the pure tests cannot see.
+ *
+ * `nextIndexForKey` decides *where* a key moves the selection; whether the group is one Tab
+ * stop, whether focus follows the selection, and whether an unrelated key is left alone are
+ * facts about the rendered tree. Getting them wrong produces a control that looks correct and
+ * announces correctly, and cannot be operated without a mouse.
+ */
+
+const THEME = themeInputFromPreset('conference', '#2563EB');
+
+const OPTIONS = [
+  { value: 'day', label: 'Day' },
+  { value: 'week', label: 'Week' },
+  { value: 'list', label: 'List' },
+] as const;
+
+type View = (typeof OPTIONS)[number]['value'];
+
+const renderSegmented = (value: View, disabled = false) => {
+  const onChange = jest.fn<(next: View) => void>();
+  render(
+    <ThemeProvider input={THEME} forceScheme="light">
+      <Segmented
+        options={OPTIONS}
+        value={value}
+        onChange={onChange}
+        label="Schedule view"
+        disabled={disabled}
+        testID="view"
+      />
+    </ThemeProvider>,
+  );
+  return onChange;
+};
+
+const segment = (value: View) => screen.getByTestId(`view-${value}`);
+const tabStops = () =>
+  OPTIONS.filter((option) => segment(option.value).getAttribute('tabindex') === '0').map(
+    (option) => option.value,
+  );
+
+describe('Segmented keyboard behaviour', () => {
+  it('is a single Tab stop, entered at the selected option', () => {
+    /* One stop for the whole group is the difference between a radiogroup and three buttons.
+       react-native-web gives every enabled Pressable `tabIndex={0}`, so this is not the
+       default — without the roving index, Tab would stop three times on one control. */
+    renderSegmented('week');
+
+    expect(tabStops()).toEqual(['week']);
+  });
+
+  it('moves the selection with the arrow keys and takes focus with it', () => {
+    const onChange = renderSegmented('day');
+
+    fireEvent.keyDown(segment('day'), { key: 'ArrowRight' });
+
+    expect(onChange).toHaveBeenCalledWith('week');
+    /* Focus, not only selection: the roving `tabIndex` decides where the *next* Tab lands and
+       does nothing for the caret already inside the group. Leaving focus behind is how a
+       keyboard user ends up moving the selection while the ring stays put. */
+    expect(document.activeElement).toBe(segment('week'));
+  });
+
+  it('treats the vertical arrows as the same movement', () => {
+    const onChange = renderSegmented('week');
+
+    fireEvent.keyDown(segment('week'), { key: 'ArrowUp' });
+
+    expect(onChange).toHaveBeenCalledWith('day');
+  });
+
+  it('wraps at both ends', () => {
+    const first = renderSegmented('day');
+    fireEvent.keyDown(segment('day'), { key: 'ArrowLeft' });
+    expect(first).toHaveBeenCalledWith('list');
+
+    screen.getByTestId('view').remove();
+    const last = renderSegmented('list');
+    fireEvent.keyDown(segment('list'), { key: 'ArrowRight' });
+    expect(last).toHaveBeenCalledWith('day');
+  });
+
+  it('jumps to the ends with Home and End', () => {
+    const onChange = renderSegmented('week');
+
+    fireEvent.keyDown(segment('week'), { key: 'End' });
+    expect(onChange).toHaveBeenCalledWith('list');
+
+    fireEvent.keyDown(segment('week'), { key: 'Home' });
+    expect(onChange).toHaveBeenCalledWith('day');
+  });
+
+  it('consumes the keys it owns, so the arrows do not scroll the page', () => {
+    renderSegmented('day');
+
+    /* fireEvent answers false when the handler called preventDefault. */
+    expect(fireEvent.keyDown(segment('day'), { key: 'ArrowRight' })).toBe(false);
+  });
+
+  it('leaves keys it does not own alone', () => {
+    const onChange = renderSegmented('day');
+
+    /* Tab has to leave the group and the browser keeps its own shortcuts. A widget that
+       swallows every key is a focus trap, which is the failure this guards. */
+    expect(fireEvent.keyDown(segment('day'), { key: 'Tab' })).toBe(true);
+    expect(fireEvent.keyDown(segment('day'), { key: 'a' })).toBe(true);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('ignores the arrow keys when the group is disabled', () => {
+    const onChange = renderSegmented('day', true);
+
+    expect(fireEvent.keyDown(segment('day'), { key: 'ArrowRight' })).toBe(true);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/inputs/Segmented.tsx
+++ b/packages/ui/src/inputs/Segmented.tsx
@@ -1,11 +1,11 @@
 import { View } from 'react-native';
 import type { LayoutViewStyle } from '../components/layoutStyle';
 import { InteractiveBox } from '../primitives/InteractiveBox';
-import { tonalPalette } from '../primitives/tones';
 import { createStyles } from '../theme/createStyles';
 import { useTheme } from '../theme/useTheme';
 import { Text } from '../components/Text';
 import { RovingGroup } from './RovingGroup';
+import { segmentPalette } from './segmentPalette';
 
 /**
  * A small set of mutually exclusive choices, all visible at once.
@@ -48,9 +48,8 @@ const useStyles = createStyles((t) => ({
     padding: t.space(1),
     gap: t.space(1),
   },
-  /* The unselected segments read as the group's own background rather than as raised cards, so
-     `neutral`'s surface is overridden here — the palette still supplies the content colour and
-     the border, which are the parts that have to stay contrast-checked. */
+  /* Sizing only. What a segment is painted with lives in segmentPalette.ts, where the colour
+     relationship it has to keep is checkable across every preset and seed. */
   segment: {
     flexGrow: 1,
     flexBasis: 0,
@@ -99,9 +98,7 @@ export function Segmented<T extends string>({
       >
         {options.map((option, index) => {
           const selected = option.value === value;
-          /* The selected segment is the brand fill and the rest are transparent, so the choice is
-           legible without relying on a hue difference between two similar greys. */
-          const palette = tonalPalette(theme, selected ? 'brandSolid' : 'neutral');
+          const palette = segmentPalette(theme, selected);
 
           return (
             <InteractiveBox

--- a/packages/ui/src/inputs/Segmented.tsx
+++ b/packages/ui/src/inputs/Segmented.tsx
@@ -1,0 +1,111 @@
+import { View } from 'react-native';
+import type { LayoutViewStyle } from '../components/layoutStyle';
+import { InteractiveBox } from '../primitives/InteractiveBox';
+import { tonalPalette } from '../primitives/tones';
+import { createStyles } from '../theme/createStyles';
+import { useTheme } from '../theme/useTheme';
+import { Text } from '../components/Text';
+
+/**
+ * A small set of mutually exclusive choices, all visible at once.
+ *
+ * Not a dropdown, and the difference is the point: with three or four options the whole choice
+ * fits on screen, so somebody can see what they are choosing between rather than discovering it
+ * by opening something. Above about five it stops being one, and the type does not stop you --
+ * a limit enforced in code would be a rule about screen width that this component cannot see.
+ *
+ * The accessibility shape is `radiogroup`, not a row of buttons. A screen reader then says "one
+ * of three" and reads the selected one, which is the whole content of the control; a row of
+ * buttons announces three unrelated things and never says which is on.
+ */
+
+export type SegmentedOption<T extends string> = {
+  readonly value: T;
+  readonly label: string;
+};
+
+type Props<T extends string> = {
+  readonly options: readonly SegmentedOption<T>[];
+  readonly value: T;
+  readonly onChange: (value: T) => void;
+  /** Names the group for a screen reader — "Schedule view", not the value it currently holds. */
+  readonly label: string;
+  readonly disabled?: boolean;
+  readonly testID?: string | undefined;
+  readonly style?: LayoutViewStyle | undefined;
+};
+
+const useStyles = createStyles((t) => ({
+  group: {
+    flexDirection: 'row',
+    backgroundColor: t.color.surfaceSunken,
+    borderRadius: t.radius.pill,
+    padding: t.space(1),
+    gap: t.space(1),
+  },
+  /* The unselected segments read as the group's own background rather than as raised cards, so
+     `neutral`'s surface is overridden here — the palette still supplies the content colour and
+     the border, which are the parts that have to stay contrast-checked. */
+  segment: {
+    flexGrow: 1,
+    flexBasis: 0,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: t.space(2),
+    paddingHorizontal: t.space(3),
+    borderRadius: t.radius.pill,
+  },
+}));
+
+export function Segmented<T extends string>({
+  options,
+  value,
+  onChange,
+  label,
+  disabled = false,
+  testID,
+  style,
+}: Props<T>) {
+  const styles = useStyles();
+  const theme = useTheme();
+
+  return (
+    <View
+      role="radiogroup"
+      aria-label={label}
+      aria-disabled={disabled}
+      style={[styles.group, style]}
+      testID={testID}
+    >
+      {options.map((option) => {
+        const selected = option.value === value;
+        /* The selected segment is the brand fill and the rest are transparent, so the choice is
+           legible without relying on a hue difference between two similar greys. */
+        const palette = tonalPalette(theme, selected ? 'brandSolid' : 'neutral');
+
+        return (
+          <InteractiveBox
+            key={option.value}
+            palette={palette}
+            disabled={disabled}
+            onPress={() => {
+              onChange(option.value);
+            }}
+            /* `radio` rather than `button`, and `aria-checked` rather than `aria-selected`:
+               `selected` is only valid on options and tabs, so a screen reader ignores it here
+               and the control announces nothing about its state. */
+            role="radio"
+            aria-checked={selected}
+            aria-label={option.label}
+            boxStyle={styles.segment}
+            testID={testID === undefined ? undefined : `${testID}-${option.value}`}
+          >
+            <Text variant="bodyStrong" tone={selected ? 'onBrand' : 'default'}>
+              {option.label}
+            </Text>
+          </InteractiveBox>
+        );
+      })}
+    </View>
+  );
+}

--- a/packages/ui/src/inputs/Segmented.tsx
+++ b/packages/ui/src/inputs/Segmented.tsx
@@ -5,6 +5,7 @@ import { tonalPalette } from '../primitives/tones';
 import { createStyles } from '../theme/createStyles';
 import { useTheme } from '../theme/useTheme';
 import { Text } from '../components/Text';
+import { RovingGroup } from './RovingGroup';
 
 /**
  * A small set of mutually exclusive choices, all visible at once.
@@ -17,6 +18,10 @@ import { Text } from '../components/Text';
  * The accessibility shape is `radiogroup`, not a row of buttons. A screen reader then says "one
  * of three" and reads the selected one, which is the whole content of the control; a row of
  * buttons announces three unrelated things and never says which is on.
+ *
+ * Claiming that role is a promise about the keyboard as well as about the announcement: the
+ * group is one Tab stop, and the arrow keys move within it. Both halves live here -- the roving
+ * `tabIndex` below decides where Tab lands, and RovingGroup handles the arrow keys.
  */
 
 export type SegmentedOption<T extends string> = {
@@ -69,6 +74,12 @@ export function Segmented<T extends string>({
   const styles = useStyles();
   const theme = useTheme();
 
+  /* A `value` that is not among the options is a caller's bug, and one that must not cost the
+     group its Tab stop: without a fallback no segment would carry `tabIndex={0}`, and a
+     keyboard user would find the control unreachable rather than merely showing nothing. */
+  const selectedIndex = options.findIndex((option) => option.value === value);
+  const activeIndex = selectedIndex === -1 ? 0 : selectedIndex;
+
   return (
     <View
       role="radiogroup"
@@ -77,35 +88,47 @@ export function Segmented<T extends string>({
       style={[styles.group, style]}
       testID={testID}
     >
-      {options.map((option) => {
-        const selected = option.value === value;
-        /* The selected segment is the brand fill and the rest are transparent, so the choice is
+      <RovingGroup
+        count={options.length}
+        index={activeIndex}
+        disabled={disabled}
+        onMove={(next) => {
+          const moved = options[next];
+          if (moved !== undefined) onChange(moved.value);
+        }}
+      >
+        {options.map((option, index) => {
+          const selected = option.value === value;
+          /* The selected segment is the brand fill and the rest are transparent, so the choice is
            legible without relying on a hue difference between two similar greys. */
-        const palette = tonalPalette(theme, selected ? 'brandSolid' : 'neutral');
+          const palette = tonalPalette(theme, selected ? 'brandSolid' : 'neutral');
 
-        return (
-          <InteractiveBox
-            key={option.value}
-            palette={palette}
-            disabled={disabled}
-            onPress={() => {
-              onChange(option.value);
-            }}
-            /* `radio` rather than `button`, and `aria-checked` rather than `aria-selected`:
+          return (
+            <InteractiveBox
+              key={option.value}
+              palette={palette}
+              disabled={disabled}
+              onPress={() => {
+                onChange(option.value);
+              }}
+              /* `radio` rather than `button`, and `aria-checked` rather than `aria-selected`:
                `selected` is only valid on options and tabs, so a screen reader ignores it here
                and the control announces nothing about its state. */
-            role="radio"
-            aria-checked={selected}
-            aria-label={option.label}
-            boxStyle={styles.segment}
-            testID={testID === undefined ? undefined : `${testID}-${option.value}`}
-          >
-            <Text variant="bodyStrong" tone={selected ? 'onBrand' : 'default'}>
-              {option.label}
-            </Text>
-          </InteractiveBox>
-        );
-      })}
+              role="radio"
+              aria-checked={selected}
+              aria-label={option.label}
+              /* Roving: one stop for the group, entered at the option that is selected. */
+              tabIndex={index === activeIndex ? 0 : -1}
+              boxStyle={styles.segment}
+              testID={testID === undefined ? undefined : `${testID}-${option.value}`}
+            >
+              <Text variant="bodyStrong" tone={selected ? 'onBrand' : 'default'}>
+                {option.label}
+              </Text>
+            </InteractiveBox>
+          );
+        })}
+      </RovingGroup>
     </View>
   );
 }

--- a/packages/ui/src/inputs/Sheet.tsx
+++ b/packages/ui/src/inputs/Sheet.tsx
@@ -94,6 +94,9 @@ export function Sheet({ visible, onDismiss, label, children, testID }: Props) {
              user leaves a dialog with its own affordance, not by tapping the page behind it. */
           accessibilityElementsHidden
           importantForAccessibility="no-hide-descendants"
+          /* react-native-web gives an enabled Pressable `tabIndex={0}`, so without this the
+             first Tab inside a sheet lands on an invisible element that announces nothing. */
+          tabIndex={-1}
           style={styles.backdrop}
           onPress={onDismiss}
         />
@@ -102,6 +105,14 @@ export function Sheet({ visible, onDismiss, label, children, testID }: Props) {
           role="dialog"
           aria-modal
           aria-label={label}
+          /*
+           * `accessible` is what makes `onAccessibilityEscape` reachable: it is the VoiceOver
+           * two-finger scrub, and without it an iOS user whose sheet has no visible close
+           * control is stuck inside it. The backdrop cannot rescue them -- it is deliberately
+           * hidden from the accessibility tree.
+           */
+          accessible
+          onAccessibilityEscape={onDismiss}
           style={[styles.panel, toElevationStyle(theme.elevation.lg)]}
         >
           <View aria-hidden style={styles.handle} />

--- a/packages/ui/src/inputs/Sheet.tsx
+++ b/packages/ui/src/inputs/Sheet.tsx
@@ -97,6 +97,16 @@ export function Sheet({ visible, onDismiss, label, children, testID }: Props) {
           /* react-native-web gives an enabled Pressable `tabIndex={0}`, so without this the
              first Tab inside a sheet lands on an invisible element that announces nothing. */
           tabIndex={-1}
+          /*
+           * The one Pressable in this package with no hover or pressed fill, deliberately.
+           *
+           * The house rule that every pressable shows its four states is about controls, and
+           * this is not one — it is the scrim, and it is the size of the screen. A hover tint
+           * on it means the page behind the sheet changes shade whenever the pointer moves;
+           * a pressed fill means the whole screen flashes on the way to dismissing. That is
+           * not feedback, it is the background misbehaving. What acknowledges the tap is the
+           * sheet leaving.
+           */
           style={styles.backdrop}
           onPress={onDismiss}
         />

--- a/packages/ui/src/inputs/Sheet.tsx
+++ b/packages/ui/src/inputs/Sheet.tsx
@@ -106,12 +106,21 @@ export function Sheet({ visible, onDismiss, label, children, testID }: Props) {
           aria-modal
           aria-label={label}
           /*
-           * `accessible` is what makes `onAccessibilityEscape` reachable: it is the VoiceOver
-           * two-finger scrub, and without it an iOS user whose sheet has no visible close
-           * control is stuck inside it. The backdrop cannot rescue them -- it is deliberately
-           * hidden from the accessibility tree.
+           * The VoiceOver two-finger scrub, so an iOS user whose sheet has no visible close
+           * control is not stuck inside it. The backdrop cannot rescue them — it is
+           * deliberately hidden from the accessibility tree.
+           *
+           * Deliberately *without* `accessible`. The first version had it, on the theory that
+           * the prop needs an accessibility element to land on; what `accessible` actually does
+           * on a container is merge it and everything under it into one element, which would
+           * hide the sheet's own fields and buttons from VoiceOver and TalkBack — turning a
+           * missing escape gesture into a sheet whose contents cannot be reached at all. UIKit
+           * passes `accessibilityPerformEscape` up the view hierarchy from whatever has focus,
+           * so the handler is found here without this view being an element itself.
+           *
+           * Not covered by the component tests: react-native-web has no equivalent grouping, so
+           * this is a native-only behaviour that the device pass owns.
            */
-          accessible
           onAccessibilityEscape={onDismiss}
           style={[styles.panel, toElevationStyle(theme.elevation.lg)]}
         >

--- a/packages/ui/src/inputs/Sheet.tsx
+++ b/packages/ui/src/inputs/Sheet.tsx
@@ -1,0 +1,123 @@
+import { type ReactNode } from 'react';
+import { KeyboardAvoidingView, Modal, Platform, Pressable, ScrollView, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { withAlpha } from '@occasio/theme';
+import { createStyles } from '../theme/createStyles';
+import { toElevationStyle } from '../theme/elevation';
+import { useTheme } from '../theme/useTheme';
+
+/**
+ * A panel that comes up from the bottom for one focused task: composing a post, editing a
+ * session, picking a table.
+ *
+ * Two things it must get right, and both are invisible until they are wrong.
+ *
+ * **The keyboard.** A sheet with a text field in it is the one place a keyboard reliably covers
+ * the thing being typed into. `KeyboardAvoidingView` needs opposite behaviours per platform —
+ * `padding` on iOS, `height` on Android — which is exactly the kind of detail a screen author
+ * gets wrong once and copies four times.
+ *
+ * **The bottom inset.** A sheet is flush with the bottom of the screen, so on a phone with a
+ * gesture bar its last control sits under the bar unless the inset is added. It is the control
+ * people reach for, because it is the one at the bottom.
+ */
+
+type Props = {
+  readonly visible: boolean;
+  /** Called for the backdrop, the hardware back button and the escape key alike. */
+  readonly onDismiss: () => void;
+  /** Names the sheet for a screen reader. A sheet without one is announced as "dialog". */
+  readonly label: string;
+  readonly children: ReactNode;
+  readonly testID?: string | undefined;
+};
+
+/** Enough to push the page back without hiding what the sheet is about. */
+const SCRIM_ALPHA = 0.45;
+
+const useStyles = createStyles((t) => ({
+  /*
+   * Derived from the tenant's own darkest neutral rather than a literal black.
+   *
+   * My first version hardcoded `rgba(0, 0, 0, 0.45)` with a comment arguing a scrim is not a
+   * palette colour — which is the reasoning D17's lint rule exists to refuse, and it refused
+   * it. A flat black behind a warm-neutral wedding reads as a different product's dialog; the
+   * ramp's dark end carries the tenant's tint, so the darkening belongs to the event.
+   */
+  backdrop: {
+    flex: 1,
+    backgroundColor: withAlpha(t.color.ramp.neutral[11], SCRIM_ALPHA),
+    justifyContent: 'flex-end',
+  },
+  panel: {
+    backgroundColor: t.color.surfaceRaised,
+    borderTopLeftRadius: t.radius.lg,
+    borderTopRightRadius: t.radius.lg,
+    maxHeight: '90%',
+  },
+  content: { paddingHorizontal: t.space(4), paddingTop: t.space(4), gap: t.space(3) },
+  /* The handle is decoration and is hidden from the accessibility tree: announcing it says
+     "image" where the sheet's own label should be read. */
+  handle: {
+    alignSelf: 'center',
+    width: t.space(10),
+    height: t.space(1),
+    borderRadius: t.radius.pill,
+    backgroundColor: t.color.border,
+    marginTop: t.space(2),
+  },
+}));
+
+export function Sheet({ visible, onDismiss, label, children, testID }: Props) {
+  const styles = useStyles();
+  const theme = useTheme();
+  const insets = useSafeAreaInsets();
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType={theme.motion.enabled ? 'slide' : 'none'}
+      /* Android's hardware back and the web's escape key both arrive here, so a sheet cannot be
+         dismissed by one route and not the other. */
+      onRequestClose={onDismiss}
+      testID={testID}
+    >
+      <KeyboardAvoidingView
+        /* Opposite behaviours per platform: iOS insets the view, Android resizes it. Using one
+           for both leaves the field under the keyboard on whichever platform was not tested. */
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        style={styles.backdrop}
+      >
+        <Pressable
+          /* The backdrop dismisses, and is hidden from assistive technology: a screen reader
+             user leaves a dialog with its own affordance, not by tapping the page behind it. */
+          accessibilityElementsHidden
+          importantForAccessibility="no-hide-descendants"
+          style={styles.backdrop}
+          onPress={onDismiss}
+        />
+
+        <View
+          role="dialog"
+          aria-modal
+          aria-label={label}
+          style={[styles.panel, toElevationStyle(theme.elevation.lg)]}
+        >
+          <View aria-hidden style={styles.handle} />
+          <ScrollView
+            /* The sheet scrolls rather than the page behind it, and taps outside a field still
+               dismiss the keyboard — the gesture people expect from a sheet. */
+            keyboardShouldPersistTaps="handled"
+            contentContainerStyle={[
+              styles.content,
+              { paddingBottom: insets.bottom + theme.space(4) },
+            ]}
+          >
+            {children}
+          </ScrollView>
+        </View>
+      </KeyboardAvoidingView>
+    </Modal>
+  );
+}

--- a/packages/ui/src/inputs/fieldState.test.ts
+++ b/packages/ui/src/inputs/fieldState.test.ts
@@ -26,22 +26,29 @@ describe('fieldMessage', () => {
     expect(fieldMessage(undefined, undefined).text).toBeNull();
   });
 
-  it('treats an empty error as invalid with no message', () => {
+  it('treats an empty error as invalid, and still withholds the hint', () => {
     /*
      * What a validator produces when it knows the field is wrong and has nothing printable to
-     * say — a required field left blank on submit. Treating it as "no error" shows the hint
-     * under a field the form will refuse, and tells a screen reader the field is fine.
+     * say — a required field left blank on submit. It is invalid, and the hint does not come
+     * back: "Optional" under a field the form is refusing is worse than silence, because it is
+     * advice contradicting what just happened.
      */
     const state = fieldMessage('Optional', '');
 
     expect(state.invalid).toBe(true);
-    expect(state.text).toBe('Optional');
-    expect(state.tone).toBe('hint');
+    expect(state.text).toBeNull();
+    expect(state.tone).toBe('error');
   });
 
-  it('ignores whitespace that is not a message', () => {
-    /* `error={serverError}` where the server sent `"  "` is not an error anyone can read. */
-    expect(fieldMessage('A hint', '   ').text).toBe('A hint');
+  it('treats a whitespace error the same way', () => {
+    /* `error={serverError}` where the server sent `"  "` is not readable and is still not ok. */
+    const state = fieldMessage('A hint', '   ');
+
+    expect(state.invalid).toBe(true);
+    expect(state.text).toBeNull();
+  });
+
+  it('ignores whitespace that is not a hint', () => {
     expect(fieldMessage('   ', null).text).toBeNull();
   });
 });

--- a/packages/ui/src/inputs/fieldState.test.ts
+++ b/packages/ui/src/inputs/fieldState.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from '@jest/globals';
+import { fieldAria, fieldMessage } from './fieldState';
+
+describe('fieldMessage', () => {
+  it('shows the hint when there is no error', () => {
+    expect(fieldMessage('We will only use this for the seating plan', null)).toEqual({
+      text: 'We will only use this for the seating plan',
+      tone: 'hint',
+      invalid: false,
+    });
+  });
+
+  it('replaces the hint with the error rather than showing both', () => {
+    /* Two lines of small text under an input, one of them red, is a layout that shifts as
+       validation runs — and advice for filling a field in stops being the most useful thing to
+       say the moment the field is wrong. */
+    expect(fieldMessage('Any format is fine', 'That is not an email address')).toEqual({
+      text: 'That is not an email address',
+      tone: 'error',
+      invalid: true,
+    });
+  });
+
+  it('says nothing when there is nothing to say', () => {
+    expect(fieldMessage(null, null).text).toBeNull();
+    expect(fieldMessage(undefined, undefined).text).toBeNull();
+  });
+
+  it('treats an empty error as invalid with no message', () => {
+    /*
+     * What a validator produces when it knows the field is wrong and has nothing printable to
+     * say — a required field left blank on submit. Treating it as "no error" shows the hint
+     * under a field the form will refuse, and tells a screen reader the field is fine.
+     */
+    const state = fieldMessage('Optional', '');
+
+    expect(state.invalid).toBe(true);
+    expect(state.text).toBe('Optional');
+    expect(state.tone).toBe('hint');
+  });
+
+  it('ignores whitespace that is not a message', () => {
+    /* `error={serverError}` where the server sent `"  "` is not an error anyone can read. */
+    expect(fieldMessage('A hint', '   ').text).toBe('A hint');
+    expect(fieldMessage('   ', null).text).toBeNull();
+  });
+});
+
+describe('fieldAria', () => {
+  it('describes the field by its message when there is one', () => {
+    const state = fieldMessage(null, 'Required');
+    expect(fieldAria('guest-email', state).describedBy).toBe('guest-email-message');
+  });
+
+  it('points at nothing when there is no message', () => {
+    /*
+     * `aria-describedby` naming an element that does not exist is worse than omitting it: the
+     * screen reader announces nothing and the author believes a description is being read.
+     */
+    const state = fieldMessage(null, null);
+
+    expect(fieldAria('guest-email', state).describedBy).toBeUndefined();
+    expect(fieldAria('guest-email', state).messageId).toBeUndefined();
+  });
+
+  it('keeps the label id stable whether or not there is a message', () => {
+    expect(fieldAria('guest-email', fieldMessage(null, null)).labelId).toBe('guest-email-label');
+    expect(fieldAria('guest-email', fieldMessage(null, 'Bad')).labelId).toBe('guest-email-label');
+  });
+});

--- a/packages/ui/src/inputs/fieldState.ts
+++ b/packages/ui/src/inputs/fieldState.ts
@@ -31,18 +31,16 @@ export const fieldMessage = (
   if (trimmedError !== '') return { text: trimmedError, tone: 'error', invalid: true };
 
   /*
-   * An empty-string error still means invalid. `error=""` is what a validator produces when it
-   * knows the field is wrong and has nothing printable to say, and treating it as "no error"
-   * shows the hint under a field the form will refuse to submit.
+   * An unprintable error is still an error. `error=""` is what a validator produces when it
+   * knows the field is wrong and has nothing to say about it, and the hint does not come back:
+   * "Optional" under a field the form is refusing is worse than silence, because it is advice
+   * that contradicts what just happened.
    */
   const invalid = error !== null && error !== undefined;
-  const trimmedHint = hint?.trim() ?? '';
+  if (invalid) return { text: null, tone: 'error', invalid: true };
 
-  return {
-    text: trimmedHint === '' ? null : trimmedHint,
-    tone: 'hint',
-    invalid,
-  };
+  const trimmedHint = hint?.trim() ?? '';
+  return { text: trimmedHint === '' ? null : trimmedHint, tone: 'hint', invalid: false };
 };
 
 /**

--- a/packages/ui/src/inputs/fieldState.ts
+++ b/packages/ui/src/inputs/fieldState.ts
@@ -1,0 +1,64 @@
+/**
+ * What a field says beneath itself, and how a screen reader is told about it.
+ *
+ * Pulled out of the component because it is the part with decisions in it, and because the
+ * combinations that matter are awkward to reach through a rendered tree: a field with both a
+ * hint and an error, a field whose error arrives while it is focused, a field with neither.
+ *
+ * The rule the rest follows: **an error replaces the hint rather than joining it.** Two lines of
+ * small text under an input, one of them red, is a layout that shifts as validation runs — and
+ * the hint is advice for filling the field in, which stops being the most useful thing to say
+ * the moment the field is wrong.
+ */
+
+export type FieldMessage = {
+  /** The text shown beneath the input, or `null` when there is nothing to say. */
+  readonly text: string | null;
+  /** Which tone renders it: an error is not merely red, it is announced differently. */
+  readonly tone: 'hint' | 'error';
+  /**
+   * `aria-invalid`, and the reason it is separate from the tone: a field can be invalid with no
+   * message — a required field left empty on submit — and a screen reader must still say so.
+   */
+  readonly invalid: boolean;
+};
+
+export const fieldMessage = (
+  hint: string | null | undefined,
+  error: string | null | undefined,
+): FieldMessage => {
+  const trimmedError = error?.trim() ?? '';
+  if (trimmedError !== '') return { text: trimmedError, tone: 'error', invalid: true };
+
+  /*
+   * An empty-string error still means invalid. `error=""` is what a validator produces when it
+   * knows the field is wrong and has nothing printable to say, and treating it as "no error"
+   * shows the hint under a field the form will refuse to submit.
+   */
+  const invalid = error !== null && error !== undefined;
+  const trimmedHint = hint?.trim() ?? '';
+
+  return {
+    text: trimmedHint === '' ? null : trimmedHint,
+    tone: 'hint',
+    invalid,
+  };
+};
+
+/**
+ * The ids a field wires together, or `undefined` where there is nothing to point at.
+ *
+ * `aria-describedby` pointing at an element that does not exist is worse than omitting it: a
+ * screen reader announces nothing and the author believes the description is being read.
+ */
+export const fieldAria = (
+  id: string,
+  message: FieldMessage,
+): {
+  readonly labelId: string;
+  readonly messageId: string | undefined;
+  readonly describedBy: string | undefined;
+} => {
+  const messageId = message.text === null ? undefined : `${id}-message`;
+  return { labelId: `${id}-label`, messageId, describedBy: messageId };
+};

--- a/packages/ui/src/inputs/rovingGroupProps.ts
+++ b/packages/ui/src/inputs/rovingGroupProps.ts
@@ -1,0 +1,19 @@
+import type { ReactNode } from 'react';
+
+/**
+ * The shape both RovingGroup variants take.
+ *
+ * In its own module because the platform split makes the obvious alternative circular: on web,
+ * `./RovingGroup` resolves to `RovingGroup.web.tsx`, so the web file importing the type from
+ * "the other one" would import itself.
+ */
+export type RovingGroupProps = {
+  /** How many options the group holds. */
+  readonly count: number;
+  /** Which option is selected — the one that is Tab-reachable. */
+  readonly index: number;
+  /** Called when a key moves the selection. The caller re-renders with the new index. */
+  readonly onMove: (next: number) => void;
+  readonly disabled?: boolean | undefined;
+  readonly children: ReactNode;
+};

--- a/packages/ui/src/inputs/segmentPalette.test.ts
+++ b/packages/ui/src/inputs/segmentPalette.test.ts
@@ -1,0 +1,54 @@
+import { PRESET_IDS, contrast, resolveTheme, themeInputFromPreset } from '@occasio/theme';
+import { describe, expect, it } from '@jest/globals';
+import { segmentPalette } from './segmentPalette';
+
+/**
+ * A relationship between colours, checked across the matrix rather than asserted once.
+ *
+ * The defect this covers was invisible in every unit test and every screenshot taken in one
+ * theme: unselected segments were painted `surfaceRaised`, one step *above* the sunken track
+ * they sit in, so the control read as three cards in a well rather than one track with a
+ * selection in it.
+ */
+
+const SEEDS = ['#2563EB', '#B91C1C', '#0F766E', '#CA8A04', '#7C3AED'];
+const SCHEMES = ['light', 'dark'] as const;
+
+const themes = PRESET_IDS.flatMap((preset) =>
+  SEEDS.flatMap((seed) =>
+    SCHEMES.map((scheme) => ({
+      name: `${preset} ${seed} ${scheme}`,
+      theme: resolveTheme(themeInputFromPreset(preset, seed), { forceScheme: scheme }),
+    })),
+  ),
+);
+
+describe('segmentPalette', () => {
+  it('paints an unselected segment as the track it sits in, in every theme', () => {
+    for (const { name, theme } of themes) {
+      /* The group's own background is `surfaceSunken`. Anything else and the segment reads as a
+         card sitting on the track rather than as part of it. */
+      expect([name, segmentPalette(theme, false).background]).toEqual([
+        name,
+        theme.color.surfaceSunken,
+      ]);
+    }
+  });
+
+  it('makes the selected segment the brand fill, so the choice is not a shade of grey', () => {
+    for (const { name, theme } of themes) {
+      expect([name, segmentPalette(theme, true).background]).toEqual([name, theme.color.brand]);
+    }
+  });
+
+  it('keeps both labels readable on their own fill', () => {
+    /* Contrast is the reason background and content travel together in a palette at all. An
+       unselected segment losing its raised surface must not cost its label. */
+    for (const { name, theme } of themes) {
+      for (const selected of [true, false]) {
+        const palette = segmentPalette(theme, selected);
+        expect([name, contrast(palette.content, palette.background) >= 4.5]).toEqual([name, true]);
+      }
+    }
+  });
+});

--- a/packages/ui/src/inputs/segmentPalette.ts
+++ b/packages/ui/src/inputs/segmentPalette.ts
@@ -1,0 +1,21 @@
+import type { ResolvedTheme } from '@occasio/theme';
+import { surfacePalette, tonalPalette, type TonalPalette } from '../primitives/tones';
+
+/**
+ * What one segment is painted with.
+ *
+ * Its own module because the interesting property is a colour relationship, and a colour
+ * relationship is checkable across every preset and seed without rendering anything — the same
+ * reason tones.ts is free of React.
+ *
+ * The selected segment is the brand fill and the rest are the group's own sunken surface, so
+ * the choice is legible without relying on a hue difference between two similar greys.
+ *
+ * `neutral` is what this reached for first, and it was wrong in a way a comment hid: that tone
+ * is `surfaceRaised`, so every unselected segment rendered as a card standing *above* the
+ * sunken track it sits in — three raised buttons in a well, which is the row-of-buttons look
+ * the control exists to avoid. The comment above it claimed the background was overridden. It
+ * was not; nothing in the component set one.
+ */
+export const segmentPalette = (theme: ResolvedTheme, selected: boolean): TonalPalette =>
+  selected ? tonalPalette(theme, 'brandSolid') : surfacePalette(theme, 'sunken', 'hairline');

--- a/packages/ui/src/inputs/segmentedKeys.test.ts
+++ b/packages/ui/src/inputs/segmentedKeys.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from '@jest/globals';
+import { nextIndexForKey } from './segmentedKeys';
+
+describe('nextIndexForKey', () => {
+  it('moves forward and back along the group', () => {
+    expect(nextIndexForKey('ArrowRight', 0, 3)).toBe(1);
+    expect(nextIndexForKey('ArrowLeft', 2, 3)).toBe(1);
+  });
+
+  it('treats the vertical arrows as the same movement', () => {
+    /* A group can be laid out either way, and a keyboard user should not have to know which. */
+    expect(nextIndexForKey('ArrowDown', 0, 3)).toBe(1);
+    expect(nextIndexForKey('ArrowUp', 1, 3)).toBe(0);
+  });
+
+  it('wraps at both ends, as the role specifies', () => {
+    expect(nextIndexForKey('ArrowRight', 2, 3)).toBe(0);
+    expect(nextIndexForKey('ArrowLeft', 0, 3)).toBe(2);
+  });
+
+  it('jumps to the ends with Home and End', () => {
+    expect(nextIndexForKey('Home', 2, 3)).toBe(0);
+    expect(nextIndexForKey('End', 0, 3)).toBe(2);
+  });
+
+  it('answers null for a key this group does not own', () => {
+    /* The caller consumes the event only when this answers, so Tab still leaves the group and
+       the browser keeps its own shortcuts. Swallowing everything is how a widget traps focus. */
+    expect(nextIndexForKey('Tab', 0, 3)).toBeNull();
+    expect(nextIndexForKey('a', 0, 3)).toBeNull();
+    expect(nextIndexForKey('Enter', 0, 3)).toBeNull();
+  });
+
+  it('answers null for an empty group rather than an impossible index', () => {
+    expect(nextIndexForKey('ArrowRight', 0, 0)).toBeNull();
+  });
+
+  it('starts from the first option when the current one is not in the group', () => {
+    /* Happens when `value` is not among `options` — a caller's bug, but pressing an arrow key
+       should still move somewhere real rather than to -1 or past the end. */
+    expect(nextIndexForKey('ArrowRight', -1, 3)).toBe(1);
+    expect(nextIndexForKey('ArrowLeft', 99, 3)).toBe(2);
+  });
+});

--- a/packages/ui/src/inputs/segmentedKeys.ts
+++ b/packages/ui/src/inputs/segmentedKeys.ts
@@ -1,0 +1,39 @@
+/**
+ * Where an arrow key moves the selection in a radio group.
+ *
+ * A `radiogroup` is not a row of buttons, and the difference is not only what a screen reader
+ * announces: the role promises that arrow keys move between the options and that Tab moves past
+ * the whole group. A control that claims the role and ignores the keys is worse than one that
+ * never claimed it — a keyboard user is told the behaviour exists and finds it does not.
+ *
+ * Wrapping, because that is what the role specifies and what every native implementation does:
+ * pressing Right on the last option returns to the first. Both axes, because a group can be
+ * laid out either way and a keyboard user should not have to know which.
+ */
+
+export type ArrowKey = 'ArrowLeft' | 'ArrowRight' | 'ArrowUp' | 'ArrowDown';
+
+const BACKWARD: readonly string[] = ['ArrowLeft', 'ArrowUp'];
+const FORWARD: readonly string[] = ['ArrowRight', 'ArrowDown'];
+
+/**
+ * The index the selection moves to, or `null` when the key is not one this group handles.
+ *
+ * `null` rather than "stay where you are", so the caller knows whether to consume the event.
+ * Swallowing an unrelated key is how a group breaks Tab, or the browser's own find-as-you-type.
+ */
+export const nextIndexForKey = (key: string, current: number, count: number): number | null => {
+  if (count === 0) return null;
+
+  /* A current index outside the group is not a position to move from. It happens when the
+     selected value is not among the options, which is a caller's bug rather than a keypress. */
+  const from = current >= 0 && current < count ? current : 0;
+
+  if (BACKWARD.includes(key)) return (from - 1 + count) % count;
+  if (FORWARD.includes(key)) return (from + 1) % count;
+  /* Home and End are part of the same contract and cost nothing to honour. */
+  if (key === 'Home') return 0;
+  if (key === 'End') return count - 1;
+
+  return null;
+};

--- a/packages/ui/src/primitives/InteractiveBox.tsx
+++ b/packages/ui/src/primitives/InteractiveBox.tsx
@@ -44,6 +44,14 @@ export type BoxAccessibilityProps = {
   readonly 'aria-label'?: string | undefined;
   /** For a chip that toggles. Left undefined by anything that is not a toggle. */
   readonly 'aria-checked'?: boolean | undefined;
+  /**
+   * Whether Tab stops here. Left undefined by everything that is one Tab stop on its own.
+   *
+   * It exists for the composites that are a single stop made of several boxes — a radio group
+   * is entered once and traversed with the arrow keys — where react-native-web's default of
+   * `tabIndex={0}` on every enabled Pressable would instead make each option its own stop.
+   */
+  readonly tabIndex?: 0 | -1 | undefined;
 };
 
 export type InteractiveBoxProps = BoxAccessibilityProps & {
@@ -65,6 +73,7 @@ export function InteractiveBox({
   role,
   'aria-label': ariaLabel,
   'aria-checked': ariaChecked,
+  tabIndex,
   testID,
   style,
   children,
@@ -84,6 +93,7 @@ export function InteractiveBox({
         aria-label={ariaLabel}
         aria-checked={ariaChecked}
         aria-disabled={ariaDisabled}
+        tabIndex={tabIndex}
         testID={testID}
         /* A box with no onPress still honours `disabled`: a chip that reads as available but
            silently does nothing is worse than one that looks switched off. */
@@ -100,6 +110,7 @@ export function InteractiveBox({
       aria-label={ariaLabel}
       aria-checked={ariaChecked}
       aria-disabled={ariaDisabled}
+      tabIndex={tabIndex}
       testID={testID}
       onPress={onPress}
       disabled={disabled}


### PR DESCRIPTION
Closes #29 — the last unstarted issue in v0.1.

### Field

A **real label**, not a placeholder. A placeholder disappears the moment somebody types, so a form filled in with placeholders cannot be checked before submitting — and it is not a name for the field at all.

**An error replaces the hint rather than joining it.** Two lines of small text under an input, one of them red, is a layout that shifts as validation runs; and advice for filling a field in stops being the most useful thing to say once the field is wrong.

**`error=""` still means invalid.** That is what a validator produces when it knows the field is wrong and has nothing printable to say — a required field left blank on submit. Treating it as "no error" shows the hint under a field the form will refuse, and tells a screen reader everything is fine.

Colour is never the only signal: an error changes the message, the border weight and `aria-invalid` together.

### Segmented

A `radiogroup`, not a row of buttons. A reader then says "one of three" and reads the selected one — the whole content of the control. Three buttons announce three unrelated things and never say which is on. `aria-checked` rather than `aria-selected`, since `selected` is only valid on options and tabs and is silently ignored here.

### Sheet

The two things it must get right are both invisible until they are wrong.

`KeyboardAvoidingView` needs **opposite behaviours per platform** — `padding` on iOS, `height` on Android — which is the kind of detail a screen author gets wrong once and copies four times.

A sheet is flush with the bottom of the screen, so its last control sits **under the gesture bar** unless the inset is added. That is the control people reach for, because it is the one at the bottom.

### Where the tests are, and why

The decisions live in `fieldState`, a pure module: hint and error together, an empty error, whitespace that is not a message. The rendered tests cover what it cannot see — that the message element exists and that the input points at it. `aria-describedby` naming an element that does not exist is *worse* than omitting it, because the reader announces nothing while the author believes a description is being read.

**Mutation-checked:** always setting `aria-describedby` fails the empty-message case; treating an empty error as valid fails the invalid-without-message one.

### The lint rule earned its keep

My first Sheet hardcoded `rgba(0, 0, 0, 0.45)` with a comment arguing a scrim is not a palette colour — which is exactly the reasoning D17 exists to refuse, and it refused it. It derives from the tenant's darkest neutral now: a flat black behind a warm-neutral wedding reads as another product's dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145VPJXGgJA9PWqeNXDr1DG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added accessible form fields with labels, hints, validation messages, disabled and multiline states.
  * Added segmented controls with single-choice selection, keyboard navigation and accessibility support.
  * Added accessible bottom sheets with dismissal, scrolling, safe-area support and reduced-motion handling.
  * Added helpers for consistent field messaging and screen-reader descriptions.
  * Added improved focus and tab-navigation support for interactive controls.
  * Added theme-aware styling for segmented controls.

* **Tests**
  * Added coverage for field accessibility, validation states, message handling, themes and segmented-control keyboard interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->