### PR TITLE
fix(ui): four boundary leaks from the retrospective review

### DIFF
--- a/packages/ui/src/feedback/EmptyState.tsx
+++ b/packages/ui/src/feedback/EmptyState.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode } from 'react';
-import { Text, View, type StyleProp, type ViewStyle } from 'react-native';
+import { Text, View, type StyleProp } from 'react-native';
+import type { LayoutViewStyle } from '../components/layoutStyle';
 import { createStyles } from '../theme/createStyles';
 
 /**
@@ -16,7 +17,7 @@ import { createStyles } from '../theme/createStyles';
  * depending on the button component to render an empty list.
  */
 
-type Props = {
+export type EmptyStateProps = {
   /**
    * Decorative only — it is hidden from screen readers, because the title and message already
    * carry the meaning and a described picture of nothing is noise. Anything load-bearing
@@ -38,7 +39,11 @@ type Props = {
    * second top-level heading on the page and an outline that reads as two documents.
    */
   readonly headingLevel?: 2 | 3 | 4;
-  readonly style?: StyleProp<ViewStyle> | undefined;
+  /* The narrowing from #120: where the empty state sits, not what it looks like. Typed as the
+     full `ViewStyle` this accepted a caller-supplied background, padding or radius — the D17
+     boundary standing open at one component, and the harder half to see, since a token
+     smuggled through a variable is not a literal for the lint rule to catch. */
+  readonly style?: StyleProp<LayoutViewStyle> | undefined;
 };
 
 const useStyles = createStyles((t) => ({
@@ -63,7 +68,7 @@ export function EmptyState({
   action,
   headingLevel = 2,
   style,
-}: Props) {
+}: EmptyStateProps) {
   const styles = useStyles();
 
   return (

--- a/packages/ui/src/feedback/typeContracts.assertions.ts
+++ b/packages/ui/src/feedback/typeContracts.assertions.ts
@@ -1,0 +1,46 @@
+import type { EmptyStateProps } from './EmptyState';
+
+/**
+ * Compile-time proof that the feedback components' `style` props are the narrowed ones.
+ *
+ * `LayoutViewStyle` is contract-tested where it is defined, which proves the *type* rejects a
+ * colour. It says nothing about whether a given component uses it — and `EmptyState` did not:
+ * its prop stayed `StyleProp<ViewStyle>` after #120 narrowed the others, leaving the D17
+ * boundary open at exactly one component (#138 item 4).
+ *
+ * That is the harder half of D17 to see. The lint rule catches a literal colour in a stylesheet;
+ * it cannot catch a token handed in through a variable at a call site, which is what a wide
+ * `style` prop allows. Nothing here runs — it is a source file rather than a test because Jest
+ * strips types, and `tsc` is the only assertion available for a type.
+ */
+
+/** `true` when `Value` is NOT assignable to `Shape` — i.e. the prop rejects it. */
+type Rejects<Value, Shape> = [Value] extends [Shape] ? false : true;
+
+/** `true` when `Value` IS assignable — a legitimate call still compiles. */
+type Accepts<Value, Shape> = [Value] extends [Shape] ? true : false;
+
+/** A complete, valid call. The style under test is the only thing that varies below. */
+type EmptyStateCall<Style> = { title: 'No photos yet'; style: Style };
+
+export const FEEDBACK_TYPE_CONTRACTS: {
+  readonly emptyStateRejectsColour: Rejects<
+    EmptyStateCall<{ backgroundColor: 'red' }>,
+    EmptyStateProps
+  >;
+  readonly emptyStateRejectsPadding: Rejects<EmptyStateCall<{ padding: 8 }>, EmptyStateProps>;
+  readonly emptyStateRejectsRadius: Rejects<EmptyStateCall<{ borderRadius: 8 }>, EmptyStateProps>;
+
+  /* …while the layout the prop exists for still goes through. A prop that rejects everything is
+     not a narrowed prop, it is a broken one — and with `title` required, a contract built from
+     `style` alone would have "rejected" every one of these for the wrong reason. */
+  readonly emptyStateAcceptsLayout: Accepts<
+    EmptyStateCall<{ maxWidth: 480; alignSelf: 'center' }>,
+    EmptyStateProps
+  >;
+} = {
+  emptyStateRejectsColour: true,
+  emptyStateRejectsPadding: true,
+  emptyStateRejectsRadius: true,
+  emptyStateAcceptsLayout: true,
+};

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -6,9 +6,15 @@ export { toCssVars } from './theme/cssVars';
 export { toElevationStyle } from './theme/elevation';
 export { createStyleCache, DEFAULT_MAX_THEMES, type StyleCache } from './theme/styleCache';
 
-export { EmptyState } from './feedback/EmptyState';
+export { EmptyState, type EmptyStateProps } from './feedback/EmptyState';
 export { Skeleton, SkeletonText } from './feedback/Skeleton';
-export { SkeletonGroup, SkeletonPulseContext, useSkeletonPulse } from './feedback/SkeletonGroup';
+/*
+ * `SkeletonPulseContext` is deliberately not exported. Wrapping bare `<Skeleton>` components in
+ * a provider of one's own silences `useSkeletonPulse`'s outside-group error while the group's
+ * `role="progressbar"`, `aria-label` and `aria-busy` never render — an escape hatch that
+ * removes the accessibility semantics and the error that would have reported their absence.
+ */
+export { SkeletonGroup, useSkeletonPulse } from './feedback/SkeletonGroup';
 export {
   DEFAULT_LAST_LINE_WIDTH,
   skeletonTextRows,

--- a/packages/ui/src/media/Image.tsx
+++ b/packages/ui/src/media/Image.tsx
@@ -200,8 +200,7 @@ export function Image({
           /* Decoration over a picture: it must never eat a tap meant for the card beneath it,
              and it must never be announced. */
           pointerEvents="none"
-          accessibilityElementsHidden
-          importantForAccessibility="no-hide-descendants"
+          aria-hidden
           style={styles.scrim}
         />
       )}

--- a/packages/ui/src/media/imageFrame.test.ts
+++ b/packages/ui/src/media/imageFrame.test.ts
@@ -15,13 +15,18 @@ describe('imageAccessibility', () => {
     warn.mockRestore();
   });
 
+  it('carries no hiding flag at all on an image it describes', () => {
+    /* Omitted rather than `false`. `aria-hidden="false"` is a real value with real meaning on
+       web, and spreading it onto every described image is a prop that has to be read to be
+       ignored — the deprecated pair it replaced had exactly that shape. */
+    expect(imageAccessibility('The cake', false)['aria-hidden']).toBeUndefined();
+  });
+
   it('announces an image that has alternative text', () => {
     expect(imageAccessibility('The couple cutting the cake', false)).toEqual({
       accessible: true,
-      accessibilityRole: 'image',
-      accessibilityLabel: 'The couple cutting the cake',
-      accessibilityElementsHidden: false,
-      importantForAccessibility: 'yes',
+      role: 'img',
+      'aria-label': 'The couple cutting the cake',
     });
     expect(warn).not.toHaveBeenCalled();
   });
@@ -29,14 +34,14 @@ describe('imageAccessibility', () => {
   it('hides a decorative image rather than announcing an empty one', () => {
     const props = imageAccessibility(undefined, true);
 
-    /* Empty rather than absent: expo-image maps accessibilityLabel to the web `alt` attribute,
-       and `alt=""` is what removes an image from the accessibility tree. A missing attribute
-       makes a screen reader read the file name instead. */
-    expect(props.accessibilityLabel).toBe('');
+    /* Empty rather than absent: an empty label is what removes an image from the accessibility
+       tree, where a missing one makes a screen reader read the file name instead. */
+    expect(props['aria-label']).toBe('');
     expect(props.accessible).toBe(false);
-    expect(props.accessibilityElementsHidden).toBe(true);
-    expect(props.importantForAccessibility).toBe('no-hide-descendants');
-    expect(props.accessibilityRole).toBeUndefined();
+    /* One flag now covers both platforms — React Native maps `aria-hidden` onto
+       `accessibilityElementsHidden` for iOS and `importantForAccessibility` for Android. */
+    expect(props['aria-hidden']).toBe(true);
+    expect(props.role).toBeUndefined();
 
     /* Declaring an image decorative is a decision, not a mistake, so it is the one hiding path
        that must stay quiet. A warning here would train people to ignore the others. */
@@ -61,7 +66,7 @@ describe('imageAccessibility', () => {
     const props = imageAccessibility(undefined, false);
 
     expect(props.accessible).toBe(false);
-    expect(props.accessibilityElementsHidden).toBe(true);
+    expect(props['aria-hidden']).toBe(true);
     expect(warn).toHaveBeenCalledTimes(1);
     expect(warn.mock.calls[0]?.[0]).toContain('neither');
   });
@@ -71,7 +76,7 @@ describe('imageAccessibility', () => {
        `decorative` would drop a description someone actually wrote. */
     const props = imageAccessibility('The ceremony arch', true);
 
-    expect(props.accessibilityLabel).toBe('The ceremony arch');
+    expect(props['aria-label']).toBe('The ceremony arch');
     expect(props.accessible).toBe(true);
     expect(warn).toHaveBeenCalledTimes(1);
     expect(warn.mock.calls[0]?.[0]).toContain('both');
@@ -81,8 +86,10 @@ describe('imageAccessibility', () => {
 describe('hasOverlay', () => {
   it('counts anything React will actually paint', () => {
     expect(hasOverlay('A caption')).toBe(true);
+    /* React paints `0`, so a caption of zero is a caption. */
     expect(hasOverlay(0)).toBe(true);
-    expect(hasOverlay([])).toBe(true);
+    expect(hasOverlay(['A caption'])).toBe(true);
+    expect(hasOverlay([null, 'A caption'])).toBe(true);
   });
 
   it('does not count the values a JSX conditional collapses to', () => {
@@ -94,6 +101,26 @@ describe('hasOverlay', () => {
     expect(hasOverlay(null)).toBe(false);
     expect(hasOverlay(false)).toBe(false);
     expect(hasOverlay(true)).toBe(false);
+  });
+
+  it('does not count an empty string or an empty list', () => {
+    /*
+     * `{caption}` where the caption is `''`, and `{items.map(…)}` where the list is empty. Both
+     * paint nothing and both used to count as content, so a photograph with no text on it got a
+     * scrim and an absolutely-positioned padded overlay laid over it.
+     *
+     * `''` was the reported case; `[]` is the same bug in the value one line above it, and the
+     * old suite asserted it was content.
+     */
+    expect(hasOverlay('')).toBe(false);
+    expect(hasOverlay([])).toBe(false);
+  });
+
+  it('does not count a list whose every entry collapses', () => {
+    /* What a list of conditionals leaves behind: `{[cond1 && <A/>, cond2 && <B/>]}` with both
+       false. Checking only the array itself would call this content. */
+    expect(hasOverlay([null, false, undefined])).toBe(false);
+    expect(hasOverlay([[], ['']])).toBe(false);
   });
 });
 

--- a/packages/ui/src/media/imageFrame.ts
+++ b/packages/ui/src/media/imageFrame.ts
@@ -18,14 +18,25 @@ import type { ReactNode } from 'react';
 /**
  * What the accessibility layer needs, expressed structurally so this file stays free of React
  * Native. Every field is assignable to the prop of the same name on a View or an expo-image.
+ *
+ * ARIA spellings, for the reason #127 established: react-native-web 0.21's forwarded-prop table
+ * does not carry `accessibilityState` at all and marks `accessibilityRole` and
+ * `accessibilityLabel` deprecated, each emitting a `warnOnce`. React Native maps `role`,
+ * `aria-label` and `aria-hidden` back to the native equivalents — `aria-hidden` covers both
+ * `accessibilityElementsHidden` on iOS and `importantForAccessibility` on Android — so nothing
+ * is lost on device, and web, which ships first (D30), gets props it actually reads.
+ *
+ * That this is a structural type is what made it more than a rename: the two hiding props were
+ * one boolean and one string union, and their replacement is a single optional flag, so every
+ * construction site below had to be re-decided rather than search-replaced.
  */
 export type ImageAccessibility = {
   readonly accessible: boolean;
   /** Becomes the `alt` attribute on web. Empty string is the correct value for decoration. */
-  readonly accessibilityLabel: string;
-  readonly accessibilityElementsHidden: boolean;
-  readonly importantForAccessibility: 'yes' | 'no-hide-descendants';
-  readonly accessibilityRole?: 'image';
+  readonly 'aria-label': string;
+  /** Omitted rather than `false`, so a described image carries no hiding prop at all. */
+  readonly 'aria-hidden'?: true;
+  readonly role?: 'img';
 };
 
 /**
@@ -66,13 +77,7 @@ export const imageAccessibility = (
        contradiction is reported rather than resolved silently. */
     if (decorative) warnInDevelopment('both `alt` and `decorative` were given; using `alt`.');
 
-    return {
-      accessible: true,
-      accessibilityRole: 'image',
-      accessibilityLabel: alt,
-      accessibilityElementsHidden: false,
-      importantForAccessibility: 'yes',
-    };
+    return { accessible: true, role: 'img', 'aria-label': alt };
   }
 
   if (!decorative) {
@@ -83,12 +88,7 @@ export const imageAccessibility = (
     );
   }
 
-  return {
-    accessible: false,
-    accessibilityLabel: '',
-    accessibilityElementsHidden: true,
-    importantForAccessibility: 'no-hide-descendants',
-  };
+  return { accessible: false, 'aria-label': '', 'aria-hidden': true };
 };
 
 /* -------------------------------------------------------------------------------------------
@@ -102,9 +102,19 @@ export const imageAccessibility = (
  * when the title is empty and `{caption ?? null}` to `null` — React renders nothing for either,
  * and both are how a caller writes "sometimes there is a caption". Treating them as content puts
  * a scrim and an empty overlay over a photograph that has no text on it at all.
+ *
+ * The empty string and the empty array are the same bug and were both counted as content:
+ * `{caption}` where the caption is `''`, and `{items.map(…)}` where the list is empty, each
+ * paint nothing. So does an array whose every entry collapses — `[null, false]` — which is what
+ * a list of conditionals leaves behind, so this recurses rather than checking only the array
+ * itself. A number stays content: React paints `0`.
  */
-export const hasOverlay = (children: ReactNode): boolean =>
-  children !== undefined && children !== null && typeof children !== 'boolean';
+export const hasOverlay = (children: ReactNode): boolean => {
+  if (children === undefined || children === null || typeof children === 'boolean') return false;
+  if (typeof children === 'string') return children !== '';
+  if (Array.isArray(children)) return children.some(hasOverlay);
+  return true;
+};
 
 /* -------------------------------------------------------------------------------------------
  * Scrim


### PR DESCRIPTION
#138 items 4, 5, 7 and 8 — all in code that reached `main` unreviewed.

## A scrim over a photograph with nothing on it (item 7)

`hasOverlay('')` was `true`, so `{caption}` with an empty caption painted a scrim *and* an absolutely positioned padded overlay over a bare picture. `null` and `false` were fixed for this in #131; the empty string was one value short.

The empty array is the same bug one line above it — `{items.map(…)}` with an empty list — and the old suite asserted it **was** content. So this recurses: a list whose every entry collapses paints nothing either, which is exactly what `{[a && <A/>, b && <B/>]}` leaves behind. A number stays content, because React paints `0`.

## The D17 boundary open at one component (item 4)

`EmptyState`'s `style` was `StyleProp<ViewStyle>` where #120 narrowed the others to `LayoutViewStyle`, so a caller could hand it a background, padding or radius. That is the harder half of D17 to see: the lint rule catches a literal in a stylesheet and cannot catch a token passed in through a variable at a call site.

`LayoutViewStyle` was already contract-tested where it is defined — which proves the *type* rejects a colour and says nothing about whether a component uses it. The narrowing is now pinned per-component in `feedback/typeContracts.assertions.ts`.

Worth reporting: **the first version of that contract was wrong in the way the file exists to catch.** Built from `{ style: … }` alone, it "rejected" every case because `title` is required, and would have passed as three green rejections. `tsc` refused the one assertion meant to *accept*, which is the only reason it surfaced. The contracts now vary the style inside a complete call.

## An escape hatch that removed the accessibility semantics (item 5)

`SkeletonPulseContext` was exported from the barrel, so a consumer could wrap bare `<Skeleton>` components in a provider of their own — silencing `useSkeletonPulse`'s outside-group error while `SkeletonGroup`'s `role="progressbar"`, `aria-label` and `aria-busy` never rendered. It removed both the semantics and the error that would have reported their absence.

## Deprecated accessibility spellings on the image scrim (item 8)

The migration #127 made elsewhere: react-native-web 0.21.2 emits a `warnOnce` for each of `accessibilityElementsHidden`, `importantForAccessibility`, `accessibilityRole` and `accessibilityLabel`.

`aria-hidden` covers both native hiding props at once (iOS `accessibilityElementsHidden`, Android `importantForAccessibility`), so `ImageAccessibility` loses a field rather than renaming two. That is why this was not a find-and-replace — the structural type meant every construction site had to be re-decided. A described image now carries no hiding flag at all, rather than an explicit `false` that has to be read to be ignored.

## Verification

| mutation | result |
|---|---|
| count `''` as content | 2 tests fail |
| count `[]` as content | 2 tests fail |
| check the array without recursing | 1 test fails |
| put `aria-hidden` on a described image | 2 tests fail |
| widen `EmptyState`'s prop back to `ViewStyle` | 3 typecheck errors |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145VPJXGgJA9PWqeNXDr1DG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `EmptyStateProps` is now publicly exported, with styling limited to supported layout properties.
  - Image accessibility metadata now uses standard ARIA properties for improved web compatibility.

- **Bug Fixes**
  - Decorative image content is correctly excluded from accessibility announcements.
  - Empty or non-rendering overlay values are no longer treated as visible overlays.

- **Breaking Changes**
  - `SkeletonPulseContext` is no longer publicly exported from `SkeletonGroup`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->