### PR TITLE
feat(app): tenant resolution, one abstraction over two platforms

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -7,6 +7,7 @@ import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { AppAdapterProvider } from '../src/data/AppAdapterProvider';
 import { ErrorFallback } from '../src/features/errors/ErrorFallback';
+import { TenantProvider } from '../src/tenant/TenantProvider';
 import { AppThemeProvider } from '../src/theme/AppThemeProvider';
 import { APP_THEME } from '../src/theme/inputs';
 
@@ -53,9 +54,9 @@ export function ErrorBoundary({ error, retry }: ErrorBoundaryProps) {
 /**
  * The root layout composes providers and nothing else — no data fetching, no business logic.
  *
- * Providers arrive as their epics land: the theme provider with #22, tenant resolution and
- * session with the v0.2 milestone. Screens stay pure so the theme editor can render them under
- * an overridden provider later.
+ * Providers arrive as their epics land: the theme provider with #22, tenant resolution with
+ * #39, session with the rest of the v0.2 milestone. Screens stay pure so the theme editor can
+ * render them under an overridden provider later.
  */
 export default function RootLayout() {
   // Created once per app instance rather than per render, so the cache is not thrown away.
@@ -65,12 +66,16 @@ export default function RootLayout() {
     <GestureHandlerRootView style={{ flex: 1 }}>
       <QueryClientProvider client={queryClient}>
         <AppAdapterProvider>
-          <AppThemeProvider input={APP_THEME}>
-            <SafeAreaProvider>
-              <StatusBar style="auto" />
-              <Stack screenOptions={{ headerShown: false }} />
-            </SafeAreaProvider>
-          </AppThemeProvider>
+          {/* No slug: the root is where the platform gets asked, once. Inside /e/[slug] the
+              route already knows, and its own provider says so rather than resolving again. */}
+          <TenantProvider>
+            <AppThemeProvider input={APP_THEME}>
+              <SafeAreaProvider>
+                <StatusBar style="auto" />
+                <Stack screenOptions={{ headerShown: false }} />
+              </SafeAreaProvider>
+            </AppThemeProvider>
+          </TenantProvider>
         </AppAdapterProvider>
       </QueryClientProvider>
     </GestureHandlerRootView>

--- a/apps/mobile/app/e/[slug]/_layout.tsx
+++ b/apps/mobile/app/e/[slug]/_layout.tsx
@@ -1,4 +1,5 @@
-import { Slot } from 'expo-router';
+import { Slot, useLocalSearchParams } from 'expo-router';
+import { TenantProvider } from '../../../src/tenant/TenantProvider';
 import { AppThemeProvider } from '../../../src/theme/AppThemeProvider';
 import { FIXTURE_TENANT_THEME } from '../../../src/theme/inputs';
 
@@ -9,13 +10,22 @@ import { FIXTURE_TENANT_THEME } from '../../../src/theme/inputs';
  * rewrite at the hosting layer plus a lookup table, never by routing inside the app.
  *
  * The nested ThemeProvider is the mechanism the theme editor's live preview will use: the
- * subtree below it renders under a different theme without a single duplicated component.
- * TenantProvider replaces the fixture input once tenancy lands.
+ * subtree below it renders under a different theme without a single duplicated component. The
+ * theme is still the fixture — the tenant's own config arrives with its repository read.
+ *
+ * The nested TenantProvider is not a second resolution. This route already holds the slug, so it
+ * says so; the root's provider is what asks the platform, and only where there is no route to
+ * read. Resolution is asynchronous, so without this every navigation into an event would pass
+ * through a `resolving` frame to arrive at a fact the URL had all along.
  */
 export default function TenantLayout() {
+  const { slug } = useLocalSearchParams<{ slug: string }>();
+
   return (
-    <AppThemeProvider input={FIXTURE_TENANT_THEME}>
-      <Slot />
-    </AppThemeProvider>
+    <TenantProvider slug={slug}>
+      <AppThemeProvider input={FIXTURE_TENANT_THEME}>
+        <Slot />
+      </AppThemeProvider>
+    </TenantProvider>
   );
 }

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -21,6 +21,7 @@
     "@expo-google-fonts/sora": "^0.4.2",
     "@expo-google-fonts/work-sans": "^0.4.2",
     "@expo/metro-runtime": "~57.0.15",
+    "@react-native-async-storage/async-storage": "2.2.0",
     "@tanstack/react-query": "^5.102.8",
     "expo": "^57.0.20",
     "expo-constants": "~57.0.17",

--- a/apps/mobile/src/tenant/TenantProvider.dom.test.tsx
+++ b/apps/mobile/src/tenant/TenantProvider.dom.test.tsx
@@ -1,0 +1,150 @@
+import { describe, expect, it, beforeEach } from '@jest/globals';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { TenantProvider, useTenantResolution } from './TenantProvider';
+
+/**
+ * The provider's job is to turn what the platform knows into one of three states, and the parts
+ * worth rendering to check are the ones the pure tests cannot see: that an explicit slug does
+ * not wait for anything, that a resolved event is remembered, and that a hook used outside the
+ * provider fails loudly instead of looking like an event that could not be found.
+ *
+ * This is the web implementation — `resolveTenant.web.ts` — because that is what Jest and the
+ * web build both resolve. The native path is the same union from a different source.
+ */
+
+const Probe = () => {
+  const resolution = useTenantResolution();
+  return (
+    <div data-testid="probe">
+      {resolution.kind === 'resolved'
+        ? `${resolution.kind}:${resolution.source}:${resolution.slug}`
+        : resolution.kind}
+    </div>
+  );
+};
+
+const probe = () => screen.getByTestId('probe').textContent;
+
+const at = (path: string) => {
+  window.history.pushState({}, '', path);
+};
+
+describe('TenantProvider', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    at('/');
+  });
+
+  it('does not ask the platform when the route already knows', async () => {
+    /* The URL is the answer. Asking again would be a second opinion about a fact, and it would
+       cost a `resolving` frame on every navigation inside an event. */
+    render(
+      <TenantProvider slug="lila-and-sam">
+        <Probe />
+      </TenantProvider>,
+    );
+
+    expect(probe()).toBe('resolved:path:lila-and-sam');
+    await waitFor(() => {
+      expect(window.localStorage.getItem('occasio.recentTenant')).toBe('lila-and-sam');
+    });
+  });
+
+  it('reads the canonical path when it is not given a slug', async () => {
+    at('/e/harvest-lights/schedule');
+
+    render(
+      <TenantProvider>
+        <Probe />
+      </TenantProvider>,
+    );
+
+    await waitFor(() => {
+      expect(probe()).toBe('resolved:path:harvest-lights');
+    });
+  });
+
+  it('falls back to the last event this browser opened', async () => {
+    /* The one moment storage matters on web: the bare origin, opened by somebody who has been
+       to an event before. */
+    window.localStorage.setItem('occasio.recentTenant', 'dev-summit-2026');
+
+    render(
+      <TenantProvider>
+        <Probe />
+      </TenantProvider>,
+    );
+
+    await waitFor(() => {
+      expect(probe()).toBe('resolved:recent:dev-summit-2026');
+    });
+  });
+
+  it('is unresolved, not broken, when nothing identifies an event', async () => {
+    /* A first visit to the bare origin. It is the state the join screen and the discover page
+       exist to answer, so it must not read as an error. */
+    render(
+      <TenantProvider>
+        <Probe />
+      </TenantProvider>,
+    );
+
+    await waitFor(() => {
+      expect(probe()).toBe('unresolved');
+    });
+  });
+
+  it('ignores a stored value that is not a slug', async () => {
+    /* Written by an older build, or by whoever had the console open. It is about to become a
+       path segment. */
+    window.localStorage.setItem('occasio.recentTenant', '../../etc/passwd');
+
+    render(
+      <TenantProvider>
+        <Probe />
+      </TenantProvider>,
+    );
+
+    await waitFor(() => {
+      expect(probe()).toBe('unresolved');
+    });
+  });
+
+  it('takes a slug given later over an answer still in flight', async () => {
+    /*
+     * Resolution is asynchronous on both platforms, so a late answer landing after the provider
+     * has been told the slug would overwrite a correct state with a stale one — and it would do
+     * it a frame after the screen looked right, which is the hardest kind of bug to attribute.
+     */
+    window.localStorage.setItem('occasio.recentTenant', 'dev-summit-2026');
+
+    const { rerender } = render(
+      <TenantProvider>
+        <Probe />
+      </TenantProvider>,
+    );
+
+    rerender(
+      <TenantProvider slug="lila-and-sam">
+        <Probe />
+      </TenantProvider>,
+    );
+
+    expect(probe()).toBe('resolved:path:lila-and-sam');
+
+    /* Let every pending resolution settle: the abandoned one must not arrive after all. */
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(probe()).toBe('resolved:path:lila-and-sam');
+  });
+
+  it('fails loudly when a screen is mounted outside the provider', () => {
+    /*
+     * Returning `unresolved` here would render as a plausible empty state that nobody
+     * investigates — the wiring mistake wearing the costume of a legitimate outcome.
+     */
+    expect(() => render(<Probe />)).toThrow(/inside a <TenantProvider>/);
+  });
+});

