### PR TITLE
test(data): close the two holes in the repository contract suite

### DIFF
--- a/packages/data/src/repositories.test.ts
+++ b/packages/data/src/repositories.test.ts
@@ -32,9 +32,12 @@ type Alias = {
   readonly fields: readonly string[];
 };
 
+const parseSource = (name: string, text: string): ts.SourceFile =>
+  ts.createSourceFile(name, text, ts.ScriptTarget.Latest, true);
+
 const parse = (file: string): ts.SourceFile => {
   const path = join(__dirname, file);
-  return ts.createSourceFile(path, readFileSync(path, 'utf8'), ts.ScriptTarget.Latest, true);
+  return parseSource(path, readFileSync(path, 'utf8'));
 };
 
 const normalise = (node: ts.Node): string => node.getText().replace(/\s+/g, ' ').trim();
@@ -47,18 +50,44 @@ const objectAliases = (source: ts.SourceFile): readonly Alias[] =>
     const methods: Method[] = [];
     const fields: string[] = [];
 
+    const parametersOf = (declared: ts.NodeArray<ts.ParameterDeclaration>): readonly Parameter[] =>
+      declared.map((parameter) => ({
+        name: ts.isIdentifier(parameter.name) ? parameter.name.text : '<destructured>',
+        type: parameter.type === undefined ? '<untyped>' : normalise(parameter.type),
+        optional: parameter.questionToken !== undefined,
+      }));
+
     for (const member of statement.type.members) {
+      /*
+       * Both ways of writing a method, because TypeScript has two and this file only knew one.
+       *
+       *     list: (tenantId: TenantId) => Promise<Page<Session>>   // PropertySignature
+       *     list(tenantId: TenantId): Promise<Page<Session>>       // MethodSignature
+       *
+       * They mean the same thing to `tsc` and meant nothing at all here: a shorthand member is
+       * neither a property nor a field, so it fell out of the loop entirely and every rule
+       * below — tenant-first, async, no bare arrays, PageRequest last — silently skipped it.
+       * A contract test with a syntax it cannot see is one anybody can step around without
+       * ever meaning to, and `repositories.ts` happens to use the other form throughout, which
+       * is why nothing was wrong yet and why nothing would have said so.
+       */
+      if (ts.isMethodSignature(member) && ts.isIdentifier(member.name)) {
+        methods.push({
+          owner,
+          name: member.name.text,
+          parameters: parametersOf(member.parameters),
+          returns: member.type === undefined ? '<untyped>' : normalise(member.type),
+        });
+        continue;
+      }
+
       if (!ts.isPropertySignature(member) || !ts.isIdentifier(member.name)) continue;
       const type = member.type;
       if (type !== undefined && ts.isFunctionTypeNode(type)) {
         methods.push({
           owner,
           name: member.name.text,
-          parameters: type.parameters.map((parameter) => ({
-            name: ts.isIdentifier(parameter.name) ? parameter.name.text : '<destructured>',
-            type: parameter.type === undefined ? '<untyped>' : normalise(parameter.type),
-            optional: parameter.questionToken !== undefined,
-          })),
+          parameters: parametersOf(type.parameters),
           returns: normalise(type.type),
         });
       } else {
@@ -88,6 +117,44 @@ const repositories = aliases.filter((alias) => alias.name.endsWith('Repository')
 const repositoryNames = repositories.map((repository) => repository.name);
 
 /**
+ * The inventory, written down rather than counted.
+ *
+ * Every size assertion here used to be a floor — *at least* 16 repositories, 30 methods, 10
+ * paged ones — and the adapter and barrel requirements were derived from the same parsed source
+ * they were checking. So deleting a repository along with its adapter entry and its export left
+ * the whole suite green: the floor still held, and "every repository is in the adapter" is
+ * trivially true of a repository that no longer exists. A suite that measures its subject
+ * against itself agrees with it by construction.
+ *
+ * Pinned literally, so removing one is a decision somebody makes here in writing. Adding one
+ * costs a line in this list, which is the intended price.
+ */
+const EXPECTED_REPOSITORIES = [
+  'TenantRepository',
+  'UserRepository',
+  'MembershipRepository',
+  'ApprovalRequestRepository',
+  'VenueRepository',
+  'SessionRepository',
+  'PersonRepository',
+  'MediaRepository',
+  'PersonaRepository',
+  'GossipRepository',
+  'TaskRepository',
+  'UnitRepository',
+  'AssignmentRepository',
+  'AnnouncementRepository',
+  'RsvpRepository',
+  'NotificationPreferenceRepository',
+] as const;
+
+/** Repository methods, excluding `TenantDirectory`'s two. */
+const EXPECTED_REPOSITORY_METHODS = 50;
+
+/** Methods returning a `Page`, across repositories and the directory alike. */
+const EXPECTED_PAGED_METHODS = 15;
+
+/**
  * `TenantDirectory` is the documented exception: its two methods are how a caller obtains a
  * `TenantId` in the first place, so they cannot be given one. It is held apart from the
  * tenant-first rule here and pinned by size below, so a third cross-tenant method has to be a
@@ -104,10 +171,13 @@ const everyMethod = [...repositoryMethods, ...(directory?.methods ?? [])];
 const label = (method: Method): string => `${method.owner}.${method.name}`;
 
 describe('the repository surface', () => {
-  it('found the repositories at all (this suite is worth nothing if it found none)', () => {
-    expect(repositories.length).toBeGreaterThanOrEqual(12);
-    expect(repositoryNames).toContain('GossipRepository');
-    expect(repositoryMethods.length).toBeGreaterThanOrEqual(30);
+  it('is exactly the set of repositories this package is documented to have', () => {
+    /* Equality, not a floor: a floor cannot tell a deletion from a suite that never looked. */
+    expect([...repositoryNames].sort()).toEqual([...EXPECTED_REPOSITORIES].sort());
+  });
+
+  it('has exactly the number of methods it had when this was written', () => {
+    expect(repositoryMethods.length).toBe(EXPECTED_REPOSITORY_METHODS);
   });
 
   it('declares only methods on a repository, never a data field', () => {
@@ -115,6 +185,51 @@ describe('the repository surface', () => {
       repository.fields.map((field) => `${repository.name}.${field}`),
     );
     expect(offenders).toEqual([]);
+  });
+});
+
+describe('the parser sees both ways of writing a method', () => {
+  /**
+   * The rules below are only as wide as what the parser reads, and it read one of TypeScript's
+   * two spellings. `repositories.ts` happens to use the other form throughout — so nothing was
+   * wrong, nothing would have said so, and the first person to write the shorthand would have
+   * got a method exempt from every check in this file.
+   *
+   * Parsed from a literal rather than from the real file, because the case worth proving is the
+   * one the real file does not contain.
+   */
+  const fixture = `
+    export type ExampleRepository = {
+      readonly asProperty: (tenantId: TenantId, page?: PageRequest) => Promise<Page<Thing>>;
+      asMethod(tenantId: TenantId, page?: PageRequest): Promise<Page<Thing>>;
+      readonly notAMethod: string;
+    };
+  `;
+
+  const parsed = objectAliases(parseSource('fixture.ts', fixture))[0];
+
+  it('records a method-shorthand member as a method', () => {
+    expect(parsed?.methods.map((method) => method.name).sort()).toEqual(['asMethod', 'asProperty']);
+  });
+
+  it('does not quietly drop it into fields, or out of the file altogether', () => {
+    /* Before this, `asMethod` appeared in neither list — invisible rather than misfiled, which
+       is why no assertion anywhere failed. */
+    expect(parsed?.fields).toEqual(['notAMethod']);
+  });
+
+  it('reads the same parameters and return type from both spellings', () => {
+    const asProperty = parsed?.methods.find((method) => method.name === 'asProperty');
+    const asMethod = parsed?.methods.find((method) => method.name === 'asMethod');
+
+    expect(asMethod?.parameters).toEqual(asProperty?.parameters);
+    expect(asMethod?.returns).toEqual(asProperty?.returns);
+    /* Spelled out, so this cannot pass by both being empty. */
+    expect(asMethod?.parameters).toEqual([
+      { name: 'tenantId', type: 'TenantId', optional: false },
+      { name: 'page', type: 'PageRequest', optional: true },
+    ]);
+    expect(asMethod?.returns).toBe('Promise<Page<Thing>>');
   });
 });
 
