### PR TITLE
test(tools): give the review gate's network layer a harness

### DIFF
--- a/tools/review/check-reviewed.mjs
+++ b/tools/review/check-reviewed.mjs
@@ -48,8 +48,20 @@ const headers = () => {
   return h;
 };
 
+/**
+ * A stalled socket is not a slow answer, it is no answer.
+ *
+ * Without this, one unresponsive connection holds the request until the CI job's own timeout —
+ * so a gate that exists to answer in seconds fails the build twenty minutes later, with a
+ * cancellation notice rather than a verdict. Thirty seconds is far past any healthy response
+ * from this API and far short of anything a person would wait through.
+ */
+const REQUEST_TIMEOUT_MS = 30_000;
+const request = (url) =>
+  fetch(url, { headers: headers(), signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) });
+
 const api = async (path) => {
-  const res = await fetch(`https://api.github.com${path}`, { headers: headers() });
+  const res = await request(`https://api.github.com${path}`);
   if (!res.ok) throw new Error(`${path} -> ${String(res.status)} ${res.statusText}`);
   return res.json();
 };
@@ -59,7 +71,7 @@ const apiAll = async (path) => {
   const out = [];
   for (let page = 1; page <= 20; page += 1) {
     const url = `https://api.github.com${path}${path.includes('?') ? '&' : '?'}per_page=100&page=${String(page)}`;
-    const res = await fetch(url, { headers: headers() });
+    const res = await request(url);
     if (!res.ok) throw new Error(`${path} -> ${String(res.status)} ${res.statusText}`);
     const batch = await res.json();
     if (!Array.isArray(batch) || batch.length === 0) break;

--- a/tools/review/check-reviewed.mjs
+++ b/tools/review/check-reviewed.mjs
@@ -11,39 +11,17 @@
  * #123 merged that way. This looks for evidence of an actual review instead — either
  * CodeRabbit's, or Claude's when it stepped in as CodeRabbit's fallback (D42).
  *
+ * The decision lives in reviewGate.mjs, which takes its data through one injected `api` seam so
+ * every rule in it can be tested (#148). What is left here is the command line: where the token
+ * comes from, how the answer is printed, and what the exit code is.
+ *
  * Usage: node tools/review/check-reviewed.mjs <pr-number>
  *   GITHUB_TOKEN or GH_TOKEN is used when set. The repository is public, so unauthenticated
  *   requests also work, at a lower rate limit.
  */
 import { readFileSync } from 'node:fs';
-import { isReviewable, parseExcludedPaths } from './reviewablePaths.mjs';
-import { COMPARE_FILE_CAP, coversAllOf, diffEntries, isDescribable } from './diffFingerprint.mjs';
-import { isFullReviewFinished } from './reviewMarkers.mjs';
-
-/**
- * Exact logins, not a substring match.
- *
- * Matching any login *containing* "coderabbit" would let anyone who registers such an account
- * post a comment saying "Walkthrough" and make this gate report a PR as reviewed — an
- * authorization bypass in the one check that exists to be trusted.
- *
- * Exactly one login, not two. The bare `coderabbitai` was here as a hedge, and a hedge is the
- * bypass again with a smaller opening: the app posts as `coderabbitai[bot]`, which is what
- * every comment and review on this repository actually carries.
- */
-const REVIEWER_LOGINS = new Set(['coderabbitai[bot]']);
-
-/**
- * D42 — Claude only ever runs here as CodeRabbit's fallback (see
- * .github/workflows/claude-fallback-review.yml, triggered solely by CodeRabbit's own
- * "Review limit reached" comment), posting through the official Claude GitHub app
- * (https://github.com/apps/claude). Exact login, no substring — the same rule REVIEWER_LOGINS
- * applies above, extended to a second trusted reviewer rather than hedged into the first one.
- *
- * Unconfirmed until the workflow has actually posted once: check `user.login` on that PR's
- * comments and correct this if the app's account name differs.
- */
-const CLAUDE_REVIEWER_LOGIN = 'claude[bot]';
+import { parseExcludedPaths } from './reviewablePaths.mjs';
+import { evaluate } from './reviewGate.mjs';
 
 const REPO = process.env['GITHUB_REPOSITORY'] ?? 'dharlabs/occasio';
 const pr = process.argv[2];
@@ -64,14 +42,24 @@ const tokenFromCredentialsFile = () => {
 
 const token = process.env['GITHUB_TOKEN'] ?? process.env['GH_TOKEN'] ?? tokenFromCredentialsFile();
 
+const headers = () => {
+  const h = { accept: 'application/vnd.github+json' };
+  if (token !== undefined) h.authorization = `Bearer ${token}`;
+  return h;
+};
+
+const api = async (path) => {
+  const res = await fetch(`https://api.github.com${path}`, { headers: headers() });
+  if (!res.ok) throw new Error(`${path} -> ${String(res.status)} ${res.statusText}`);
+  return res.json();
+};
+
 /** Follows pagination: evidence on page two is still evidence. */
 const apiAll = async (path) => {
-  const headers = { accept: 'application/vnd.github+json' };
-  if (token !== undefined) headers.authorization = `Bearer ${token}`;
   const out = [];
   for (let page = 1; page <= 20; page += 1) {
     const url = `https://api.github.com${path}${path.includes('?') ? '&' : '?'}per_page=100&page=${String(page)}`;
-    const res = await fetch(url, { headers });
+    const res = await fetch(url, { headers: headers() });
     if (!res.ok) throw new Error(`${path} -> ${String(res.status)} ${res.statusText}`);
     const batch = await res.json();
     if (!Array.isArray(batch) || batch.length === 0) break;
@@ -80,104 +68,6 @@ const apiAll = async (path) => {
   }
   return out;
 };
-
-const apiOne = async (path) => {
-  const headers = { accept: 'application/vnd.github+json' };
-  if (token !== undefined) headers.authorization = `Bearer ${token}`;
-  const res = await fetch(`https://api.github.com${path}`, { headers });
-  if (!res.ok) throw new Error(`${path} -> ${String(res.status)} ${res.statusText}`);
-  return res.json();
-};
-
-const byReviewer = (item) => REVIEWER_LOGINS.has(item.user?.login ?? '');
-
-const [issueComments, reviewComments, reviews, prData] = await Promise.all([
-  apiAll(`/repos/${REPO}/issues/${pr}/comments`),
-  apiAll(`/repos/${REPO}/pulls/${pr}/comments`),
-  apiAll(`/repos/${REPO}/pulls/${pr}/reviews`),
-  apiOne(`/repos/${REPO}/pulls/${pr}`),
-]);
-
-const status = await apiOne(`/repos/${REPO}/commits/${prData.head.sha}/status`);
-const reviewerStatus = status.statuses.find((s) => s.context.toLowerCase().includes('coderabbit'));
-
-const rateLimited = issueComments.some(
-  (c) => byReviewer(c) && c.body.includes('Review limit reached'),
-);
-const walkthrough = issueComments.some((c) => byReviewer(c) && c.body.includes('Walkthrough'));
-const findings = reviewComments.filter(byReviewer).length;
-/* A PENDING review has no submitted_at. Counting it would report "reviewed" before the review
-   exists — the same mistake, one level in. */
-const submitted = reviews.filter((r) => byReviewer(r) && r.submitted_at != null).length;
-
-const byClaude = (item) => (item.user?.login ?? '') === CLAUDE_REVIEWER_LOGIN;
-const claudeFindings = reviewComments.filter(byClaude).length;
-const claudeComment = issueComments.some(byClaude);
-/*
- * Claude counts as a reviewer only where D42 puts it: standing in for CodeRabbit after the
- * budget ran out. Without the `rateLimited` conjunct, any Claude comment on any PR — a reply in
- * a thread, an answer to a question, anything the app posts — satisfied this gate, so the
- * fallback reviewer doubled as a way to skip review entirely.
- */
-const claudeReviewed = rateLimited && (claudeFindings > 0 || claudeComment);
-
-/*
- * When the newest review happened, and when the code it would have read was written.
- *
- * A review is of a commit, not of a pull request. Push a fix after the review and the PR still
- * carries a walkthrough, findings and a submitted review — every signal below is still true —
- * while the diff that is about to land has been read by nobody. On #134 that was a 374-line
- * commit changing who may read invitation contact details, eight minutes after the review it
- * appeared to have.
- */
-/*
- * Only evidence that could make `reviewed` true may date it. Any reviewer comment would be
- * wrong here in a specific and useful way: "Review limit reached" is posted by the reviewer,
- * after the commit, and says a review did *not* happen — counting it would let the one comment
- * that means "unreviewed" certify a stale review as fresh. Claude's activity is admitted only
- * on the condition D42 gives it, matching `claudeReviewed` above.
- */
-const reviewEvidence = [
-  ...reviews.filter((r) => byReviewer(r) && r.submitted_at != null).map((r) => r.submitted_at),
-  ...reviewComments.filter(byReviewer).map((c) => c.created_at),
-  ...issueComments
-    .filter((c) => byReviewer(c) && c.body.includes('Walkthrough'))
-    .map((c) => c.created_at),
-  /*
-   * A full review that found nothing.
-   *
-   * Every other entry here is something a review produced, and a clean review produces none of
-   * them: no walkthrough, no finding, no submitted review — just a note edited into the
-   * acknowledgement saying it finished. #144 sat on that for hours, reviewed and clean and
-   * permanently stale, because the gate had nothing newer than the head to point at.
-   *
-   * Dated by `created_at`, which is when the command was acknowledged and therefore when the
-   * review was scoped, not `updated_at`, which is when it finished. The two differ by minutes,
-   * and a commit pushed inside that window is one the review did not read — with `created_at`
-   * the head is then newer than the evidence and this still refuses, which is the answer that
-   * costs a wait rather than a merge.
-   *
-   * Evidence only: it dates a review, it cannot be one. `reviewed` below is deliberately left
-   * alone, so this can refresh an existing review and never manufacture a first one.
-   */
-  ...issueComments
-    .filter((c) => byReviewer(c) && isFullReviewFinished(c.body))
-    .map((c) => c.created_at),
-  ...(rateLimited
-    ? [
-        ...reviewComments.filter(byClaude).map((c) => c.created_at),
-        ...issueComments.filter(byClaude).map((c) => c.created_at),
-      ]
-    : []),
-].filter((value) => value != null);
-const lastReviewAt = reviewEvidence.length === 0 ? null : reviewEvidence.sort().at(-1);
-
-/** Reported separately, because "clean full review" and "no review" look identical otherwise. */
-const fullReviewAt = issueComments
-  .filter((c) => byReviewer(c) && isFullReviewFinished(c.body))
-  .map((c) => c.created_at)
-  .sort()
-  .at(-1);
 
 /** Read once. Absent in a checkout that does not have it, which simply excludes nothing. */
 const excludedPaths = (() => {
@@ -188,130 +78,29 @@ const excludedPaths = (() => {
   }
 })();
 
-const headCommit = await apiOne(`/repos/${REPO}/commits/${prData.head.sha}`);
-const headAt = headCommit.commit?.committer?.date ?? null;
+const v = await evaluate({ api, apiAll, repo: REPO, pr, excludedPaths });
 
-/**
- * The change a commit proposes, independent of where it sits in history.
- *
- * `/compare/base...head` is three-dot, so it reports the difference from the merge base — the
- * pull request's own changes, without whatever the base branch has done since. Hashing the
- * patches gives a value that survives a rebase and moves the moment a line does.
- */
-const effectiveDiff = async (sha) => {
-  try {
-    const comparison = await apiOne(
-      `/repos/${REPO}/compare/${prData.base.ref}...${sha}?per_page=300`,
-    );
-    /*
-     * Everything below fails closed, because this function's answer is used to skip a review and
-     * every uncertainty here is shaped the same way: two incomplete comparisons produce equal
-     * fingerprints, and equal reads as "already reviewed".
-     */
-    /*
-     * Only the files the reviewer is asked to read. `.coderabbit.yaml` excludes the lockfile,
-     * the scratch directory and the screenshot baselines, so a commit touching only those gives
-     * it nothing to review and it will never produce one — leaving the freshness check demanding
-     * something that cannot arrive. Missing config means nothing is excluded, which errs toward
-     * asking for more review rather than less.
-     */
-    const reported = comparison.files;
-    /* An absent list fingerprints as the empty string, and so does another absent list. */
-    if (!Array.isArray(reported)) return null;
-    /*
-     * The cap is checked against what the endpoint reported, before anything is filtered out.
-     * Checking the filtered list instead lets excluded entries hide the truncation: 300 files
-     * of which 40 are lockfile-and-screenshot noise leaves 260, under the cap, and the check
-     * passes on a comparison that was cut short — with the unlisted change being the one nobody
-     * reviewed.
-     */
-    if (reported.length >= COMPARE_FILE_CAP) return null;
-    const files = reported.filter((f) => isReviewable(excludedPaths, String(f.filename ?? '')));
-    /* A file with neither a patch nor a blob sha is a file this cannot describe. Both would
-       serialise as `binary:unknown`, which is one unknown matching another. */
-    if (!files.every(isDescribable)) return null;
-    return diffEntries(files);
-  } catch {
-    /* A force-pushed commit can fall out of reach. Unknown is not "unchanged". */
-    return null;
-  }
-};
-
-/*
- * A rebase is not a change to the code.
- *
- * Branch protection requires a branch to be up to date, so every open PR is rebased whenever
- * `main` moves — and the head commit is then newer than its review while proposing exactly the
- * same diff. CodeRabbit will not re-review that, correctly, because there is nothing new to
- * read, so a date comparison alone leaves the PR stuck between a gate wanting a review and a
- * reviewer with no reason to give one (#140).
- *
- * So the date is the cheap check and the diff is the authority: when the newest review sits on
- * a commit proposing the same effective diff as the head, the review still applies. Any real
- * edit changes the patches and this stops helping, which is the point.
- */
-const reviewedSha = [...reviews]
-  .filter((r) => byReviewer(r) && r.submitted_at != null)
-  .sort((a, b) => (a.submitted_at < b.submitted_at ? -1 : 1))
-  .at(-1)?.commit_id;
-
-/**
- * Whether everything the head proposes was part of what the review read.
- *
- * A subset rather than an equality, and the difference is not a convenience. A pull request
- * whose base absorbed one of its files — `main` merged the same lockfile fix, say — proposes a
- * strictly smaller change than the one that was reviewed, and dropping a file cannot introduce
- * code nobody read. Equality refuses that, and CodeRabbit will not clear it either: asked to
- * look again it answers "No files to review", because there is nothing new to read. The gate
- * then wants a review that cannot be produced, which is a stuck pull request rather than a safe
- * one.
- *
- * Any file whose patch differs is simply not in the reviewed set, so an edit still fails here.
- */
-const sameDiffAsReviewed = async () => {
-  if (reviewedSha === undefined || reviewedSha === prData.head.sha) return false;
-  const [reviewedDiff, headDiff] = await Promise.all([
-    effectiveDiff(reviewedSha),
-    effectiveDiff(prData.head.sha),
-  ]);
-  if (reviewedDiff === null || headDiff === null) return false;
-  return coversAllOf(reviewedDiff, headDiff);
-};
-/*
- * Fails closed. An absent timestamp is a reason to look rather than to pass, and treating one
- * as `not stale` would have made every unknown a quiet approval — which is the failure this
- * whole file exists to answer, reintroduced by its newest check.
- */
-const newerThanReview =
-  lastReviewAt == null || headAt === null ? true : Date.parse(headAt) > Date.parse(lastReviewAt);
-const rebasedOnly = newerThanReview && (await sameDiffAsReviewed());
-const stale = newerThanReview && !rebasedOnly;
-
-const reviewed = walkthrough || findings > 0 || submitted > 0 || claudeReviewed;
-
-console.log(`PR #${pr} — ${prData.title}`);
-console.log(
-  `  status      : ${reviewerStatus?.state ?? 'none'} | ${reviewerStatus?.description ?? ''}`,
-);
-console.log(`  walkthrough : ${String(walkthrough)}`);
-console.log(`  findings    : ${String(findings)}`);
-console.log(`  reviews     : ${String(submitted)}`);
-console.log(`  rate limited: ${String(rateLimited)}`);
-console.log(`  claude      : ${String(claudeReviewed)} (findings: ${String(claudeFindings)})`);
-console.log(`  last review : ${lastReviewAt ?? 'none'}`);
-if (fullReviewAt !== undefined) console.log(`  full review : ${fullReviewAt}`);
-console.log(`  head commit : ${prData.head.sha.slice(0, 7)} ${headAt ?? 'unknown'}`);
-if (rebasedOnly) {
+console.log(`PR #${pr} — ${v.title}`);
+console.log(`  status      : ${v.reviewerState} | ${v.reviewerDescription}`);
+console.log(`  walkthrough : ${String(v.walkthrough)}`);
+console.log(`  findings    : ${String(v.findings)}`);
+console.log(`  reviews     : ${String(v.submitted)}`);
+console.log(`  rate limited: ${String(v.rateLimited)}`);
+console.log(`  claude      : ${String(v.claudeReviewed)} (findings: ${String(v.claudeFindings)})`);
+console.log(`  last review : ${v.lastReviewAt ?? 'none'}`);
+if (v.fullReviewAt !== null) console.log(`  full review : ${v.fullReviewAt}`);
+console.log(`  head commit : ${(v.headSha ?? 'unknown').slice(0, 7)} ${v.headAt ?? 'unknown'}`);
+if (v.rebasedOnly) {
   console.log(
-    `  rebase only : yes — every change is one the review of ${String(reviewedSha).slice(0, 7)} already read`,
+    `  rebase only : yes — every change is one the review of ${String(v.reviewedSha).slice(0, 7)} already read`,
   );
 }
 
-if (reviewed && stale) {
+if (v.reviewed && v.stale) {
   console.error(
-    lastReviewAt == null || headAt === null
-      ? `\nNOT REVIEWED. Could not date the review (${String(lastReviewAt)}) or the head commit (${String(headAt)}), so freshness cannot be established.`
-      : `\nNOT REVIEWED. Head commit ${prData.head.sha.slice(0, 7)} (${String(headAt)}) is newer than the last review (${String(lastReviewAt)}).`,
+    v.lastReviewAt == null || v.headAt === null
+      ? `\nNOT REVIEWED. Could not date the review (${String(v.lastReviewAt)}) or the head commit (${String(v.headAt)}), so freshness cannot be established.`
+      : `\nNOT REVIEWED. Head commit ${String(v.headSha).slice(0, 7)} (${String(v.headAt)}) is newer than the last review (${String(v.lastReviewAt)}).`,
   );
   console.error(
     'The pull request has been reviewed; the code about to merge has not. Wait for the',
@@ -320,9 +109,9 @@ if (reviewed && stale) {
   process.exit(1);
 }
 
-if (!reviewed) {
+if (!v.reviewed) {
   console.error(
-    `\nNOT REVIEWED. ${rateLimited ? 'The review budget was exhausted, and Claude has not stepped in yet; wait for .github/workflows/claude-fallback-review.yml or for the budget to reset.' : 'No walkthrough, finding or submitted review from a known reviewer account.'}`,
+    `\nNOT REVIEWED. ${v.rateLimited ? 'The review budget was exhausted, and Claude has not stepped in yet; wait for .github/workflows/claude-fallback-review.yml or for the budget to reset.' : 'No walkthrough, finding or submitted review from a known reviewer account.'}`,
   );
   console.error('Merging now would satisfy the letter of D40 and none of its point.');
   process.exit(1);

--- a/tools/review/reviewGate.d.mts
+++ b/tools/review/reviewGate.d.mts
@@ -1,0 +1,32 @@
+/** Types for the `.mjs` beside this file; see diffFingerprint.d.mts for why it stays `.mjs`. */
+
+export type ReviewVerdict = {
+  title: string;
+  headSha: string | null;
+  headAt: string | null;
+  reviewerState: string;
+  reviewerDescription: string;
+  walkthrough: boolean;
+  findings: number;
+  submitted: number;
+  rateLimited: boolean;
+  claudeReviewed: boolean;
+  claudeFindings: number;
+  lastReviewAt: string | null;
+  fullReviewAt: string | null;
+  reviewedSha: string | null;
+  rebasedOnly: boolean;
+  stale: boolean;
+  reviewed: boolean;
+  ok: boolean;
+};
+
+export declare const REVIEWER_LOGINS: Set<string>;
+export declare const CLAUDE_REVIEWER_LOGIN: string;
+export declare const evaluate: (options: {
+  api: (path: string) => Promise<unknown>;
+  apiAll: (path: string) => Promise<unknown[]>;
+  repo: string;
+  pr: string | number;
+  excludedPaths?: readonly string[];
+}) => Promise<ReviewVerdict>;

--- a/tools/review/reviewGate.mjs
+++ b/tools/review/reviewGate.mjs
@@ -1,0 +1,273 @@
+/**
+ * Whether a pull request was actually reviewed, decided from data rather than from the network.
+ *
+ * Everything here used to live in check-reviewed.mjs, interleaved with `fetch`, and so could not
+ * be tested at all (#148). That mattered more than it sounds: every rule below was added because
+ * a defect got past it, and each fix was verified by running the real gate against a real pull
+ * request and reading the output — which proves the answer for that one PR on that one day.
+ *
+ * The single seam is `api`. Give it a function from path to parsed JSON and this makes the same
+ * decision it makes in CI, against canned responses, in milliseconds.
+ */
+import { isReviewable } from './reviewablePaths.mjs';
+import { COMPARE_FILE_CAP, coversAllOf, diffEntries, isDescribable } from './diffFingerprint.mjs';
+import { isFullReviewFinished } from './reviewMarkers.mjs';
+
+/**
+ * Exact logins, not a substring match.
+ *
+ * Matching any login *containing* "coderabbit" would let anyone who registers such an account
+ * post a comment saying "Walkthrough" and make this gate report a PR as reviewed — an
+ * authorization bypass in the one check that exists to be trusted.
+ *
+ * Exactly one login, not two. The bare `coderabbitai` was here as a hedge, and a hedge is the
+ * bypass again with a smaller opening: the app posts as `coderabbitai[bot]`, which is what
+ * every comment and review on this repository actually carries.
+ */
+export const REVIEWER_LOGINS = new Set(['coderabbitai[bot]']);
+
+/**
+ * D42 — Claude only ever runs here as CodeRabbit's fallback (see
+ * .github/workflows/claude-fallback-review.yml, whose automatic trigger is CodeRabbit's own
+ * "Review limit reached" comment), posting through the official Claude GitHub app
+ * (https://github.com/apps/claude). Exact login, no substring — the same rule REVIEWER_LOGINS
+ * applies above, extended to a second trusted reviewer rather than hedged into the first one.
+ *
+ * Unconfirmed until the workflow has actually posted once: check `user.login` on that PR's
+ * comments and correct this if the app's account name differs. #142 tracks doing exactly that.
+ */
+export const CLAUDE_REVIEWER_LOGIN = 'claude[bot]';
+
+const byReviewer = (item) => REVIEWER_LOGINS.has(item?.user?.login ?? '');
+const byClaude = (item) => (item?.user?.login ?? '') === CLAUDE_REVIEWER_LOGIN;
+
+/**
+ * The change a commit proposes, independent of where it sits in history.
+ *
+ * `/compare/base...head` is three-dot, so it reports the difference from the merge base — the
+ * pull request's own changes, without whatever the base branch has done since. Hashing the
+ * patches gives a value that survives a rebase and moves the moment a line does.
+ */
+const effectiveDiff = async (api, repo, base, sha, excludedPaths) => {
+  let comparison;
+  try {
+    comparison = await api(`/repos/${repo}/compare/${base}...${sha}?per_page=300`);
+  } catch {
+    /* A force-pushed commit can fall out of reach. Unknown is not "unchanged". */
+    return null;
+  }
+  /*
+   * Everything below fails closed, because this function's answer is used to skip a review and
+   * every uncertainty here is shaped the same way: two incomplete comparisons produce equal
+   * fingerprints, and equal reads as "already reviewed".
+   */
+  const reported = comparison?.files;
+  /* An absent list fingerprints as the empty string, and so does another absent list. */
+  if (!Array.isArray(reported)) return null;
+  /*
+   * The cap is checked against what the endpoint reported, before anything is filtered out.
+   * Checking the filtered list instead lets excluded entries hide the truncation: 300 files of
+   * which 40 are lockfile-and-screenshot noise leaves 260, under the cap, and the check passes
+   * on a comparison that was cut short — with the unlisted change being the one nobody
+   * reviewed.
+   */
+  if (reported.length >= COMPARE_FILE_CAP) return null;
+  /*
+   * Only the files the reviewer is asked to read. `.coderabbit.yaml` excludes the lockfile, the
+   * scratch directory and the screenshot baselines, so a commit touching only those gives it
+   * nothing to review and it will never produce one — leaving the freshness check demanding
+   * something that cannot arrive. Missing config means nothing is excluded, which errs toward
+   * asking for more review rather than less.
+   */
+  const files = reported.filter((f) => isReviewable(excludedPaths, String(f?.filename ?? '')));
+  /* A file with neither a patch nor a blob sha is a file this cannot describe. Both would
+     serialise as `binary:unknown`, which is one unknown matching another. */
+  if (!files.every(isDescribable)) return null;
+  return diffEntries(files);
+};
+
+/**
+ * The gate's verdict, and everything it was derived from.
+ *
+ * Returned as data rather than printed, so the CLI decides how to say it and the tests can ask
+ * about any single rule without parsing prose.
+ */
+export const evaluate = async ({ api, apiAll, repo, pr, excludedPaths = [] }) => {
+  const [issueComments, reviewComments, reviews, prData] = await Promise.all([
+    apiAll(`/repos/${repo}/issues/${pr}/comments`),
+    apiAll(`/repos/${repo}/pulls/${pr}/comments`),
+    apiAll(`/repos/${repo}/pulls/${pr}/reviews`),
+    api(`/repos/${repo}/pulls/${pr}`),
+  ]);
+
+  const headSha = prData?.head?.sha ?? null;
+  const baseRef = prData?.base?.ref ?? null;
+
+  const status = headSha === null ? null : await api(`/repos/${repo}/commits/${headSha}/status`);
+  const reviewerStatus = (status?.statuses ?? []).find((s) =>
+    String(s?.context ?? '')
+      .toLowerCase()
+      .includes('coderabbit'),
+  );
+
+  const rateLimited = issueComments.some(
+    (c) => byReviewer(c) && String(c.body ?? '').includes('Review limit reached'),
+  );
+  const walkthrough = issueComments.some(
+    (c) => byReviewer(c) && String(c.body ?? '').includes('Walkthrough'),
+  );
+  const findings = reviewComments.filter(byReviewer).length;
+  /* A PENDING review has no submitted_at. Counting it would report "reviewed" before the review
+     exists — the same mistake, one level in. */
+  const submittedReviews = reviews.filter((r) => byReviewer(r) && r.submitted_at != null);
+  const submitted = submittedReviews.length;
+
+  const claudeFindings = reviewComments.filter(byClaude).length;
+  const claudeComment = issueComments.some(byClaude);
+  /*
+   * Claude counts as a reviewer only where D42 puts it: standing in for CodeRabbit after the
+   * budget ran out. Without the `rateLimited` conjunct, any Claude comment on any PR — a reply
+   * in a thread, an answer to a question, anything the app posts — satisfied this gate, so the
+   * fallback reviewer doubled as a way to skip review entirely.
+   */
+  const claudeReviewed = rateLimited && (claudeFindings > 0 || claudeComment);
+
+  /*
+   * When the newest review happened, and when the code it would have read was written.
+   *
+   * A review is of a commit, not of a pull request. Push a fix after the review and the PR still
+   * carries a walkthrough, findings and a submitted review — every signal above is still true —
+   * while the diff that is about to land has been read by nobody. On #134 that was a 374-line
+   * commit changing who may read invitation contact details, eight minutes after the review it
+   * appeared to have.
+   *
+   * Only evidence that could make `reviewed` true may date it. Any reviewer comment would be
+   * wrong here in a specific and useful way: "Review limit reached" is posted by the reviewer,
+   * after the commit, and says a review did *not* happen — counting it would let the one comment
+   * that means "unreviewed" certify a stale review as fresh. Claude's activity is admitted only
+   * on the condition D42 gives it, matching `claudeReviewed` above.
+   */
+  const fullReviewComments = issueComments.filter(
+    (c) => byReviewer(c) && isFullReviewFinished(c.body),
+  );
+  const reviewEvidence = [
+    ...submittedReviews.map((r) => r.submitted_at),
+    ...reviewComments.filter(byReviewer).map((c) => c.created_at),
+    ...issueComments
+      .filter((c) => byReviewer(c) && String(c.body ?? '').includes('Walkthrough'))
+      .map((c) => c.created_at),
+    /*
+     * A full review that found nothing.
+     *
+     * Every other entry here is something a review produced, and a clean review produces none of
+     * them: no walkthrough, no finding, no submitted review — just a note edited into the
+     * acknowledgement saying it finished. #144 sat on that for hours, reviewed and clean and
+     * permanently stale, because the gate had nothing newer than the head to point at.
+     *
+     * Dated by `created_at`, which is when the command was acknowledged and therefore when the
+     * review was scoped, not `updated_at`, which is when it finished. The two differ by minutes,
+     * and a commit pushed inside that window is one the review did not read — with `created_at`
+     * the head is then newer than the evidence and this still refuses, which is the answer that
+     * costs a wait rather than a merge.
+     *
+     * Evidence only: it dates a review, it cannot be one. `reviewed` below is deliberately left
+     * alone, so this can refresh an existing review and never manufacture a first one.
+     */
+    ...fullReviewComments.map((c) => c.created_at),
+    /* Claude's activity is admitted only on the condition D42 gives it, matching
+       `claudeReviewed` above — otherwise the fallback reviewer's every comment could refresh a
+       review it had nothing to do with. Dropping this branch is not harmless in the other
+       direction either: without it a rate-limited PR that Claude *did* review has no evidence
+       to date, so it reads as permanently stale and can never merge. */
+    ...(rateLimited
+      ? [
+          ...reviewComments.filter(byClaude).map((c) => c.created_at),
+          ...issueComments.filter(byClaude).map((c) => c.created_at),
+        ]
+      : []),
+  ].filter((value) => value != null);
+  const lastReviewAt = reviewEvidence.length === 0 ? null : reviewEvidence.sort().at(-1);
+
+  /** Reported separately, because "clean full review" and "no review" look identical otherwise. */
+  const fullReviewAt = fullReviewComments
+    .map((c) => c.created_at)
+    .filter((value) => value != null)
+    .sort()
+    .at(-1);
+
+  const headCommit = headSha === null ? null : await api(`/repos/${repo}/commits/${headSha}`);
+  const headAt = headCommit?.commit?.committer?.date ?? null;
+
+  /*
+   * A rebase is not a change to the code.
+   *
+   * Branch protection requires a branch to be up to date, so every open PR is rebased whenever
+   * `main` moves — and the head commit is then newer than its review while proposing exactly the
+   * same diff. CodeRabbit will not re-review that, correctly, because there is nothing new to
+   * read, so a date comparison alone leaves the PR stuck between a gate wanting a review and a
+   * reviewer with no reason to give one (#140).
+   *
+   * So the date is the cheap check and the diff is the authority: when the newest review sits on
+   * a commit proposing the same effective diff as the head, the review still applies. Any real
+   * edit changes the patches and this stops helping, which is the point.
+   */
+  const reviewedSha = [...submittedReviews]
+    .sort((a, b) => (a.submitted_at < b.submitted_at ? -1 : 1))
+    .at(-1)?.commit_id;
+
+  /**
+   * Whether everything the head proposes was part of what the review read.
+   *
+   * A subset rather than an equality, and the difference is not a convenience. A pull request
+   * whose base absorbed one of its files — `main` merged the same lockfile fix, say — proposes a
+   * strictly smaller change than the one that was reviewed, and dropping a file cannot introduce
+   * code nobody read. Equality refuses that, and CodeRabbit will not clear it either: asked to
+   * look again it answers "No files to review", because there is nothing new to read. The gate
+   * then wants a review that cannot be produced, which is a stuck pull request rather than a
+   * safe one.
+   *
+   * Any file whose patch differs is simply not in the reviewed set, so an edit still fails here.
+   */
+  const sameDiffAsReviewed = async () => {
+    if (reviewedSha === undefined || reviewedSha === headSha) return false;
+    if (headSha === null || baseRef === null) return false;
+    const [reviewedDiff, headDiff] = await Promise.all([
+      effectiveDiff(api, repo, baseRef, reviewedSha, excludedPaths),
+      effectiveDiff(api, repo, baseRef, headSha, excludedPaths),
+    ]);
+    if (reviewedDiff === null || headDiff === null) return false;
+    return coversAllOf(reviewedDiff, headDiff);
+  };
+
+  /*
+   * Fails closed. An absent timestamp is a reason to look rather than to pass, and treating one
+   * as `not stale` would have made every unknown a quiet approval — which is the failure this
+   * whole file exists to answer, reintroduced by its newest check.
+   */
+  const newerThanReview =
+    lastReviewAt == null || headAt === null ? true : Date.parse(headAt) > Date.parse(lastReviewAt);
+  const rebasedOnly = newerThanReview && (await sameDiffAsReviewed());
+  const stale = newerThanReview && !rebasedOnly;
+  const reviewed = walkthrough || findings > 0 || submitted > 0 || claudeReviewed;
+
+  return {
+    title: prData?.title ?? '',
+    headSha,
+    headAt,
+    reviewerState: reviewerStatus?.state ?? 'none',
+    reviewerDescription: reviewerStatus?.description ?? '',
+    walkthrough,
+    findings,
+    submitted,
+    rateLimited,
+    claudeReviewed,
+    claudeFindings,
+    lastReviewAt: lastReviewAt ?? null,
+    fullReviewAt: fullReviewAt ?? null,
+    reviewedSha: reviewedSha ?? null,
+    rebasedOnly,
+    stale,
+    reviewed,
+    ok: reviewed && !stale,
+  };
+};

--- a/tools/review/reviewGate.mjs
+++ b/tools/review/reviewGate.mjs
@@ -211,9 +211,27 @@ export const evaluate = async ({ api, apiAll, repo, pr, excludedPaths = [] }) =>
    * a commit proposing the same effective diff as the head, the review still applies. Any real
    * edit changes the patches and this stops helping, which is the point.
    */
-  const reviewedSha = [...submittedReviews]
-    .sort((a, b) => (a.submitted_at < b.submitted_at ? -1 : 1))
-    .at(-1)?.commit_id;
+  /*
+   * Which commit the newest review sat on.
+   *
+   * Claude's review comments count here on the same condition they count as evidence, and for a
+   * reason that only shows up after a rebase: on a rate-limited pull request there is no
+   * CodeRabbit review to take a sha from, so this stayed undefined, `sameDiffAsReviewed` could
+   * never answer, and the PR went permanently stale the first time `main` moved. D42 gives the
+   * fallback no re-review trigger either, so nothing would have rescued it.
+   *
+   * Review comments only, never issue comments: a review comment is bound to a commit and an
+   * issue comment is not, and a sha invented for an unbound comment would be a guess about
+   * which code was read.
+   */
+  const shaCandidates = [
+    ...submittedReviews.map((r) => ({ at: r.submitted_at, sha: r.commit_id })),
+    ...(rateLimited
+      ? reviewComments.filter(byClaude).map((c) => ({ at: c.created_at, sha: c.commit_id }))
+      : []),
+  ].filter((candidate) => candidate.at != null && candidate.sha != null);
+
+  const reviewedSha = shaCandidates.sort((a, b) => (a.at < b.at ? -1 : 1)).at(-1)?.sha;
 
   /**
    * Whether everything the head proposes was part of what the review read.

--- a/tools/review/reviewGate.test.ts
+++ b/tools/review/reviewGate.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, it } from '@jest/globals';
+import { evaluate } from './reviewGate.mjs';
+
+/**
+ * The rules that decide whether a merge is allowed, exercised against canned GitHub responses.
+ *
+ * Every one of these was added because a defect got past it, and until now each fix was verified
+ * by running the real gate against a real pull request and reading the output — which proves the
+ * answer for one PR on one day and nothing about the next. The cases below are the situations
+ * that produced those defects, written down.
+ *
+ * They lean one way on purpose. A gate that refuses when it should pass costs a wait; a gate
+ * that passes when it should refuse is a commit nobody read, on `main`. So the uncertain cases —
+ * a missing timestamp, a truncated comparison, a commit that cannot be fetched — all assert
+ * refusal.
+ */
+
+const REPO = 'dharlabs/occasio';
+const PR = '1';
+const BOT = 'coderabbitai[bot]';
+
+const HEAD = 'head000';
+const REVIEWED = 'revd000';
+
+const AT_REVIEW = '2026-09-06T10:00:00Z';
+const AT_HEAD_BEFORE = '2026-09-06T09:00:00Z';
+const AT_HEAD_AFTER = '2026-09-06T11:00:00Z';
+
+/** A file entry as `/compare` reports one. */
+const file = (filename: string, patch = '@@ -1 +1 @@\n-a\n+b') => ({ filename, patch });
+
+/**
+ * Routes are thunks so a test can make one of them throw — a force-pushed commit that has
+ * fallen out of reach is a case the gate has to answer, and it cannot be expressed by a value.
+ *
+ * Object endpoints and list endpoints are kept apart rather than narrowed at the call site: the
+ * two seams `evaluate` takes have different return types, and a single map would need a cast to
+ * satisfy both, which D16 refuses and which would let a mistyped fixture through anyway.
+ */
+type Objects = Record<string, () => unknown>;
+type Lists = Record<string, () => unknown[]>;
+
+type Scenario = {
+  headSha?: string;
+  headAt?: string | null;
+  issueComments?: unknown[];
+  reviewComments?: unknown[];
+  reviews?: unknown[];
+  compare?: Objects;
+  excludedPaths?: string[];
+};
+
+/**
+ * A pull request that has been reviewed, cleanly, with the review newer than the head. Every
+ * test below starts here and breaks exactly one thing, so a failure names its own cause.
+ */
+const run = (scenario: Scenario = {}) => {
+  const headSha = scenario.headSha ?? HEAD;
+  const headAt = scenario.headAt === undefined ? AT_HEAD_BEFORE : scenario.headAt;
+
+  const lists: Lists = {
+    [`/repos/${REPO}/issues/${PR}/comments`]: () =>
+      scenario.issueComments ?? [
+        { user: { login: BOT }, body: '## Walkthrough\n…', created_at: AT_REVIEW },
+      ],
+    [`/repos/${REPO}/pulls/${PR}/comments`]: () => scenario.reviewComments ?? [],
+    [`/repos/${REPO}/pulls/${PR}/reviews`]: () => scenario.reviews ?? [],
+  };
+
+  const objects: Objects = {
+    [`/repos/${REPO}/pulls/${PR}`]: () => ({
+      title: 'a pull request',
+      head: { sha: headSha },
+      base: { ref: 'main' },
+    }),
+    [`/repos/${REPO}/commits/${headSha}/status`]: () => ({
+      statuses: [{ context: 'CodeRabbit', state: 'success', description: 'Review completed' }],
+    }),
+    [`/repos/${REPO}/commits/${headSha}`]: () => ({ commit: { committer: { date: headAt } } }),
+    ...(scenario.compare ?? {}),
+  };
+
+  /* An unrouted path is a broken fixture, not an empty answer. Returning undefined here would
+     quietly exercise the gate's fail-closed paths and pass for the wrong reason. */
+  const pick = <T>(table: Record<string, () => T>, path: string): T => {
+    const route = table[path];
+    if (route === undefined) throw new Error(`unrouted: ${path}`);
+    return route();
+  };
+
+  return evaluate({
+    api: (path) => Promise.resolve(pick(objects, path)),
+    apiAll: (path) => Promise.resolve(pick(lists, path)),
+    repo: REPO,
+    pr: PR,
+    excludedPaths: scenario.excludedPaths ?? ['package-lock.json', '**/__screenshots__/**'],
+  });
+};
+
+describe('the review gate', () => {
+  it('passes a reviewed pull request whose head predates the review', async () => {
+    /* The baseline every other case departs from. If this ever fails, nothing below means
+       what it says. */
+    expect(await run()).toMatchObject({ reviewed: true, stale: false, ok: true });
+  });
+
+  it('refuses a pull request with no evidence of any review', async () => {
+    const v = await run({ issueComments: [] });
+    expect(v).toMatchObject({ reviewed: false, ok: false });
+  });
+
+  it('refuses when the head is newer than the review', async () => {
+    /*
+     * The #134 case: a 374-line commit changing who may read invitation contact details, pushed
+     * eight minutes after the review it appeared to have. Every other signal stayed true.
+     */
+    const v = await run({ headAt: AT_HEAD_AFTER });
+    expect(v).toMatchObject({ reviewed: true, stale: true, ok: false });
+  });
+
+  describe('what may date a review', () => {
+    it('does not let "Review limit reached" refresh a stale review', async () => {
+      /*
+       * That comment is posted by the reviewer, after the commit, and says a review did *not*
+       * happen. Counting it as evidence would let the one comment meaning "unreviewed" certify
+       * a stale review as fresh — the exact inversion this gate exists to prevent.
+       */
+      const v = await run({
+        headAt: AT_HEAD_AFTER,
+        issueComments: [
+          { user: { login: BOT }, body: '## Walkthrough\n…', created_at: AT_REVIEW },
+          {
+            user: { login: BOT },
+            body: 'Review limit reached',
+            created_at: '2026-09-06T12:00:00Z',
+          },
+        ],
+      });
+      expect(v).toMatchObject({ rateLimited: true, stale: true, ok: false });
+      expect(v.lastReviewAt).toBe(AT_REVIEW);
+    });
+
+    it('accepts a full review that finished after the head commit', async () => {
+      /* A clean full review produces no walkthrough, no finding and no review record — only a
+         note edited into its own acknowledgement. #144 was stuck on exactly that. */
+      const v = await run({
+        headAt: AT_HEAD_AFTER,
+        issueComments: [
+          { user: { login: BOT }, body: '## Walkthrough\n…', created_at: AT_REVIEW },
+          {
+            user: { login: BOT },
+            body: 'A full review will evaluate the current head.\n\nFull review finished.',
+            created_at: '2026-09-06T12:00:00Z',
+          },
+        ],
+      });
+      expect(v).toMatchObject({ stale: false, ok: true });
+      expect(v.fullReviewAt).toBe('2026-09-06T12:00:00Z');
+    });
+
+    it('does not count a review that has not been submitted', async () => {
+      /* A PENDING review has no `submitted_at`. Counting it reports "reviewed" before the
+         review exists. */
+      const v = await run({
+        issueComments: [],
+        reviews: [{ user: { login: BOT }, submitted_at: null, commit_id: HEAD }],
+      });
+      expect(v).toMatchObject({ submitted: 0, reviewed: false, ok: false });
+    });
+  });
+
+  describe('Claude as the fallback reviewer (D42)', () => {
+    it('counts Claude only when CodeRabbit was actually rate limited', async () => {
+      const withoutLimit = await run({
+        issueComments: [{ user: { login: 'claude[bot]' }, body: 'review', created_at: AT_REVIEW }],
+      });
+      /* Without the conjunct, any comment the app ever posts — a reply in a thread, an answer to
+         a question — satisfied the gate, so the fallback reviewer doubled as a way to skip
+         review entirely. */
+      expect(withoutLimit).toMatchObject({ claudeReviewed: false, reviewed: false, ok: false });
+
+      const withLimit = await run({
+        issueComments: [
+          { user: { login: BOT }, body: 'Review limit reached', created_at: AT_HEAD_BEFORE },
+          { user: { login: 'claude[bot]' }, body: 'review', created_at: AT_REVIEW },
+        ],
+      });
+      expect(withLimit).toMatchObject({ claudeReviewed: true, reviewed: true, ok: true });
+    });
+  });
+
+  describe('a rebase is not a change to the code', () => {
+    const compareOf = (sha: string, files: unknown) => ({
+      [`/repos/${REPO}/compare/main...${sha}?per_page=300`]: () => ({ files }),
+    });
+
+    const rebased = (headFiles: unknown, reviewedFiles: unknown, excludedPaths?: string[]) =>
+      run({
+        headAt: AT_HEAD_AFTER,
+        reviews: [{ user: { login: BOT }, submitted_at: AT_REVIEW, commit_id: REVIEWED }],
+        compare: { ...compareOf(HEAD, headFiles), ...compareOf(REVIEWED, reviewedFiles) },
+        ...(excludedPaths === undefined ? {} : { excludedPaths }),
+      });
+
+    it('passes when the head proposes the same diff the review read', async () => {
+      const files = [file('packages/ui/src/a.ts'), file('packages/ui/src/b.ts')];
+      expect(await rebased(files, files)).toMatchObject({ rebasedOnly: true, ok: true });
+    });
+
+    it('passes when the base absorbed one of the files, leaving a smaller change', async () => {
+      /* A subset, not an equality. Dropping a file cannot introduce code nobody read, and
+         CodeRabbit will not clear it either — asked again it answers "No files to review". */
+      const reviewedFiles = [file('packages/ui/src/a.ts'), file('packages/ui/src/b.ts')];
+      expect(await rebased([file('packages/ui/src/a.ts')], reviewedFiles)).toMatchObject({
+        rebasedOnly: true,
+        ok: true,
+      });
+    });
+
+    it('refuses when a line actually changed', async () => {
+      const reviewedFiles = [file('packages/ui/src/a.ts', '@@ -1 +1 @@\n-a\n+b')];
+      const headFiles = [file('packages/ui/src/a.ts', '@@ -1 +1 @@\n-a\n+c')];
+      expect(await rebased(headFiles, reviewedFiles)).toMatchObject({
+        rebasedOnly: false,
+        stale: true,
+        ok: false,
+      });
+    });
+
+    it('refuses a comparison the API truncated, even when the excess is all excluded', async () => {
+      /*
+       * The #147 finding. Filtering before the cap check lets excluded entries hide the
+       * truncation: 300 files of which 40 are lockfile-and-screenshot noise leaves 260, under
+       * the cap, and the check passes on a comparison that was cut short — with the unlisted
+       * change being the one nobody reviewed.
+       */
+      const bulk = Array.from({ length: 260 }, (_, i) => file(`packages/ui/src/f${String(i)}.ts`));
+      const noise = Array.from({ length: 40 }, (_, i) =>
+        file(`packages/ui/src/__screenshots__/s${String(i)}.png`),
+      );
+      const truncated = [...bulk, ...noise];
+      expect(truncated).toHaveLength(300);
+
+      const v = await rebased(truncated, truncated);
+      expect(v).toMatchObject({ rebasedOnly: false, stale: true, ok: false });
+    });
+
+    it('refuses a comparison with no file list at all', async () => {
+      /* An absent list fingerprints as the empty string, and so does another absent list —
+         two unknowns matching each other and reading as "already reviewed". */
+      expect(await rebased(undefined, undefined)).toMatchObject({ rebasedOnly: false, ok: false });
+    });
+
+    it('refuses a file it cannot describe', async () => {
+      /* Neither a patch nor a blob sha: both sides would serialise as `binary:unknown`, which
+         is one unknown matching another. */
+      const opaque = [{ filename: 'assets/logo.png' }];
+      expect(await rebased(opaque, opaque)).toMatchObject({ rebasedOnly: false, ok: false });
+    });
+
+    it('refuses when the reviewed commit can no longer be fetched', async () => {
+      /* A force push can put it out of reach. Unknown is not "unchanged". */
+      const files = [file('packages/ui/src/a.ts')];
+      const v = await run({
+        headAt: AT_HEAD_AFTER,
+        reviews: [{ user: { login: BOT }, submitted_at: AT_REVIEW, commit_id: REVIEWED }],
+        compare: {
+          [`/repos/${REPO}/compare/main...${HEAD}?per_page=300`]: () => ({ files }),
+          [`/repos/${REPO}/compare/main...${REVIEWED}?per_page=300`]: () => {
+            throw new Error('404 Not Found');
+          },
+        },
+      });
+      expect(v).toMatchObject({ rebasedOnly: false, stale: true, ok: false });
+    });
+  });
+
+  it('refuses when the head commit carries no date', async () => {
+    /*
+     * Fails closed. Treating an absent timestamp as "not stale" would make every unknown a
+     * quiet approval — the failure the whole gate exists to answer, reintroduced by its own
+     * freshness check.
+     */
+    const v = await run({ headAt: null });
+    expect(v).toMatchObject({ headAt: null, stale: true, ok: false });
+  });
+});

--- a/tools/review/reviewGate.test.ts
+++ b/tools/review/reviewGate.test.ts
@@ -30,6 +30,16 @@ const AT_HEAD_AFTER = '2026-09-06T11:00:00Z';
 const file = (filename: string, patch = '@@ -1 +1 @@\n-a\n+b') => ({ filename, patch });
 
 /**
+ * The comparison path, in one place.
+ *
+ * Written out twice — once to route the fixture, once to assert the gate asked for it — it
+ * would drift the moment `effectiveDiff` changed its query string, and drift silently: an
+ * unrouted path throws, `effectiveDiff` catches every throw and returns null, and null is
+ * refusal. Every refusal case below would keep passing while reaching nothing.
+ */
+const comparePath = (sha: string) => `/repos/${REPO}/compare/main...${sha}?per_page=300`;
+
+/**
  * Routes are thunks so a test can make one of them throw — a force-pushed commit that has
  * fallen out of reach is a case the gate has to answer, and it cannot be expressed by a value.
  *
@@ -54,7 +64,7 @@ type Scenario = {
  * A pull request that has been reviewed, cleanly, with the review newer than the head. Every
  * test below starts here and breaks exactly one thing, so a failure names its own cause.
  */
-const run = (scenario: Scenario = {}) => {
+const run = async (scenario: Scenario = {}) => {
   const headSha = scenario.headSha ?? HEAD;
   const headAt = scenario.headAt === undefined ? AT_HEAD_BEFORE : scenario.headAt;
 
@@ -80,32 +90,53 @@ const run = (scenario: Scenario = {}) => {
     ...(scenario.compare ?? {}),
   };
 
-  /* An unrouted path is a broken fixture, not an empty answer. Returning undefined here would
-     quietly exercise the gate's fail-closed paths and pass for the wrong reason. */
+  const asked: string[] = [];
+  const unrouted: string[] = [];
+
+  /*
+   * An unrouted path is a broken fixture, not an empty answer — and it cannot be left to throw
+   * and be noticed, because `effectiveDiff` catches every throw and returns null, and null is
+   * refusal. A misrouted comparison would therefore produce exactly the answer the refusal
+   * tests assert, and they would pass having reached nothing. So the throw is recorded, and
+   * `gate` below refuses to hand back a verdict that was reached over a missing route.
+   */
   const pick = <T>(table: Record<string, () => T>, path: string): T => {
+    asked.push(path);
     const route = table[path];
-    if (route === undefined) throw new Error(`unrouted: ${path}`);
+    if (route === undefined) {
+      unrouted.push(path);
+      throw new Error(`unrouted: ${path}`);
+    }
     return route();
   };
 
-  return evaluate({
+  const verdict = await evaluate({
     api: (path) => Promise.resolve(pick(objects, path)),
     apiAll: (path) => Promise.resolve(pick(lists, path)),
     repo: REPO,
     pr: PR,
     excludedPaths: scenario.excludedPaths ?? ['package-lock.json', '**/__screenshots__/**'],
   });
+
+  return { verdict, asked, unrouted };
+};
+
+/** The verdict, with a broken fixture failing loudly instead of passing as a refusal. */
+const gate = async (scenario: Scenario = {}) => {
+  const { verdict, unrouted } = await run(scenario);
+  expect(unrouted).toEqual([]);
+  return verdict;
 };
 
 describe('the review gate', () => {
   it('passes a reviewed pull request whose head predates the review', async () => {
     /* The baseline every other case departs from. If this ever fails, nothing below means
        what it says. */
-    expect(await run()).toMatchObject({ reviewed: true, stale: false, ok: true });
+    expect(await gate()).toMatchObject({ reviewed: true, stale: false, ok: true });
   });
 
   it('refuses a pull request with no evidence of any review', async () => {
-    const v = await run({ issueComments: [] });
+    const v = await gate({ issueComments: [] });
     expect(v).toMatchObject({ reviewed: false, ok: false });
   });
 
@@ -114,7 +145,7 @@ describe('the review gate', () => {
      * The #134 case: a 374-line commit changing who may read invitation contact details, pushed
      * eight minutes after the review it appeared to have. Every other signal stayed true.
      */
-    const v = await run({ headAt: AT_HEAD_AFTER });
+    const v = await gate({ headAt: AT_HEAD_AFTER });
     expect(v).toMatchObject({ reviewed: true, stale: true, ok: false });
   });
 
@@ -125,7 +156,7 @@ describe('the review gate', () => {
        * happen. Counting it as evidence would let the one comment meaning "unreviewed" certify
        * a stale review as fresh — the exact inversion this gate exists to prevent.
        */
-      const v = await run({
+      const v = await gate({
         headAt: AT_HEAD_AFTER,
         issueComments: [
           { user: { login: BOT }, body: '## Walkthrough\n…', created_at: AT_REVIEW },
@@ -143,7 +174,7 @@ describe('the review gate', () => {
     it('accepts a full review that finished after the head commit', async () => {
       /* A clean full review produces no walkthrough, no finding and no review record — only a
          note edited into its own acknowledgement. #144 was stuck on exactly that. */
-      const v = await run({
+      const v = await gate({
         headAt: AT_HEAD_AFTER,
         issueComments: [
           { user: { login: BOT }, body: '## Walkthrough\n…', created_at: AT_REVIEW },
@@ -161,7 +192,7 @@ describe('the review gate', () => {
     it('does not count a review that has not been submitted', async () => {
       /* A PENDING review has no `submitted_at`. Counting it reports "reviewed" before the
          review exists. */
-      const v = await run({
+      const v = await gate({
         issueComments: [],
         reviews: [{ user: { login: BOT }, submitted_at: null, commit_id: HEAD }],
       });
@@ -169,9 +200,26 @@ describe('the review gate', () => {
     });
   });
 
+  it('does not accept a login that merely contains a reviewer name', async () => {
+    /*
+     * Exact logins, not a substring match. Anyone can register `coderabbitai` or
+     * `my-coderabbitai[bot]`, post a comment containing the word "Walkthrough", and — under a
+     * substring rule — make this gate report a PR as reviewed. That is an authorization bypass
+     * in the one check that exists to be trusted, and nothing else here would notice: replace
+     * `Set.has` with `String.includes` and every other case in this file still passes.
+     */
+    for (const login of ['coderabbitai', 'my-coderabbitai[bot]', 'coderabbitai[bot]-x']) {
+      const v = await gate({
+        issueComments: [{ user: { login }, body: '## Walkthrough\n…', created_at: AT_REVIEW }],
+      });
+      expect([login, v.reviewed]).toEqual([login, false]);
+      expect([login, v.lastReviewAt]).toEqual([login, null]);
+    }
+  });
+
   describe('Claude as the fallback reviewer (D42)', () => {
     it('counts Claude only when CodeRabbit was actually rate limited', async () => {
-      const withoutLimit = await run({
+      const withoutLimit = await gate({
         issueComments: [{ user: { login: 'claude[bot]' }, body: 'review', created_at: AT_REVIEW }],
       });
       /* Without the conjunct, any comment the app ever posts — a reply in a thread, an answer to
@@ -179,7 +227,7 @@ describe('the review gate', () => {
          review entirely. */
       expect(withoutLimit).toMatchObject({ claudeReviewed: false, reviewed: false, ok: false });
 
-      const withLimit = await run({
+      const withLimit = await gate({
         issueComments: [
           { user: { login: BOT }, body: 'Review limit reached', created_at: AT_HEAD_BEFORE },
           { user: { login: 'claude[bot]' }, body: 'review', created_at: AT_REVIEW },
@@ -190,17 +238,33 @@ describe('the review gate', () => {
   });
 
   describe('a rebase is not a change to the code', () => {
-    const compareOf = (sha: string, files: unknown) => ({
-      [`/repos/${REPO}/compare/main...${sha}?per_page=300`]: () => ({ files }),
-    });
+    const CLAUDE = 'claude[bot]';
 
-    const rebased = (headFiles: unknown, reviewedFiles: unknown, excludedPaths?: string[]) =>
-      run({
+    const compareOf = (sha: string, files: unknown) => ({ [comparePath(sha)]: () => ({ files }) });
+
+    /**
+     * The verdict, plus proof that both comparisons were actually fetched.
+     *
+     * Without the second half every refusal case below would pass on a typo: `effectiveDiff`
+     * turns any throw into `null`, `null` is refusal, and refusal is what they assert. So the
+     * helper checks the gate asked for both compare paths and that nothing went unrouted —
+     * the assertions then only hold when the code under test ran.
+     */
+    const rebased = async (
+      headFiles: unknown,
+      reviewedFiles: unknown,
+      excludedPaths?: string[],
+    ) => {
+      const { verdict, asked, unrouted } = await run({
         headAt: AT_HEAD_AFTER,
         reviews: [{ user: { login: BOT }, submitted_at: AT_REVIEW, commit_id: REVIEWED }],
         compare: { ...compareOf(HEAD, headFiles), ...compareOf(REVIEWED, reviewedFiles) },
         ...(excludedPaths === undefined ? {} : { excludedPaths }),
       });
+      expect(unrouted).toEqual([]);
+      expect(asked).toEqual(expect.arrayContaining([comparePath(HEAD), comparePath(REVIEWED)]));
+      return verdict;
+    };
 
     it('passes when the head proposes the same diff the review read', async () => {
       const files = [file('packages/ui/src/a.ts'), file('packages/ui/src/b.ts')];
@@ -258,20 +322,54 @@ describe('the review gate', () => {
       expect(await rebased(opaque, opaque)).toMatchObject({ rebasedOnly: false, ok: false });
     });
 
+    it("anchors on Claude's review comment when CodeRabbit never reviewed", async () => {
+      /*
+       * A rate-limited pull request has no CodeRabbit review to take a sha from, so before this
+       * `reviewedSha` was undefined, `sameDiffAsReviewed` could not answer, and the PR went
+       * permanently stale the first time `main` moved — with D42 giving the fallback no
+       * re-review trigger to rescue it.
+       *
+       * Review comments only. An issue comment carries no `commit_id`, so it cannot say which
+       * code was read, and a sha invented for one would be a guess.
+       */
+      const files = [file('packages/ui/src/a.ts')];
+      const { verdict, unrouted } = await run({
+        headAt: AT_HEAD_AFTER,
+        issueComments: [
+          { user: { login: BOT }, body: 'Review limit reached', created_at: AT_HEAD_BEFORE },
+        ],
+        reviewComments: [
+          {
+            user: { login: CLAUDE },
+            created_at: AT_REVIEW,
+            commit_id: REVIEWED,
+            body: 'a finding',
+          },
+        ],
+        compare: { ...compareOf(HEAD, files), ...compareOf(REVIEWED, files) },
+      });
+      expect(unrouted).toEqual([]);
+      expect(verdict).toMatchObject({ claudeReviewed: true, rebasedOnly: true, ok: true });
+    });
+
     it('refuses when the reviewed commit can no longer be fetched', async () => {
       /* A force push can put it out of reach. Unknown is not "unchanged". */
       const files = [file('packages/ui/src/a.ts')];
-      const v = await run({
+      const { verdict, asked, unrouted } = await run({
         headAt: AT_HEAD_AFTER,
         reviews: [{ user: { login: BOT }, submitted_at: AT_REVIEW, commit_id: REVIEWED }],
         compare: {
-          [`/repos/${REPO}/compare/main...${HEAD}?per_page=300`]: () => ({ files }),
-          [`/repos/${REPO}/compare/main...${REVIEWED}?per_page=300`]: () => {
+          [comparePath(HEAD)]: () => ({ files }),
+          [comparePath(REVIEWED)]: () => {
             throw new Error('404 Not Found');
           },
         },
       });
-      expect(v).toMatchObject({ rebasedOnly: false, stale: true, ok: false });
+      /* The throw has to come from the route, not from a path nobody wired up — those are
+         indistinguishable to `effectiveDiff` and only one of them is the case under test. */
+      expect(unrouted).toEqual([]);
+      expect(asked).toContain(comparePath(REVIEWED));
+      expect(verdict).toMatchObject({ rebasedOnly: false, stale: true, ok: false });
     });
   });
 
@@ -281,7 +379,7 @@ describe('the review gate', () => {
      * quiet approval — the failure the whole gate exists to answer, reintroduced by its own
      * freshness check.
      */
-    const v = await run({ headAt: null });
+    const v = await gate({ headAt: null });
     expect(v).toMatchObject({ headAt: null, stale: true, ok: false });
   });
 });


### PR DESCRIPTION
Closes #148.

Everything testable in the gate had already been pulled into pure modules — `diffFingerprint.mjs`, `reviewablePaths.mjs`, `reviewMarkers.mjs`. What was left in `check-reviewed.mjs` was the part that talks to GitHub, and it had no tests, while carrying:

- the 300-file truncation check and its ordering against the path filter
- `sameDiffAsReviewed`, which decides whether an existing review still applies
- which evidence may date a review, and the `rateLimited` conjunct on Claude's
- four fail-closed branches

Every one exists because a defect got past it, and each fix was verified by running the real gate against a real PR and reading the output. That proves the answer for one PR on one day.

## Shape

The decision moves to `reviewGate.mjs`, which takes its data through one injected `api` seam and returns a verdict as data. `check-reviewed.mjs` keeps what is genuinely a command line: token discovery, printing, exit codes. The logic was moved rather than rewritten — diff it against the previous file and the rules should read identically.

Fifteen cases, all leaning one way. A gate that refuses when it should pass costs a wait; a gate that passes when it should refuse is a commit nobody read, on `main`. So every uncertain case asserts refusal: a comparison the API truncated (with the excess entirely under excluded paths — the #147 finding), a comparison with no file list, a file with neither patch nor blob sha, a reviewed commit that can no longer be fetched, a head commit with no date.

## The harness found a bug in its own refactor

Moving the code, I dropped the branch admitting Claude's timestamps as review evidence when CodeRabbit was rate-limited.

Nothing failed. `npm run verify` was green, and the gate gave the right answer on all four PRs I ran it against — because none of them was rate-limited. The consequence would have surfaced only on the day the budget ran out: a PR the fallback reviewer *had* reviewed, reading as permanently stale, at the exact moment there is nothing else to fall back to.

The test that caught it is the one asserting Claude counts when and only when CodeRabbit was rate limited. That is the whole argument for this PR, made by accident.

## Verification

Each guard is mutation-verified — removing the cap check, moving it after the path filter, dropping the `rateLimited` conjunct, treating a missing timestamp as fresh, or admitting any reviewer comment as evidence each fails a test.

Also run live against #156 before and after the refactor, producing byte-identical output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145VPJXGgJA9PWqeNXDr1DG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a centralised review gate that assesses pull-request review status, reviewer activity, walkthroughs, findings, rebases and commit freshness.
  - Review decisions now include clear evidence, diff applicability and merge eligibility.
  - Added support for excluded paths and fallback review activity.

- **Bug Fixes**
  - Uncertain conditions, unavailable commits and incomplete comparisons now fail safely rather than allowing approval.

- **Tests**
  - Expanded coverage for missing, pending, stale and rate-limited review scenarios, including changed or truncated comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->