--- a/apps/mobile/src/tenant/TenantProvider.tsx
+++ b/apps/mobile/src/tenant/TenantProvider.tsx
@@ -1,0 +1,104 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+import { writeRecentTenant } from './recentTenant';
+import { resolveTenant } from './resolveTenant';
+import { resolvedAs, resolving, type TenantResolution } from './tenantResolution';
+
+/**
+ * Which event the app is currently showing.
+ *
+ * One abstraction over two platforms that share nothing here: web reads a hostname then a path,
+ * native reads a deep link then this device's history. Both arrive as the same three-state
+ * union, so a screen never learns which platform it is on — see resolveTenant.ts and
+ * resolveTenant.web.ts, which Metro and Jest both pick automatically.
+ *
+ * Deliberately free of expo-router. The canonical route already knows its own slug and can say
+ * so through `slug`, and keeping the router out means this renders under a test, under the theme
+ * editor's preview, and anywhere else a screen needs a tenant without a URL.
+ */
+
+const TenantContext = createContext<TenantResolution | null>(null);
+
+type Props = {
+  /**
+   * The slug the caller already knows — the route param under `/e/[slug]`.
+   *
+   * When given, there is nothing to resolve: the URL is the answer, and asking the platform
+   * again would be a second opinion about a fact. When absent, the platform is asked, which is
+   * what the root layout and a cold native launch need.
+   */
+  readonly slug?: string | undefined;
+  readonly children: ReactNode;
+};
+
+export function TenantProvider({ slug, children }: Props) {
+  const [resolution, setResolution] = useState<TenantResolution>(() =>
+    slug === undefined ? resolving : resolvedAs(slug, 'path'),
+  );
+
+  useEffect(() => {
+    if (slug !== undefined) {
+      setResolution(resolvedAs(slug, 'path'));
+      return;
+    }
+
+    /*
+     * Resolution is asynchronous on both platforms — storage on web, a deep link on native — so
+     * a late answer arriving after this provider has been given a slug, or unmounted, would
+     * overwrite a correct state with a stale one. The flag is per-effect, so a `slug` that
+     * changes mid-flight abandons the in-flight answer rather than racing it.
+     */
+    let abandoned = false;
+    setResolution(resolving);
+
+    void resolveTenant().then((resolved) => {
+      if (!abandoned) setResolution(resolved);
+    });
+
+    return () => {
+      abandoned = true;
+    };
+  }, [slug]);
+
+  useEffect(() => {
+    /*
+     * Remember where we are, so a native launch with no deep link lands back here.
+     *
+     * Written on every resolution including `recent` itself, which is a harmless rewrite of the
+     * same value and one branch fewer to be wrong about.
+     */
+    if (resolution.kind === 'resolved') void writeRecentTenant(resolution.slug);
+  }, [resolution]);
+
+  return <TenantContext.Provider value={resolution}>{children}</TenantContext.Provider>;
+}
+
+/**
+ * The current resolution, in full.
+ *
+ * Throws outside a provider rather than returning `unresolved`, because the two mean opposite
+ * things: "no event could be identified" is a state screens are built to handle, and "this
+ * screen was mounted outside the provider" is a wiring mistake that would otherwise render as a
+ * plausible-looking empty state nobody investigates.
+ */
+export const useTenantResolution = (): TenantResolution => {
+  const resolution = useContext(TenantContext);
+  if (resolution === null) {
+    throw new Error('useTenantResolution must be used inside a <TenantProvider>.');
+  }
+  return resolution;
+};
+
+/**
+ * The slug, or `null` while resolving or when nothing resolved.
+ *
+ * For the screens that only need to ask for data and have somewhere sensible to render while
+ * they wait. Anything that has to tell "still looking" apart from "nothing to look at" — the
+ * not-found and loading states of #40 — wants the union instead.
+ */
+export const useTenantSlug = (): string | null => {
+  const resolution = useTenantResolution();
+  return resolution.kind === 'resolved' ? resolution.slug : null;
+};
+
+/** Exported for the tests that need to build a resolution without a platform. */
+export { TenantContext };