@@ -164,7 +279,9 @@ describe('DataAdapter', () => {
    * past the check above. The adapter is the whole surface, so pinning it pins the rule.
    */
   it('exposes every repository and the directory, and nothing else', () => {
-    const expected = [...repositoryNames, 'TenantDirectory'].sort();
+    /* Against the written inventory rather than against the parsed source. Derived from
+       `repositoryNames`, this passed for a repository that had been deleted from both. */
+    const expected = [...EXPECTED_REPOSITORIES, 'TenantDirectory'].sort();
     expect([...dataAdapterMemberTypes()].sort()).toEqual(expected);
   });
 });
@@ -189,7 +306,7 @@ describe('collections are pages, not arrays', () => {
 
   it('takes an optional PageRequest as the last argument wherever it returns a Page', () => {
     const paged = everyMethod.filter((method) => method.returns.startsWith('Promise<Page<'));
-    expect(paged.length).toBeGreaterThanOrEqual(10);
+    expect(paged.length).toBe(EXPECTED_PAGED_METHODS);
 
     const offenders = paged
       .filter((method) => {
@@ -237,15 +354,22 @@ describe('the package barrel', () => {
    * nothing else complains about — the deep import still resolves.
    */
   it('re-exports every repository, the adapter and the pagination types', () => {
+    /* The required names are listed here, not read back out of the source being checked. */
     const exported = new Set(reExportedNames(indexSource));
     const required = [
-      ...repositoryNames,
+      ...EXPECTED_REPOSITORIES,
       'DataAdapter',
       'TenantDirectory',
       'Unsubscribe',
       'Page',
       'PageRequest',
       'Cursor',
+      /* The realtime and pagination surface a consumer cannot reach any other way. Omitted
+         before, so the barrel could drop them and this suite would have agreed. */
+      'Change',
+      'GossipChange',
+      'DEFAULT_PAGE_SIZE',
+      'MAX_PAGE_SIZE',
     ];
     expect(required.filter((name) => !exported.has(name))).toEqual([]);
   });


### PR DESCRIPTION
#138 items 2 and 3, from the retrospective review of the three PRs that reached `main` unreviewed.

## A syntax the suite could not see

TypeScript has two spellings for a method in a type literal:

```ts
list: (tenantId: TenantId) => Promise<Page<Session>>   // PropertySignature
list(tenantId: TenantId): Promise<Page<Session>>       // MethodSignature
```

The parser handled the first. A shorthand member is neither a property signature nor a field, so it fell out of the loop entirely — not misfiled, **invisible** — and every rule in the file skipped it: tenant-first, async, no bare arrays, `PageRequest` last.

`repositories.ts` uses the other form throughout, so nothing was wrong and nothing would have said so. The first person to write the shorthand would simply have had a method exempt from the contract, with no failure anywhere to tell them.

Proved from a literal rather than from the real file, because the case worth proving is the one the real file does not contain. Both spellings of the same method must now parse to identical parameters and return type — spelled out, so it cannot pass by both being empty.

## A suite that measured its subject against itself

The sizes were floors — *at least* 12 repositories, 30 methods, 10 paged — and the `DataAdapter` and barrel requirements were **derived from the same parsed source they were checking**.

So deleting a repository along with its adapter entry and its export left everything green: the floor still held, and "every repository appears in the adapter" is trivially true of a repository that no longer exists.

The inventory is now written down — 16 repositories by name, 50 methods, 15 paged — and the adapter and barrel are checked against that list rather than against the source. Adding a repository costs a line here, which is the intended price.

The barrel list also gains `Change`, `GossipChange`, `DEFAULT_PAGE_SIZE` and `MAX_PAGE_SIZE` — reachable no other way by a consumer, and previously absent, so the barrel could have dropped them and this suite would have agreed.

## Verification

Mutation-verified:

| mutation | result |
|---|---|
| blind the parser to method shorthand | 2 tests fail |
| delete `RsvpRepository` with its adapter entry and export | 5 tests fail |

On `main`, that second mutation passes.

## Not in scope

Item 1 of #138 concerns `claude-fallback-review.yml`, which is parked pending #142.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145VPJXGgJA9PWqeNXDr1DG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded repository contract test coverage to validate both method signatures and function-valued properties.
  - Added checks for parameter and return-value extraction across supported declaration styles.
  - Strengthened assertions for repository inventories, pagination behaviour, adapter members, exports, realtime change types, and page-size constants.
  - Added fixtures covering equivalent declaration formats and their parsed results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->