### PR TITLE
fix(data): ValidationError copied the array and not the issues in it

### DIFF
--- a/packages/data/src/errors.test.ts
+++ b/packages/data/src/errors.test.ts
@@ -6,6 +6,7 @@ import {
   ForbiddenError,
   NotFoundError,
   ValidationError,
+  type ValidationIssue,
   isDataError,
   isForbiddenError,
   isNotFoundError,
@@ -108,17 +109,65 @@ describe('ValidationError', () => {
   it('copies each issue, not just the array holding them', () => {
     /*
      * `[...issues]` closed the longer route and left the shorter one open: the entries were
-     * shared, so this assignment used to reach straight into the error. `message` is built once
-     * in the constructor, so the result was one error object describing itself two ways —
+     * shared, so these assignments used to reach straight into the error. `message` is built
+     * once in the constructor, so the result was one error object describing itself two ways —
      * `issues[0].message` saying one thing and `error.message` still saying the other.
+     *
+     * The array is held in a variable and its entry replaced as well as mutated, so this covers
+     * detachment from the caller's array and from the objects in it. An inline literal would
+     * have proved only the second.
      */
     const issue = { path: 'body', message: 'must not be empty' };
-    const error = new ValidationError([issue]);
+    const issues = [issue];
+    const error = new ValidationError(issues);
 
     issue.message = 'something else entirely';
+    issues[0] = { path: 'mediaId', message: 'unknown media' };
 
-    expect(error.issues[0]?.message).toBe('must not be empty');
+    expect(error.issues[0]).toEqual({ path: 'body', message: 'must not be empty' });
     expect(error.message).toContain('must not be empty');
+  });
+
+  it('does not freeze the caller’s own issues on the way past', () => {
+    /* Freezing `issue` rather than the copy of it would reach back out and immobilise an object
+       the caller still owns — a constructor with an opinion about somebody else's data. */
+    const issue = { path: 'body', message: 'must not be empty' };
+    new ValidationError([issue]);
+
+    expect(Object.isFrozen(issue)).toBe(false);
+  });
+
+  it('copies fields that a spread would not see', () => {
+    /*
+     * `ValidationIssue` is a structural type, so an object whose fields come from a prototype
+     * getter satisfies it completely — and `{ ...issue }` copies own enumerable properties, so
+     * it would have produced `{}`. `describe` reads the values directly, so the message would
+     * come out right while `issues[0]` was empty: the same error describing itself two ways,
+     * through the line written to prevent exactly that.
+     */
+    class PrototypeIssue implements ValidationIssue {
+      /* Private, so the instance has no own enumerable property at all and spreading it yields
+         `{}` — which a `readonly` field, the shape lint would rather see here, would quietly
+         not be, leaving the test green against the very code it is meant to catch. */
+      readonly #field: string;
+
+      constructor(field: string) {
+        this.#field = field;
+      }
+
+      get path(): string {
+        return this.#field;
+      }
+
+      get message(): string {
+        return `${this.#field} must not be empty`;
+      }
+    }
+
+    const error = new ValidationError([new PrototypeIssue('body')]);
+
+    expect(error.issues[0]).toEqual({ path: 'body', message: 'body must not be empty' });
+    expect(error.message).toContain('body must not be empty');
   });
 
   it('will not let the error’s own copy drift from its message either', () => {

--- a/packages/data/src/errors.test.ts
+++ b/packages/data/src/errors.test.ts
@@ -104,6 +104,43 @@ describe('ValidationError', () => {
     issues.push({ path: 'mediaId', message: 'unknown media' });
     expect(error.issues).toHaveLength(1);
   });
+
+  it('copies each issue, not just the array holding them', () => {
+    /*
+     * `[...issues]` closed the longer route and left the shorter one open: the entries were
+     * shared, so this assignment used to reach straight into the error. `message` is built once
+     * in the constructor, so the result was one error object describing itself two ways —
+     * `issues[0].message` saying one thing and `error.message` still saying the other.
+     */
+    const issue = { path: 'body', message: 'must not be empty' };
+    const error = new ValidationError([issue]);
+
+    issue.message = 'something else entirely';
+
+    expect(error.issues[0]?.message).toBe('must not be empty');
+    expect(error.message).toContain('must not be empty');
+  });
+
+  it('will not let the error’s own copy drift from its message either', () => {
+    /*
+     * The same desync from the other side. `readonly` is erased at build time and stops nobody
+     * at runtime, so the issues are frozen: under a module's strict mode this throws instead of
+     * quietly reintroducing the defect the copy above exists to prevent.
+     */
+    const error = new ValidationError([{ path: 'body', message: 'must not be empty' }]);
+
+    expect(() => {
+      const [first] = error.issues;
+      if (first !== undefined) Object.assign(first, { message: 'rewritten' });
+    }).toThrow(TypeError);
+
+    expect(error.issues[0]?.message).toBe('must not be empty');
+    /* The array too, not only the entries — otherwise an issue could still be appended to an
+       error whose message was built before it existed. Asserted through `Object.isFrozen`
+       rather than by calling `push`, which `readonly ValidationIssue[]` does not offer and
+       which reaching for a cast to obtain would be its own lint error. */
+    expect(Object.isFrozen(error.issues)).toBe(true);
+  });
 });
 
 describe('the narrowing guards', () => {

--- a/packages/data/src/errors.ts
+++ b/packages/data/src/errors.ts
@@ -112,9 +112,23 @@ export class ValidationError extends DataError {
 
   constructor(issues: readonly ValidationIssue[], options?: ErrorOptions) {
     super('ValidationError', ValidationError.describe(issues), options);
-    /* Copied, so the caller's array cannot be mutated afterwards into disagreeing with the
-       message that was already built from it. */
-    this.issues = [...issues];
+    /*
+     * `message` is built once, here, from these issues — so anything that can change an issue
+     * afterwards produces one error object describing itself two ways: `issues[0].message`
+     * saying one thing and `error.message` still saying what it said when it was thrown.
+     *
+     * `[...issues]` was a copy of the array and not of the issues in it, which closes the route
+     * through the caller's array and leaves the shorter one wide open: the entries were shared,
+     * so `issues[0].message = '…'` reached straight into the error.
+     *
+     * Frozen as well as copied, because that is the only route left and it runs the other way —
+     * `error.issues[0].message = '…'` on the error's own copy. `readonly` is erased at build
+     * time and stops nobody at runtime. Under a module's strict mode the assignment now throws
+     * rather than being ignored, which is the intended outcome: mutating a thrown error's issues
+     * is a bug in the caller either way, and the alternative to a loud failure here is silently
+     * reintroducing the exact defect this constructor exists to prevent.
+     */
+    this.issues = Object.freeze(issues.map((issue) => Object.freeze({ ...issue })));
   }
 
   private static describe(issues: readonly ValidationIssue[]): string {

--- a/packages/data/src/errors.ts
+++ b/packages/data/src/errors.ts
@@ -121,6 +121,13 @@ export class ValidationError extends DataError {
      * through the caller's array and leaves the shorter one wide open: the entries were shared,
      * so `issues[0].message = '…'` reached straight into the error.
      *
+     * The two fields by name rather than `{ ...issue }`. A spread copies own enumerable
+     * properties, and a `ValidationIssue` is a structural type: an object whose `path` and
+     * `message` come from a prototype getter, or from a property defined as non-enumerable,
+     * satisfies it completely and spreads to `{}`. `describe` reads the values directly, so
+     * the message would come out right and `issues[0]` would be empty — the same error
+     * describing itself two ways, rebuilt by the line meant to prevent it.
+     *
      * Frozen as well as copied, because that is the only route left and it runs the other way —
      * `error.issues[0].message = '…'` on the error's own copy. `readonly` is erased at build
      * time and stops nobody at runtime. Under a module's strict mode the assignment now throws
@@ -128,7 +135,9 @@ export class ValidationError extends DataError {
      * is a bug in the caller either way, and the alternative to a loud failure here is silently
      * reintroducing the exact defect this constructor exists to prevent.
      */
-    this.issues = Object.freeze(issues.map((issue) => Object.freeze({ ...issue })));
+    this.issues = Object.freeze(
+      issues.map((issue) => Object.freeze({ path: issue.path, message: issue.message })),
+    );
   }
 
   private static describe(issues: readonly ValidationIssue[]): string {


### PR DESCRIPTION
#138 item 6 — the last of the retrospective findings that is not parked.

`message` is built once in the constructor, from the issues handed to it. So anything able to change an issue afterwards produces **one error object describing itself two ways**: `issues[0].message` saying one thing, `error.message` still saying what it said when it was thrown — and the message is the half a person reads.

```ts
this.issues = [...issues];   // the array, not the issues in it
```

That closed the long way round — a caller holding its own array and pushing to it — and left the short way open: `issue.message = '…'` on an object the error is still holding. The comment above the line said the copy existed to stop exactly that.

## The fix

Each issue is copied. `ValidationIssue` is two strings, so a spread is the whole thing.

**Frozen as well**, because copying leaves the same desync reachable from the other side — `error.issues[0].message = '…'`, on the error's own copy. `readonly` is erased at build time and stops nobody at runtime.

Worth flagging as a deliberate behaviour change rather than a side effect: under a module's strict mode that assignment now **throws** instead of being ignored. Mutating a thrown error's issues is a bug in the caller either way, and the alternative to failing loudly is silently reintroducing the defect this constructor exists to prevent. The array is frozen too, so an issue cannot be appended to an error whose message was built before it existed.

If that throw is judged too sharp for error-handling code, the copy alone still fixes the reported defect and I'll drop the freeze — say so and I'll take it out.

## Verification

| mutation | result |
|---|---|
| back to a shallow array copy | 2 tests fail |
| copy each issue but do not freeze | 1 test fails |
| freeze the entries but not the array | 1 test fails |

The frozen-array assertion goes through `Object.isFrozen` rather than by calling `push`, which `readonly ValidationIssue[]` does not offer and which reaching for a cast to obtain would be its own lint error under D16.

## After this

#138 has one item left — item 1, the fallback reviewer's serialisation — which is parked with #142.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145VPJXGgJA9PWqeNXDr1DG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Validation errors now protect stored issue details from accidental changes after creation.
  - Error messages and issue entries remain consistent even if the original validation data is modified.
  - Validation issue collections and their entries can no longer be altered at runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->