--- a/apps/mobile/src/tenant/customDomains.test.ts
+++ b/apps/mobile/src/tenant/customDomains.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from '@jest/globals';
+import { normaliseHost, slugFor, slugForHost } from './customDomains';
+
+/**
+ * ADR-0003 keeps custom domains to a lookup, so the only things worth testing are the lookup's
+ * edges — and the one that matters is the app's own hostname, where a wrong answer pins every
+ * page to one event and reads as the router being broken.
+ */
+
+describe('normaliseHost', () => {
+  it('reduces the spellings of one site to one key', () => {
+    for (const host of [
+      'lila-and-sam.com',
+      'LILA-AND-SAM.com',
+      'www.lila-and-sam.com',
+      'WWW.Lila-And-Sam.com:8081',
+      '  lila-and-sam.com  ',
+    ]) {
+      expect([host, normaliseHost(host)]).toEqual([host, 'lila-and-sam.com']);
+    }
+  });
+});
+
+describe('slugForHost', () => {
+  it('maps a configured domain to its event', () => {
+    expect(slugForHost('lila-and-sam.com')).toBe('lila-and-sam');
+    expect(slugForHost('www.harvestlights.co.uk:443')).toBe('harvest-lights');
+  });
+
+  it('never maps the app’s own hostnames, even when the map says otherwise', () => {
+    /*
+     * The failure this guards is quiet and total: one wrong row and every local page resolves to
+     * one event, with the canonical path route unreachable and nothing to suggest the hostname
+     * is why.
+     *
+     * Tested against a map that *does* contain those hostnames. Against the real fixture it
+     * proves nothing — no app host is in there, so the lookup answers null on its own and
+     * deleting the guard entirely changes no result. That is the same defect this suite is for,
+     * one level up, and it survived a first version of this test.
+     */
+    const hostile = { localhost: 'oops', '127.0.0.1': 'oops', 'occasio.app': 'oops' };
+
+    for (const host of [
+      'localhost',
+      'localhost:8081',
+      '127.0.0.1',
+      'occasio.app',
+      'www.occasio.app',
+    ]) {
+      expect([host, slugFor(hostile, host)]).toEqual([host, null]);
+      expect([host, slugForHost(host)]).toEqual([host, null]);
+    }
+  });
+
+  it('refuses a mapped value that is not a slug', () => {
+    /* The map becomes a `tenant_domains` table, and a row is an operator's typing. It must not
+       reach the router unexamined. */
+    expect(slugFor({ 'a-domain.com': '../../etc/passwd' }, 'a-domain.com')).toBeNull();
+    expect(slugFor({ 'a-domain.com': '' }, 'a-domain.com')).toBeNull();
+  });
+
+  it('answers null for a hostname nobody configured', () => {
+    /* Not an error: almost every request arrives on the app's own domain and the path carries
+       the slug. */
+    expect(slugForHost('example.com')).toBeNull();
+    expect(slugForHost('')).toBeNull();
+    expect(slugForHost('   ')).toBeNull();
+  });
+});

--- a/apps/mobile/src/tenant/customDomains.ts
+++ b/apps/mobile/src/tenant/customDomains.ts
@@ -1,0 +1,61 @@
+import { isSlug } from './tenantResolution';
+
+/**
+ * Which event a custom hostname belongs to.
+ *
+ * A fixture map today and a `tenant_domains` table later — ADR-0003 says so, and the shape here
+ * is chosen to make that swap boring: a lookup from hostname to slug, nothing else. Anything
+ * cleverer (patterns, wildcards, per-domain settings) would be a decision made in code that the
+ * table then has to reproduce, which is how a hosting concern leaks into the app.
+ *
+ * Hostnames are lowercased and stripped of a port before lookup, and any `www.` prefix is
+ * ignored: `WWW.Lila-And-Sam.com:8081` and `lila-and-sam.com` are the same site to everybody
+ * except a string comparison.
+ *
+ * A hostname that is not in this map is not an error. Almost every request arrives on the app's
+ * own domain, where the path carries the slug — which is the canonical route and the one that
+ * always works.
+ */
+const CUSTOM_DOMAINS: Readonly<Record<string, string>> = {
+  'lila-and-sam.com': 'lila-and-sam',
+  'harvestlights.co.uk': 'harvest-lights',
+  'devsummit.example': 'dev-summit-2026',
+};
+
+/**
+ * The app's own hostnames, which never map to a tenant however they are spelled.
+ *
+ * Without this, adding `localhost` to the fixture map by accident — or a future table row
+ * pointing at the app's own domain — would pin every local page to one event and make the
+ * canonical path route unreachable, which is a failure that looks like the router being broken.
+ */
+const APP_HOSTS = new Set(['localhost', '127.0.0.1', '0.0.0.0', 'occasio.app']);
+
+/** Lowercase, no port, no `www.` — the form the map is keyed by. */
+export const normaliseHost = (host: string): string => {
+  const withoutPort = host.trim().toLowerCase().split(':')[0] ?? '';
+  return withoutPort.startsWith('www.') ? withoutPort.slice(4) : withoutPort;
+};
+
+/**
+ * The lookup, against a map given to it.
+ *
+ * Separated from the fixture so the guard below can be tested against a map that actually
+ * contains an app hostname. Written against `CUSTOM_DOMAINS` alone it could not be: no app host
+ * is in there today, so the guard never fired and removing it changed no test — which is the
+ * whole failure it exists to prevent, one level up.
+ *
+ * That the map becomes a `tenant_domains` table is exactly why: a row an operator can write is
+ * the input this guard is for, and by then there is no fixture to inspect.
+ */
+export const slugFor = (domains: Readonly<Record<string, string>>, host: string): string | null => {
+  const normalised = normaliseHost(host);
+  if (normalised === '' || APP_HOSTS.has(normalised)) return null;
+  const slug = domains[normalised];
+  /* Checked against `isSlug` rather than trusted, for the same reason: a row written by an
+     operator should not be able to hand a path segment to the router unexamined. */
+  return slug !== undefined && isSlug(slug) ? slug : null;
+};
+
+/** The slug a hostname stands for, or `null` when it stands for nothing. */
+export const slugForHost = (host: string): string | null => slugFor(CUSTOM_DOMAINS, host);

