### PR TITLE
fix(tools): a full review that found nothing is still a review

### DIFF
--- a/tools/review/check-reviewed.mjs
+++ b/tools/review/check-reviewed.mjs
@@ -18,6 +18,7 @@
 import { readFileSync } from 'node:fs';
 import { isReviewable, parseExcludedPaths } from './reviewablePaths.mjs';
 import { COMPARE_FILE_CAP, coversAllOf, diffEntries, isDescribable } from './diffFingerprint.mjs';
+import { isFullReviewFinished } from './reviewMarkers.mjs';
 
 /**
  * Exact logins, not a substring match.
@@ -142,6 +143,26 @@ const reviewEvidence = [
   ...issueComments
     .filter((c) => byReviewer(c) && c.body.includes('Walkthrough'))
     .map((c) => c.created_at),
+  /*
+   * A full review that found nothing.
+   *
+   * Every other entry here is something a review produced, and a clean review produces none of
+   * them: no walkthrough, no finding, no submitted review — just a note edited into the
+   * acknowledgement saying it finished. #144 sat on that for hours, reviewed and clean and
+   * permanently stale, because the gate had nothing newer than the head to point at.
+   *
+   * Dated by `created_at`, which is when the command was acknowledged and therefore when the
+   * review was scoped, not `updated_at`, which is when it finished. The two differ by minutes,
+   * and a commit pushed inside that window is one the review did not read — with `created_at`
+   * the head is then newer than the evidence and this still refuses, which is the answer that
+   * costs a wait rather than a merge.
+   *
+   * Evidence only: it dates a review, it cannot be one. `reviewed` below is deliberately left
+   * alone, so this can refresh an existing review and never manufacture a first one.
+   */
+  ...issueComments
+    .filter((c) => byReviewer(c) && isFullReviewFinished(c.body))
+    .map((c) => c.created_at),
   ...(rateLimited
     ? [
         ...reviewComments.filter(byClaude).map((c) => c.created_at),
@@ -150,6 +171,13 @@ const reviewEvidence = [
     : []),
 ].filter((value) => value != null);
 const lastReviewAt = reviewEvidence.length === 0 ? null : reviewEvidence.sort().at(-1);
+
+/** Reported separately, because "clean full review" and "no review" look identical otherwise. */
+const fullReviewAt = issueComments
+  .filter((c) => byReviewer(c) && isFullReviewFinished(c.body))
+  .map((c) => c.created_at)
+  .sort()
+  .at(-1);
 
 /** Read once. Absent in a checkout that does not have it, which simply excludes nothing. */
 const excludedPaths = (() => {
@@ -271,6 +299,7 @@ console.log(`  reviews     : ${String(submitted)}`);
 console.log(`  rate limited: ${String(rateLimited)}`);
 console.log(`  claude      : ${String(claudeReviewed)} (findings: ${String(claudeFindings)})`);
 console.log(`  last review : ${lastReviewAt ?? 'none'}`);
+if (fullReviewAt !== undefined) console.log(`  full review : ${fullReviewAt}`);
 console.log(`  head commit : ${prData.head.sha.slice(0, 7)} ${headAt ?? 'unknown'}`);
 if (rebasedOnly) {
   console.log(

--- a/tools/review/reviewMarkers.d.mts
+++ b/tools/review/reviewMarkers.d.mts
@@ -1,0 +1,2 @@
+/** Types for the `.mjs` beside this file; see diffFingerprint.d.mts for why it stays `.mjs`. */
+export declare const isFullReviewFinished: (body: unknown) => boolean;

--- a/tools/review/reviewMarkers.mjs
+++ b/tools/review/reviewMarkers.mjs
@@ -1,0 +1,31 @@
+/**
+ * The one sentence CodeRabbit writes when it has read the current head.
+ *
+ * A review is evidenced by what it produced — a walkthrough, findings, a submitted review — and
+ * a review that finds nothing produces none of those. `@coderabbitai full review` on a clean
+ * pull request posts no review record at all; it edits its own acknowledgement to add an
+ * "Action performed" note and stops. The freshness check then has nothing newer than the head
+ * commit to point at and refuses the merge forever, which is where #144 sat: reviewed, clean,
+ * and permanently unmergeable.
+ *
+ * So this recognises that note. Narrowly, because the same block carries a second sentence that
+ * means the opposite:
+ *
+ *     ✅ Action performed
+ *     Review finished.
+ *     > Note: CodeRabbit is an incremental review system and does not re-review already
+ *     > reviewed commits.
+ *
+ * That is `@coderabbitai review`, and it is posted whether or not anything was read — the note
+ * underneath says so in as many words. It is the comment that would have certified #144's stale
+ * review as fresh. Only the full-review form counts, because only the full form is a statement
+ * about the current head rather than about the ancestry.
+ */
+
+/**
+ * Line-anchored, so a body that merely quotes the phrase does not count. `\s*` deliberately
+ * excludes `>`: text CodeRabbit quotes from somebody else is not CodeRabbit saying it.
+ */
+const FULL_REVIEW_FINISHED = /(^|\n)[^\S\n]*Full review finished\b/;
+
+export const isFullReviewFinished = (body) => FULL_REVIEW_FINISHED.test(String(body ?? ''));

--- a/tools/review/reviewMarkers.test.ts
+++ b/tools/review/reviewMarkers.test.ts
@@ -57,8 +57,19 @@ describe('isFullReviewFinished', () => {
   });
 
   it('survives a missing or non-string body rather than throwing', () => {
-    /* The gate reads whatever the API returned. A body that is absent is not a review. */
+    /*
+     * The gate reads whatever the API returned. A body that is absent is not a review.
+     *
+     * The symbol is the case that earns the `String(...)` conversion rather than a bare
+     * `body ?? ''`: nullish values coalesce to the empty string under either, so they cannot
+     * tell the two apart, and a symbol is the one input a regular expression refuses to
+     * stringify — `RegExp.test` throws on it instead of answering false. The gate turning a
+     * surprising payload into a crash is the gate not answering at all.
+     */
     expect(isFullReviewFinished(undefined)).toBe(false);
     expect(isFullReviewFinished(null)).toBe(false);
+    expect(isFullReviewFinished(Symbol('body'))).toBe(false);
+    expect(isFullReviewFinished({ body: 'Full review finished.' })).toBe(false);
+    expect(isFullReviewFinished(42)).toBe(false);
   });
 });

--- a/tools/review/reviewMarkers.test.ts
+++ b/tools/review/reviewMarkers.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from '@jest/globals';
+import { isFullReviewFinished } from './reviewMarkers.mjs';
+
+/**
+ * This predicate can only ever make a stale review look fresh, so every case below is weighted
+ * toward it recognising *less* than asked. The dangerous direction is a false positive: one
+ * would let a commit nobody read merge under an older review's authority.
+ */
+
+/** Verbatim from the comment CodeRabbit posted on #144, minus the learnings block. */
+const FULL = `\`@Sanitdhar\` A full review will evaluate the current head of \`#144\`. It will not
+rely on the previous incremental-review ancestry.
+
+<details>
+<summary>✅ Action performed</summary>
+
+Full review finished.
+
+</details>`;
+
+/** Verbatim from the same pull request, an hour earlier. This one must not count. */
+const INCREMENTAL = `<details>
+<summary>✅ Action performed</summary>
+
+Review finished.
+
+> Note: CodeRabbit is an incremental review system and does not re-review already reviewed
+> commits. This command is applicable only when automatic reviews are paused.
+
+</details>`;
+
+describe('isFullReviewFinished', () => {
+  it('recognises a finished full review', () => {
+    expect(isFullReviewFinished(FULL)).toBe(true);
+  });
+
+  it('does not recognise a finished incremental review', () => {
+    /* The whole point. An incremental review is posted whether or not anything was read — its
+       own note says it does not re-review commits it believes it has seen — so treating it as
+       evidence would date a stale review to the moment somebody asked for a new one. */
+    expect(isFullReviewFinished(INCREMENTAL)).toBe(false);
+  });
+
+  it('does not recognise the announcement on its own', () => {
+    /* The acknowledgement is posted the second the command is read, minutes before the review
+       exists. Only the edit that adds the note means it finished. */
+    expect(isFullReviewFinished(FULL.split('<details>')[0] ?? '')).toBe(false);
+  });
+
+  it('does not count the phrase quoted from somebody else', () => {
+    expect(isFullReviewFinished('> Full review finished.')).toBe(false);
+    expect(isFullReviewFinished('The gate looks for "Full review finished".')).toBe(false);
+  });
+
+  it('does not count a longer word that starts the same way', () => {
+    expect(isFullReviewFinished('Full review finishedness')).toBe(false);
+  });
+
+  it('survives a missing or non-string body rather than throwing', () => {
+    /* The gate reads whatever the API returned. A body that is absent is not a review. */
+    expect(isFullReviewFinished(undefined)).toBe(false);
+    expect(isFullReviewFinished(null)).toBe(false);
+  });
+});


### PR DESCRIPTION
#144 has been reviewed, is clean, and cannot merge. The gate refuses it, and the gate is right by its own rules and wrong about the world.

Every piece of evidence `check-reviewed` dates a review by is something the review *produced* — a walkthrough, a finding, a submitted review record. A review that finds nothing produces none of them. `@coderabbitai full review` on a clean pull request posts no review at all; it edits its own acknowledgement to add

```
✅ Action performed
Full review finished.
```

and stops. The freshness check then has nothing newer than the head commit to point at, concludes the head was never read, and refuses. Rebasing does not help — that makes a newer head. Asking again does not help — a clean review produces the same silence. The PR is stuck in the one state the gate cannot express: read, and with nothing to say.

This recognises that note as a **date for** a review. Narrowly, because the same block carries a sentence that means the opposite:

```
Review finished.
> Note: CodeRabbit is an incremental review system and does not re-review
> already reviewed commits.
```

That is `@coderabbitai review`, posted whether or not anything was read — the note says so outright. It is exactly the comment that would have certified #144's stale review as fresh, and it is what the tests are built around. Only the full form counts, because only the full form is a claim about the current head rather than about the ancestry.

Two smaller decisions, both toward refusing:

- **`created_at`, not `updated_at`** — when the command was acknowledged and the review scoped, not when it finished. They differ by minutes, and a commit pushed inside that window is one the review did not read. With `created_at` the head is then newer than the evidence and the gate still refuses: an answer that costs a wait rather than a merge.
- **Evidence only.** It can date a review; it cannot be one. `reviewed` is untouched, so this refreshes an existing review and never manufactures a first one.

The CodeRabbit commit status is deliberately not used for this. `success` is also what it reads when the budget is exhausted and nothing was reviewed at all — the failure this whole file exists to answer.

## Verification

Run against both open PRs: #144 now passes, #154 still fails while its newest commit is under review.

Each guard is mutation-verified — broadening the pattern to the incremental form, unanchoring it, or dropping the word boundary each fails a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145VPJXGgJA9PWqeNXDr1DG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Review freshness tracking now recognises completed CodeRabbit full-review acknowledgements and records their completion time.
  - Incremental reviews, quoted messages, incomplete announcements and similarly worded messages are excluded from full-review completion tracking.
  - Review status handling remains reliable when content is missing, non-textual or otherwise unexpected.

- **Tests**
  - Added coverage for valid completion messages, invalid variants, quoted content, and missing or non-text content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->