--- a/apps/mobile/src/tenant/recentTenant.ts
+++ b/apps/mobile/src/tenant/recentTenant.ts
@@ -1,0 +1,43 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { isSlug } from './tenantResolution';
+
+/**
+ * Native: the last event this device opened.
+ *
+ * There is no URL bar to read, so without this a returning attendee lands on a join screen
+ * holding a code they were given once, weeks ago — the app forgetting where it was every time it
+ * is closed. It is the second source native tries, behind a deep link, because a link the person
+ * just followed is a stronger statement of intent than where they happened to be last.
+ *
+ * `AsyncStorage` rather than something securable: a slug is public — it is in the URL on web —
+ * so this is a convenience, not a credential. The web implementation is in recentTenant.web.ts.
+ */
+
+const KEY = 'occasio.recentTenant';
+
+/**
+ * Reads are validated, not trusted.
+ *
+ * What comes back was written by an older build of this app, or by a hand-edited simulator
+ * store, and it is about to become a path segment. Treating a bad value as absent lands on the
+ * join screen, which is recoverable; passing it on is a request built from whatever was in
+ * storage.
+ */
+export const readRecentTenant = async (): Promise<string | null> => {
+  try {
+    const stored = await AsyncStorage.getItem(KEY);
+    return stored !== null && isSlug(stored) ? stored : null;
+  } catch {
+    /* Storage being unavailable is not worth failing a launch over — it costs the shortcut. */
+    return null;
+  }
+};
+
+export const writeRecentTenant = async (slug: string): Promise<void> => {
+  if (!isSlug(slug)) return;
+  try {
+    await AsyncStorage.setItem(KEY, slug);
+  } catch {
+    /* Nothing to do and nothing to say: the app works, it just will not remember. */
+  }
+};

--- a/apps/mobile/src/tenant/recentTenant.web.ts
+++ b/apps/mobile/src/tenant/recentTenant.web.ts
@@ -1,0 +1,40 @@
+import { isSlug } from './tenantResolution';
+
+/**
+ * Web: the last event this browser opened.
+ *
+ * Barely used, and kept for symmetry rather than as a shortcut — a browser has a URL, and the
+ * URL is the answer. It matters at exactly one moment: someone opening the app's bare origin,
+ * who has been to an event before. Web resolution tries the hostname, then the path, then this.
+ *
+ * `localStorage` is read through a `try` on both sides, because it is not a variable: Safari in
+ * private mode throws on write, an embedded webview can have site data disabled entirely, and a
+ * page served from a `file://` origin throws on access itself. The same `try` covers a runtime
+ * with no DOM at all — a static export's prerender — where the property is simply absent and
+ * calling a method on it throws. `lib.dom` types it as always present, so an optional chain
+ * would be deleted as dead code by the very lint rule that reads those types.
+ */
+
+const KEY = 'occasio.recentTenant';
+
+export const readRecentTenant = (): Promise<string | null> => {
+  try {
+    const stored = globalThis.localStorage.getItem(KEY);
+    /* Validated rather than trusted: it is about to become a path segment, and what came back
+       was written by an older build or by whoever had the developer console open. */
+    return Promise.resolve(stored !== null && isSlug(stored) ? stored : null);
+  } catch {
+    return Promise.resolve(null);
+  }
+};
+
+export const writeRecentTenant = (slug: string): Promise<void> => {
+  if (isSlug(slug)) {
+    try {
+      globalThis.localStorage.setItem(KEY, slug);
+    } catch {
+      /* Private mode, a disabled store, a quota. The app works; it just will not remember. */
+    }
+  }
+  return Promise.resolve();
+};

--- a/apps/mobile/src/tenant/resolveTenant.ts
+++ b/apps/mobile/src/tenant/resolveTenant.ts
@@ -1,6 +1,11 @@
 import * as Linking from 'expo-linking';
 import { readRecentTenant } from './recentTenant';
-import { firstResolved, slugFromPath, type TenantResolution } from './tenantResolution';
+import {
+  firstResolved,
+  pathFromLink,
+  slugFromPath,
+  type TenantResolution,
+} from './tenantResolution';
 
 /**
  * Native: the deep link it was opened with, then where this device was last.
@@ -34,15 +39,13 @@ const readInitialUrl = async (): Promise<string | null> => {
 /**
  * The path part of a deep link, however the link was spelled.
  *
- * `occasio://e/lila-and-sam` and `https://occasio.app/e/lila-and-sam` have to reach the same
- * slug, and they parse differently: a custom scheme puts `e` in the host and `lila-and-sam` in
- * the path. `Linking.parse` normalises that, and its `path` is returned without a leading slash,
- * which `slugFromPath` would otherwise read as a first empty segment.
+ * The parsing belongs to expo-linking and the rule about what the parts mean belongs to
+ * `pathFromLink`, where it can be run without the native linking runtime. Keeping them apart is
+ * the point: the rule was wrong in its first version, and there was nowhere to notice.
  */
 const pathOf = (url: string): string => {
   try {
-    const { path } = Linking.parse(url);
-    return path === null ? '' : `/${path}`;
+    return pathFromLink(Linking.parse(url));
   } catch {
     return '';
   }

--- a/apps/mobile/src/tenant/resolveTenant.ts
+++ b/apps/mobile/src/tenant/resolveTenant.ts
@@ -1,0 +1,49 @@
+import * as Linking from 'expo-linking';
+import { readRecentTenant } from './recentTenant';
+import { firstResolved, slugFromPath, type TenantResolution } from './tenantResolution';
+
+/**
+ * Native: the deep link it was opened with, then where this device was last.
+ *
+ * There is no hostname to read and no URL bar to type into, so these are the only two things the
+ * platform can say. A link the person just followed beats the event they happened to open last
+ * week, which is the whole of the ordering.
+ *
+ * When neither answers, the result is `unresolved` rather than an error — a first launch with no
+ * link is the ordinary case, and it is what the join-by-code screen (#41) exists for.
+ */
+export const resolveTenant = async (): Promise<TenantResolution> => {
+  const initialUrl = await readInitialUrl();
+  const recent = await readRecentTenant();
+
+  return firstResolved([
+    ['link', initialUrl === null ? null : slugFromPath(pathOf(initialUrl))],
+    ['recent', recent],
+  ]);
+};
+
+/** A cold launch with no link resolves to `null`; a failure here must read the same way. */
+const readInitialUrl = async (): Promise<string | null> => {
+  try {
+    return await Linking.getInitialURL();
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * The path part of a deep link, however the link was spelled.
+ *
+ * `occasio://e/lila-and-sam` and `https://occasio.app/e/lila-and-sam` have to reach the same
+ * slug, and they parse differently: a custom scheme puts `e` in the host and `lila-and-sam` in
+ * the path. `Linking.parse` normalises that, and its `path` is returned without a leading slash,
+ * which `slugFromPath` would otherwise read as a first empty segment.
+ */
+const pathOf = (url: string): string => {
+  try {
+    const { path } = Linking.parse(url);
+    return path === null ? '' : `/${path}`;
+  } catch {
+    return '';
+  }
+};

--- a/apps/mobile/src/tenant/resolveTenant.web.ts
+++ b/apps/mobile/src/tenant/resolveTenant.web.ts
@@ -1,0 +1,44 @@
+import { slugForHost } from './customDomains';
+import { readRecentTenant } from './recentTenant';
+import { firstResolved, slugFromPath, type TenantResolution } from './tenantResolution';
+
+/**
+ * Web: hostname, then path, then where this browser was last.
+ *
+ * The hostname comes first because a custom domain is a stronger statement than anything else
+ * available — somebody typed `lila-and-sam.com`, and serving them the discover page because the
+ * path happened to be `/` would be the site failing to be its own site. ADR-0003 keeps this to a
+ * lookup: no pattern matching, no hostname anywhere in a route.
+ *
+ * The path is the canonical route (D9) and the one that always works. Storage is last and rarely
+ * reached — a browser has a URL — and exists for the person who opens the bare origin having
+ * been to an event before.
+ */
+export const resolveTenant = async (): Promise<TenantResolution> => {
+  const url = currentUrl();
+  const recent = await readRecentTenant();
+
+  return firstResolved([
+    ['domain', url === null ? null : slugForHost(url.hostname)],
+    ['path', url === null ? null : slugFromPath(url.pathname)],
+    ['recent', recent],
+  ]);
+};
+
+/**
+ * The two parts of the URL this cares about, or `null` where there is no URL.
+ *
+ * A static export's prerender runs with no DOM, so `globalThis.location` is absent and
+ * destructuring it throws. `lib.dom` types it as always present — an optional chain would be
+ * removed as dead code by the same lint rule that reads those types — so the absence is caught
+ * rather than tested for, and an absent location contributes no candidates instead of failing a
+ * render.
+ */
+const currentUrl = (): { hostname: string; pathname: string } | null => {
+  try {
+    const { hostname, pathname } = globalThis.location;
+    return { hostname, pathname };
+  } catch {
+    return null;
+  }
+};

--- a/apps/mobile/src/tenant/resolveTenantDomain.dom.test.tsx
+++ b/apps/mobile/src/tenant/resolveTenantDomain.dom.test.tsx
@@ -1,0 +1,39 @@
+/**
+ * @jest-environment-options {"url": "https://www.lila-and-sam.com/discover?utm=x"}
+ */
+import { describe, expect, it } from '@jest/globals';
+import { render, screen, waitFor } from '@testing-library/react';
+import { TenantProvider, useTenantResolution } from './TenantProvider';
+
+/**
+ * A custom domain, in its own file because the hostname is fixed when the environment is built —
+ * `window.location` cannot be reassigned in jsdom, which is also true of a real browser and is
+ * exactly why ADR-0003 keeps hostnames out of routing.
+ *
+ * The URL is chosen to be hostile to the check: a `www.` prefix, a path that names no event, and
+ * a query string. If the hostname does not win here, a custom domain serves the discover page,
+ * and the site fails to be its own site on the one address somebody paid for.
+ */
+
+const Probe = () => {
+  const resolution = useTenantResolution();
+  return (
+    <div data-testid="probe">
+      {resolution.kind === 'resolved' ? `${resolution.source}:${resolution.slug}` : resolution.kind}
+    </div>
+  );
+};
+
+describe('resolution on a custom domain', () => {
+  it('takes the hostname over a path that names no event', async () => {
+    render(
+      <TenantProvider>
+        <Probe />
+      </TenantProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('probe').textContent).toBe('domain:lila-and-sam');
+    });
+  });
+});

--- a/apps/mobile/src/tenant/resolveTenantPrecedence.dom.test.tsx
+++ b/apps/mobile/src/tenant/resolveTenantPrecedence.dom.test.tsx
@@ -1,0 +1,42 @@
+/**
+ * @jest-environment-options {"url": "https://lila-and-sam.com/e/harvest-lights/schedule"}
+ */
+import { describe, expect, it } from '@jest/globals';
+import { render, screen, waitFor } from '@testing-library/react';
+import { TenantProvider, useTenantResolution } from './TenantProvider';
+
+/**
+ * A URL where both sources answer, which is the only arrangement that can tell the order apart.
+ *
+ * The custom-domain test next door uses a path that names no event, so the path contributes
+ * nothing there and reversing the two would have changed no result — a test of precedence that
+ * did not test precedence. This one puts a different event in each.
+ *
+ * The hostname wins: somebody typed `lila-and-sam.com`, and a link they followed to a schedule
+ * inside another event does not overrule whose site they are on. It is also the direction that
+ * fails safely — a wrong hostname is a misconfigured domain somebody notices immediately,
+ * where a wrong path is a link that silently shows the wrong event.
+ */
+
+const Probe = () => {
+  const resolution = useTenantResolution();
+  return (
+    <div data-testid="probe">
+      {resolution.kind === 'resolved' ? `${resolution.source}:${resolution.slug}` : resolution.kind}
+    </div>
+  );
+};
+
+describe('when the hostname and the path name different events', () => {
+  it('takes the hostname', async () => {
+    render(
+      <TenantProvider>
+        <Probe />
+      </TenantProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('probe').textContent).toBe('domain:lila-and-sam');
+    });
+  });
+});

--- a/apps/mobile/src/tenant/tenantResolution.test.ts
+++ b/apps/mobile/src/tenant/tenantResolution.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from '@jest/globals';
-import { firstResolved, isSlug, slugFromPath } from './tenantResolution';
+import { firstResolved, isSlug, pathFromLink, slugFromPath } from './tenantResolution';
 
 /**
  * A slug from here becomes a path segment and then a repository argument, and it arrives from a
@@ -79,6 +79,73 @@ describe('slugFromPath', () => {
     /* `decodeURIComponent` throws on a lone `%`. A URL is attacker-supplied on web. */
     expect(slugFromPath('/e/%')).toBeNull();
     expect(slugFromPath('/e/%zz')).toBeNull();
+  });
+});
+
+describe('pathFromLink', () => {
+  /**
+   * The two spellings of the same deep link, which do not parse the same way. This is native's
+   * primary source, and the first version of the rule dropped the authority segment of a custom
+   * scheme — so `occasio://e/lila-and-sam` produced `/lila-and-sam`, matched no route, and the
+   * app fell through to storage or to the join screen. Silently, on the one path a person had
+   * just deliberately followed.
+   */
+  it('keeps the authority segment of a custom scheme, where it is really the first path segment', () => {
+    expect(pathFromLink({ scheme: 'occasio', hostname: 'e', path: 'lila-and-sam' })).toBe(
+      '/e/lila-and-sam',
+    );
+    expect(pathFromLink({ scheme: 'occasio', hostname: 'e', path: 'lila-and-sam/schedule' })).toBe(
+      '/e/lila-and-sam/schedule',
+    );
+  });
+
+  it('drops it for an http(s) link, where it is a real host', () => {
+    expect(pathFromLink({ scheme: 'https', hostname: 'occasio.app', path: 'e/lila-and-sam' })).toBe(
+      '/e/lila-and-sam',
+    );
+    expect(pathFromLink({ scheme: 'HTTP', hostname: 'occasio.app', path: 'e/x' })).toBe('/e/x');
+  });
+
+  it('reaches the same slug from either spelling', () => {
+    /* The property that matters, stated as one: a link is a link. */
+    const viaScheme = pathFromLink({ scheme: 'occasio', hostname: 'e', path: 'lila-and-sam' });
+    const viaHttps = pathFromLink({
+      scheme: 'https',
+      hostname: 'occasio.app',
+      path: 'e/lila-and-sam',
+    });
+
+    expect(slugFromPath(viaScheme)).toBe('lila-and-sam');
+    expect(slugFromPath(viaScheme)).toBe(slugFromPath(viaHttps));
+  });
+
+  it('handles a triple-slash custom scheme, where the authority is empty', () => {
+    /* `occasio:///e/lila-and-sam` is legal and puts everything in the path. Prepending an empty
+       hostname would produce a leading empty segment. */
+    expect(pathFromLink({ scheme: 'occasio', hostname: '', path: 'e/lila-and-sam' })).toBe(
+      '/e/lila-and-sam',
+    );
+    expect(pathFromLink({ scheme: 'occasio', hostname: null, path: 'e/lila-and-sam' })).toBe(
+      '/e/lila-and-sam',
+    );
+  });
+
+  it('produces a canonical path, with no doubled slashes', () => {
+    /*
+     * `slugFromPath` discards empty segments anyway, so this changes no outcome today — which
+     * is exactly why it is pinned here. The function's contract is a path, and a link that ends
+     * at the authority (`occasio://e`) is the shape that would otherwise start producing `/e/`
+     * the day something else reads this value.
+     */
+    expect(pathFromLink({ scheme: 'occasio', hostname: 'e', path: '' })).toBe('/e');
+    expect(pathFromLink({ scheme: 'https', hostname: 'occasio.app', path: '' })).toBe('/');
+  });
+
+  it('answers a bare slash when the link carries nothing', () => {
+    /* `slugFromPath` reads that as no tenant, which is the right answer for a link that names
+       no event — an app opened by its icon, say. */
+    expect(pathFromLink({})).toBe('/');
+    expect(slugFromPath(pathFromLink({}))).toBeNull();
   });
 });
 

--- a/apps/mobile/src/tenant/tenantResolution.test.ts
+++ b/apps/mobile/src/tenant/tenantResolution.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from '@jest/globals';
+import { firstResolved, isSlug, slugFromPath } from './tenantResolution';
+
+/**
+ * A slug from here becomes a path segment and then a repository argument, and it arrives from a
+ * hostname map, a URL somebody can edit, or this device's own storage. So the cases below lean
+ * toward rejecting: a slug wrongly refused lands on the join screen, which a person can recover
+ * from, and one wrongly accepted is a request built out of whatever was in a URL.
+ */
+
+describe('isSlug', () => {
+  it('accepts the shape the routes actually use', () => {
+    for (const slug of ['lila-and-sam', 'harvest-lights', 'dev-summit-2026', 'a', 'a1']) {
+      expect([slug, isSlug(slug)]).toEqual([slug, true]);
+    }
+  });
+
+  it('refuses anything that would not survive being a path segment', () => {
+    const refused = [
+      '',
+      '..',
+      '.',
+      'a/b',
+      'a b',
+      'a%2fb',
+      'Lila-And-Sam',
+      '-leading',
+      'trailing-',
+      'double--hyphen',
+      'a?b=c',
+      'a#b',
+      'a.b',
+      '../../etc/passwd',
+      'a'.repeat(65),
+    ];
+    for (const value of refused) {
+      expect([value, isSlug(value)]).toEqual([value, false]);
+    }
+  });
+
+  it('accepts the longest slug that is still in range', () => {
+    /* The boundary in both directions, so an off-by-one in the length check cannot hide. */
+    expect(isSlug('a'.repeat(64))).toBe(true);
+  });
+});
+
+describe('slugFromPath', () => {
+  it('reads the canonical route', () => {
+    expect(slugFromPath('/e/lila-and-sam')).toBe('lila-and-sam');
+    expect(slugFromPath('/e/lila-and-sam/schedule')).toBe('lila-and-sam');
+    expect(slugFromPath('/e/lila-and-sam/schedule/s-42')).toBe('lila-and-sam');
+  });
+
+  it('tolerates the spellings a router and a deep link produce', () => {
+    expect(slugFromPath('e/lila-and-sam')).toBe('lila-and-sam');
+    expect(slugFromPath('//e//lila-and-sam//')).toBe('lila-and-sam');
+    expect(slugFromPath('/e/lila-and-sam/')).toBe('lila-and-sam');
+  });
+
+  it('answers null for the routes that are deliberately not tenant routes', () => {
+    /* `/join` and `/discover` live outside `/e/` on purpose, so this is the right reading of
+       them rather than a failure to parse. */
+    expect(slugFromPath('/')).toBeNull();
+    expect(slugFromPath('/discover')).toBeNull();
+    expect(slugFromPath('/join')).toBeNull();
+    expect(slugFromPath('/events/lila-and-sam')).toBeNull();
+    expect(slugFromPath('/e')).toBeNull();
+    expect(slugFromPath('/e/')).toBeNull();
+  });
+
+  it('decodes before deciding, so an encoded traversal cannot look like a slug', () => {
+    /* `%2e%2e` is `..`, which passes a naive character check and is not a slug at all. */
+    expect(slugFromPath('/e/%2e%2e')).toBeNull();
+    expect(slugFromPath('/e/%2e%2e%2f%2e%2e')).toBeNull();
+    expect(slugFromPath('/e/lila%2Dand%2Dsam')).toBe('lila-and-sam');
+  });
+
+  it('answers null for a malformed escape rather than throwing', () => {
+    /* `decodeURIComponent` throws on a lone `%`. A URL is attacker-supplied on web. */
+    expect(slugFromPath('/e/%')).toBeNull();
+    expect(slugFromPath('/e/%zz')).toBeNull();
+  });
+});
+
+describe('firstResolved', () => {
+  it('takes the first source that has an answer, and records which it was', () => {
+    expect(
+      firstResolved([
+        ['domain', null],
+        ['path', 'lila-and-sam'],
+        ['recent', 'harvest-lights'],
+      ]),
+    ).toEqual({ kind: 'resolved', slug: 'lila-and-sam', source: 'path' });
+  });
+
+  it('keeps the order it is given, because the order is the policy', () => {
+    /* A deep link the person just followed beats where they were last week. Reversing these two
+       is a product decision, and it should have to be written at the call site to happen. */
+    expect(
+      firstResolved([
+        ['link', 'harvest-lights'],
+        ['recent', 'lila-and-sam'],
+      ]),
+    ).toMatchObject({ slug: 'harvest-lights', source: 'link' });
+  });
+
+  it('skips a candidate that is not a slug rather than stopping at it', () => {
+    /* Storage holding rubbish must not shadow a perfectly good path. Returning `unresolved` on
+       the first bad value would let a stale key blank out the URL the person is looking at. */
+    expect(
+      firstResolved([
+        ['recent', '../../etc/passwd'],
+        ['path', 'lila-and-sam'],
+      ]),
+    ).toMatchObject({ slug: 'lila-and-sam', source: 'path' });
+  });
+
+  it('is unresolved when nothing answers', () => {
+    expect(firstResolved([])).toEqual({ kind: 'unresolved' });
+    expect(
+      firstResolved([
+        ['domain', null],
+        ['path', null],
+      ]),
+    ).toEqual({ kind: 'unresolved' });
+  });
+});

--- a/apps/mobile/src/tenant/tenantResolution.ts
+++ b/apps/mobile/src/tenant/tenantResolution.ts
@@ -1,0 +1,106 @@
+/**
+ * Where the current event comes from, before anything is fetched.
+ *
+ * D9 makes `/e/[slug]/…` the canonical route forever, and ADR-0003 is explicit that a hostname
+ * is never a routing concern inside the app — no bundler has a `Host` header, and custom
+ * domains are an edge rewrite plus a lookup table in every stack there is. So the app's job is
+ * narrower than "work out the tenant": it is to turn whatever the platform can tell it into a
+ * slug, or to say honestly that it cannot.
+ *
+ * The two platforms have nothing in common here. Web has a URL and reads the hostname, then the
+ * path. Native has no URL bar at all, so it reads the deep link it was opened with, then the
+ * last event this device visited. One abstraction, two implementations — and this file is the
+ * half that belongs to neither, so it can be tested without a platform.
+ */
+
+/**
+ * How a slug was arrived at.
+ *
+ * Kept on the resolved state rather than discarded because the answer to "what now" differs by
+ * source: a slug from a custom domain that turns out not to exist is a misconfigured domain,
+ * and the same slug typed into a path is a typo. #40 is where that distinction is spent.
+ */
+export type TenantSource = 'domain' | 'path' | 'link' | 'recent';
+
+/**
+ * Resolution as a union rather than a slug plus flags.
+ *
+ * `{ slug: string | null, loading: boolean }` admits four combinations, two of which are
+ * nonsense — resolved-and-loading, and not-loading-with-no-slug-and-no-explanation — and the
+ * screens would each invent their own reading of them. Three states, and every one of them
+ * means exactly one thing.
+ */
+export type TenantResolution =
+  /** Still looking. Native reads storage asynchronously, so this is a real state, not a flicker. */
+  | { readonly kind: 'resolving' }
+  | { readonly kind: 'resolved'; readonly slug: string; readonly source: TenantSource }
+  /**
+   * Nothing to resolve from: a first native launch with no deep link and no history, or a web
+   * URL that names no event. Not an error — it is the state the join-by-code screen (#41) and
+   * the discover page (#42) exist to answer.
+   */
+  | { readonly kind: 'unresolved' };
+
+export const resolving: TenantResolution = { kind: 'resolving' };
+export const unresolved: TenantResolution = { kind: 'unresolved' };
+
+export const resolvedAs = (slug: string, source: TenantSource): TenantResolution => ({
+  kind: 'resolved',
+  slug,
+  source,
+});
+
+/**
+ * A slug is a path segment, so it has to survive being one.
+ *
+ * Rejecting rather than escaping: a slug arrives from a hostname map, a URL or this device's own
+ * storage, and every one of those can hold something that was never a slug — a stale key, a
+ * hand-edited link, a path traversal. Somewhere below this a slug is concatenated into a route
+ * and sent to a repository, and "looks like a slug" is the last point where that is cheap to
+ * insist on.
+ *
+ * Lowercase alphanumerics and single hyphens, 1–64 characters, no leading or trailing hyphen —
+ * what a URL-safe identifier looks like everywhere, and narrow enough that `..`, `%2e`, a slash
+ * and a query string are all outside it.
+ */
+const SLUG = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+export const isSlug = (value: string): boolean => value.length <= 64 && SLUG.test(value);
+
+/**
+ * The slug in a canonical path, if it is one.
+ *
+ * Only `/e/<slug>`, because D9 says that is the shape forever. A path this does not recognise is
+ * not a tenant route — the discover page and the join screen live outside `/e/` on purpose — so
+ * answering `null` is the correct reading rather than a failure to parse.
+ */
+export const slugFromPath = (pathname: string): string | null => {
+  const segments = pathname.split('/').filter((segment) => segment !== '');
+  const [prefix, slug] = segments;
+  if (prefix !== 'e' || slug === undefined) return null;
+  /* Percent-encoding is decoded before matching, so `%2e%2e` cannot arrive looking like a slug.
+     A malformed sequence throws rather than returning something half-decoded. */
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(slug);
+  } catch {
+    return null;
+  }
+  return isSlug(decoded) ? decoded : null;
+};
+
+/**
+ * The first source that produces a slug, in the order given.
+ *
+ * The order is the whole policy — a deep link the user just followed beats the event they
+ * happened to open last week — so it is expressed as a list at the call site rather than nested
+ * conditionals here, where it would be a paragraph to read instead of a line.
+ */
+export const firstResolved = (
+  candidates: readonly (readonly [TenantSource, string | null])[],
+): TenantResolution => {
+  for (const [source, slug] of candidates) {
+    if (slug !== null && isSlug(slug)) return resolvedAs(slug, source);
+  }
+  return unresolved;
+};

--- a/apps/mobile/src/tenant/tenantResolution.ts
+++ b/apps/mobile/src/tenant/tenantResolution.ts
@@ -90,6 +90,47 @@ export const slugFromPath = (pathname: string): string | null => {
 };
 
 /**
+ * The parts a deep link is parsed into, which is all this needs to know about one.
+ *
+ * Named structurally rather than imported from expo-linking, so the rule below can be tested in
+ * a plain process — the module that does the parsing pulls in the native linking runtime, and a
+ * rule nobody can run is how the first version of it stayed wrong.
+ */
+export type LinkParts = {
+  readonly scheme?: string | null;
+  readonly hostname?: string | null;
+  readonly path?: string | null;
+};
+
+/** The schemes where the hostname is a host rather than the first segment of the path. */
+const WEB_SCHEMES = new Set(['http', 'https']);
+
+/**
+ * The canonical path a deep link is pointing at, whichever way it was spelled.
+ *
+ * These two have to reach the same event and do not parse the same way:
+ *
+ *     occasio://e/lila-and-sam          scheme occasio, hostname `e`,           path `lila-and-sam`
+ *     https://occasio.app/e/lila-and-sam  scheme https, hostname `occasio.app`, path `e/lila-and-sam`
+ *
+ * A custom scheme has no authority component, so what sits in that position is the first
+ * segment of the path and dropping it loses the `/e/` prefix — which is exactly what the first
+ * version of this did, leaving the deep link, native's *primary* source, silently unable to
+ * resolve anything. Under an `https` link the same field is a real host and has to go.
+ *
+ * The comment there claimed `Linking.parse` normalised the difference. It does not, and a
+ * comment asserting what the code does not do is worse than none: it is why nothing looked.
+ */
+export const pathFromLink = (parts: LinkParts): string => {
+  const scheme = (parts.scheme ?? '').toLowerCase();
+  const hostname = parts.hostname ?? '';
+  const path = parts.path ?? '';
+
+  const segments = WEB_SCHEMES.has(scheme) || hostname === '' ? [path] : [hostname, path];
+  return `/${segments.filter((segment) => segment !== '').join('/')}`;
+};
+
+/**
  * The first source that produces a slug, in the order given.
  *
  * The order is the whole policy — a deep link the user just followed beats the event they

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "@expo-google-fonts/sora": "^0.4.2",
         "@expo-google-fonts/work-sans": "^0.4.2",
         "@expo/metro-runtime": "~57.0.15",
+        "@react-native-async-storage/async-storage": "2.2.0",
         "@tanstack/react-query": "^5.102.8",
         "expo": "^57.0.20",
         "expo-constants": "~57.0.17",
@@ -4710,6 +4711,18 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz",
+      "integrity": "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==",
+      "license": "MIT",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.65 <1.0"
       }
     },
     "node_modules/@react-native-masked-view/masked-view": {
@@ -10212,6 +10225,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
@@ -11826,6 +11848,18 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
       "license": "MIT"
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",


### PR DESCRIPTION
Closes #39. The first piece of v0.2 — nothing else in the milestone can be built until a screen can say which event it is showing.

The platforms share nothing here. Web has a URL and reads the hostname, then the path. Native has no URL bar at all, so it reads the deep link it was opened with, then the last event this device visited. Both arrive as the same union, so no screen ever learns which platform it is on — `resolveTenant.ts` and `resolveTenant.web.ts`, picked by Metro and Jest the way `ThemeScope` already is.

## Three states, not a slug and a flag

`{ slug: string | null, loading: boolean }` admits four combinations, two of them nonsense, and every screen would invent its own reading of them.

```ts
type TenantResolution =
  | { kind: 'resolving' }
  | { kind: 'resolved'; slug: string; source: TenantSource }
  | { kind: 'unresolved' }
```

`unresolved` is not an error — a first native launch with no deep link is the ordinary case, and it is what the join screen (#41) and the discover page (#42) exist to answer. The resolved state keeps its **source**, because a slug from a custom domain that turns out not to exist is a misconfigured domain, while the same slug typed into a path is a typo. #40 is where that difference gets spent.

## Custom domains are a lookup and nothing else

ADR-0003 is explicit, so the fixture map is shaped to be replaced by a `tenant_domains` table without anything else moving. Hostnames normalise (case, port, `www.`); the app's own hostnames can never map to a tenant however the map is written; and a mapped value is checked against `isSlug` rather than trusted, because that map becomes a row an operator writes.

## Last visited persists per platform

`localStorage` on web, **`@react-native-async-storage/async-storage` on native — a new dependency**, at the version `expo install` pins for SDK 57. Flagging it explicitly: React Native has no storage of its own and the issue requires per-platform persistence, so something had to be added.

Both sides read through a `try`, because storage is not a variable: private mode throws on write, an embedded webview can have site data off, a prerender has no DOM at all. What comes back is validated before use — it was written by an older build and is about to become a path segment.

## Slugs are rejected, not escaped

They arrive from a hostname map, a URL somebody can edit, or this device's storage, and then get concatenated into a route. `slugFromPath` decodes percent-escapes **before** matching, so `%2e%2e` cannot pass a check that `..` would fail, and a malformed escape reads as no slug rather than throwing.

## Two mutation checks survived, and both were holes in my tests

Reporting these because they are the more useful half of the review:

- **Deleting the app-hostname guard changed nothing.** No app host is in the fixture map, so the guard never fired and the test was measuring the map rather than the guard. The lookup now takes its map as an argument and the test hands it a hostile one.
- **Swapping hostname and path precedence changed nothing.** The custom-domain test uses a path that names no event, so the path contributed nothing either way. A second fixed-URL environment now puts a *different* event in each, which is the only arrangement that can tell an order apart.

Both are now caught, along with slug validation, percent-decoding, the `isSlug` check on mapped values, the in-flight race guard, and the hook's outside-provider throw.

## Wiring

The root layout asks the platform once. `/e/[slug]` states the slug it already has rather than resolving again — otherwise every navigation into an event would pass through a `resolving` frame to arrive at a fact the URL had all along.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145VPJXGgJA9PWqeNXDr1DG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic tenant and event resolution for mobile and web.
  - Tenants can now be identified from custom domains, event URLs, deep links, or recently visited events.
  - Added support for remembering the most recently selected tenant across app sessions.
  - Added tenant context for displaying tenant-aware content throughout the app.
  - Added safeguards for invalid links, unavailable storage, and unresolved tenants.

- **Tests**
  - Added coverage for tenant lookup priority, domain handling, URL parsing, persistence, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->