### PR TITLE
feat(app): not-found and loading states for a tenant

### DIFF
--- a/apps/mobile/app/e/[slug]/_layout.tsx
+++ b/apps/mobile/app/e/[slug]/_layout.tsx
@@ -1,4 +1,6 @@
-import { Slot, useLocalSearchParams } from 'expo-router';
+import { Platform } from 'react-native';
+import { Slot, router, useLocalSearchParams } from 'expo-router';
+import { TenantGate } from '../../../src/tenant/TenantGate';
 import { TenantProvider } from '../../../src/tenant/TenantProvider';
 import { AppThemeProvider } from '../../../src/theme/AppThemeProvider';
 import { FIXTURE_TENANT_THEME } from '../../../src/theme/inputs';
@@ -18,13 +20,38 @@ import { FIXTURE_TENANT_THEME } from '../../../src/theme/inputs';
  * read. Resolution is asynchronous, so without this every navigation into an event would pass
  * through a `resolving` frame to arrive at a fact the URL had all along.
  */
+/**
+ * Where "no event here" leads, which is the one part of it the router owns.
+ *
+ * Web has a page listing events and native does not — it has a join-by-code screen, because a
+ * phone with no URL bar cannot be handed an address. `TenantGate` is told the label and the
+ * destination rather than working either out, which is what keeps it renderable in a test and,
+ * later, in the theme editor's preview.
+ */
+const wayOut =
+  Platform.OS === 'web'
+    ? {
+        label: 'Find your event',
+        go: () => {
+          router.replace('/discover');
+        },
+      }
+    : {
+        label: 'Enter your code',
+        go: () => {
+          router.replace('/join');
+        },
+      };
+
 export default function TenantLayout() {
   const { slug } = useLocalSearchParams<{ slug: string }>();
 
   return (
     <TenantProvider slug={slug}>
       <AppThemeProvider input={FIXTURE_TENANT_THEME}>
-        <Slot />
+        <TenantGate onLeave={wayOut.go} leaveLabel={wayOut.label}>
+          <Slot />
+        </TenantGate>
       </AppThemeProvider>
     </TenantProvider>
   );

--- a/apps/mobile/src/data/hooks.ts
+++ b/apps/mobile/src/data/hooks.ts
@@ -8,7 +8,8 @@ import type {
 } from '@occasio/data';
 import type { GossipPostId, TenantId } from '@occasio/core';
 import { useMutation, useQuery, useQueryClient, type UseQueryResult } from '@tanstack/react-query';
-import type { Page, Session, Venue, GossipPost, Announcement } from '@occasio/data';
+import { isNotFoundError } from '@occasio/data';
+import type { Page, Session, Tenant, Venue, GossipPost, Announcement } from '@occasio/data';
 import { useAdapter } from './AdapterProvider';
 import { queryKeys } from './queryKeys';
 
@@ -24,6 +25,31 @@ import { queryKeys } from './queryKeys';
  * an ambient fact, and the moment it becomes ambient is the moment two open events start
  * borrowing each other's data.
  */
+
+/**
+ * The event behind a slug — the one lookup that happens before there is a tenant to scope to.
+ *
+ * Retries are deliberately narrowed. The root layout asks for two, which is right for a phone on
+ * venue wifi and wrong here: a mistyped slug is the first thing anyone will hit, and a
+ * `NotFoundError` is a settled answer rather than a bad connection. Retrying it means three
+ * round trips of a spinner before somebody is told the address is wrong.
+ */
+export const useTenantBySlug = (slug: string | null): UseQueryResult<Tenant> => {
+  const adapter = useAdapter();
+  return useQuery({
+    queryKey: queryKeys.directory.bySlug(slug ?? ''),
+    queryFn: () => adapter.directory.bySlug(slug ?? ''),
+    /* `null` is "no slug yet", which is a state and not a lookup. Without this the gate would
+       ask the directory for the empty string every time resolution had not finished — a request
+       whose only possible answer is an error, cached under a key nothing will ever want. */
+    enabled: slug !== null && slug !== '',
+    retry: (failureCount, error) => !isNotFoundError(error) && failureCount < 2,
+    /* A tenant's name and theme do not change while somebody is looking at the page, and this
+       result gates every screen under /e/[slug] — so it is kept long enough that moving between
+       events and back does not put a loading state in front of a page that is already known. */
+    staleTime: 5 * 60_000,
+  });
+};
 
 export const useSessions = (
   tenantId: TenantId,

--- a/apps/mobile/src/tenant/TenantGate.dom.test.tsx
+++ b/apps/mobile/src/tenant/TenantGate.dom.test.tsx
@@ -1,0 +1,150 @@
+import { userId } from '@occasio/core';
+import { createMockAdapter, createMemoryStorage, FIXTURE_SEED } from '@occasio/data';
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { ThemeProvider } from '@occasio/ui';
+import { AdapterProvider } from '../data/AdapterProvider';
+import { APP_THEME } from '../theme/inputs';
+import { TenantContext } from './TenantProvider';
+import { TenantGate } from './TenantGate';
+import { resolvedAs, resolving, unresolved, type TenantResolution } from './tenantResolution';
+
+/**
+ * A mistyped slug is the first thing anyone will hit, so the screen it produces is the one worth
+ * rendering rather than reasoning about.
+ *
+ * The resolution is supplied directly instead of going through `TenantProvider`, so each case
+ * is one state and nothing else — the provider's own behaviour is tested next door.
+ *
+ * `ThemeProvider` rather than `AppThemeProvider`: the app's wrapper loads tenant fonts through
+ * expo-font, which is ESM and not stubbed for jsdom. The gate needs a theme, not a font loader.
+ */
+
+const clients: QueryClient[] = [];
+
+const renderGate = (resolution: TenantResolution) => {
+  const adapter = createMockAdapter({
+    currentUserId: userId('u_meera'),
+    seed: FIXTURE_SEED,
+    storage: createMemoryStorage(),
+    latency: { minMs: 0, maxMs: 0 },
+  });
+  /* Retries off and no collection timer, for the reasons hooks.dom.test.tsx gives: a retried
+     failure reports as a timeout, and a timer outliving the test keeps a handle open. */
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: Infinity } },
+  });
+  clients.push(client);
+
+  const onLeave = jest.fn();
+  const Wrapper = ({ children }: { readonly children: ReactNode }) => (
+    <QueryClientProvider client={client}>
+      <AdapterProvider adapter={adapter}>
+        <ThemeProvider input={APP_THEME} forceScheme="light">
+          <TenantContext.Provider value={resolution}>{children}</TenantContext.Provider>
+        </ThemeProvider>
+      </AdapterProvider>
+    </QueryClientProvider>
+  );
+
+  render(
+    <Wrapper>
+      <TenantGate onLeave={onLeave} leaveLabel="Find your event">
+        <div data-testid="event">the event</div>
+      </TenantGate>
+    </Wrapper>,
+  );
+
+  return { client, onLeave };
+};
+
+describe('TenantGate', () => {
+  afterEach(() => {
+    for (const client of clients.splice(0)) client.clear();
+  });
+
+  it('renders the event once its tenant loads', async () => {
+    renderGate(resolvedAs('sanit-riyanks', 'path'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('event')).toBeTruthy();
+    });
+  });
+
+  it('says the event does not exist, and offers a way out', async () => {
+    /* A link read off a printed invitation with a character dropped. Being told a request
+       failed helps nobody: the address is wrong and only leaving fixes it. */
+    const { onLeave } = renderGate(resolvedAs('no-such-event', 'path'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('tenant-not-found')).toBeTruthy();
+    });
+    expect(screen.getByText(/No such event/)).toBeTruthy();
+    /* The slug is quoted back, because "check the link" is useless without saying which link. */
+    expect(screen.getByText(/no-such-event/)).toBeTruthy();
+
+    screen.getByText('Find your event').click();
+    expect(onLeave).toHaveBeenCalledTimes(1);
+  });
+
+  it('offers the same way out when nothing identified an event at all', async () => {
+    const { onLeave } = renderGate(unresolved);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('tenant-unresolved')).toBeTruthy();
+    });
+    screen.getByText('Find your event').click();
+    expect(onLeave).toHaveBeenCalledTimes(1);
+  });
+
+  it('paints nothing at all in the first moments of a wait', () => {
+    /*
+     * The anti-flash requirement, from the side that matters: at the instant a load begins there
+     * must be no skeleton, no spinner and no layout — otherwise every fast answer costs the page
+     * a visible jump on the way to content that was about to arrive anyway.
+     */
+    renderGate(resolving);
+
+    expect(screen.queryByTestId('tenant-loading')).toBeNull();
+    expect(screen.queryByTestId('event')).toBeNull();
+  });
+
+  it('does not flash a loading state for a tenant already in the cache', async () => {
+    /*
+     * The requirement in #40's own words. Rendered twice against one client: the second render
+     * has the answer already, so it must reach the content without passing through a loading
+     * branch at all — not "quickly", but never.
+     */
+    const first = renderGate(resolvedAs('sanit-riyanks', 'path'));
+    await waitFor(() => {
+      expect(screen.getByTestId('event')).toBeTruthy();
+    });
+
+    render(
+      <QueryClientProvider client={first.client}>
+        <AdapterProvider
+          adapter={createMockAdapter({
+            currentUserId: userId('u_meera'),
+            seed: FIXTURE_SEED,
+            storage: createMemoryStorage(),
+            latency: { minMs: 0, maxMs: 0 },
+          })}
+        >
+          <ThemeProvider input={APP_THEME} forceScheme="light">
+            <TenantContext.Provider value={resolvedAs('sanit-riyanks', 'path')}>
+              <TenantGate onLeave={() => undefined} leaveLabel="Find your event">
+                <div data-testid="cached-event">the event</div>
+              </TenantGate>
+            </TenantContext.Provider>
+          </ThemeProvider>
+        </AdapterProvider>
+      </QueryClientProvider>,
+    );
+
+    /* Synchronously, on the first render — no `waitFor`, which would hide the flash it is
+       supposed to be proving does not happen. */
+    expect(screen.getByTestId('cached-event')).toBeTruthy();
+  });
+});

--- a/apps/mobile/src/tenant/TenantGate.tsx
+++ b/apps/mobile/src/tenant/TenantGate.tsx
@@ -1,0 +1,113 @@
+import { isNotFoundError } from '@occasio/data';
+import { Button, EmptyState, Screen, Skeleton, SkeletonGroup } from '@occasio/ui';
+import type { ReactNode } from 'react';
+import { useTenantBySlug } from '../data/hooks';
+import { useTenantResolution } from './TenantProvider';
+import { useDeferredFlag } from './useDeferredFlag';
+
+/**
+ * Everything under `/e/[slug]` waits here until there is an event to show, or an answer about
+ * why there is not.
+ *
+ * A mistyped slug is the first thing anyone will hit — a link read off a printed invitation, a
+ * character dropped in a message — so "no such event" is a first-class screen rather than an
+ * error boundary, and it has a way out. Somebody who has typed the wrong address is not helped
+ * by being told a request failed.
+ *
+ * Pure of the router, per this repo's conventions: the layout above hands in `onLeave`, and this
+ * decides only *whether* to offer a way out, never where it goes. That is also what makes the
+ * whole thing renderable in a test and, later, in the theme editor's preview.
+ */
+
+/** Long enough that a cached or quick answer never paints a spinner, short enough to feel honest. */
+const SPINNER_DELAY_MS = 250;
+
+type Props = {
+  /** Where the way out goes. Discover on web, join-by-code on native — the layout knows which. */
+  readonly onLeave: () => void;
+  readonly leaveLabel: string;
+  readonly children: ReactNode;
+};
+
+export function TenantGate({ onLeave, leaveLabel, children }: Props) {
+  const resolution = useTenantResolution();
+  const slug = resolution.kind === 'resolved' ? resolution.slug : null;
+
+  /*
+   * Held disabled until there is a slug — `enabled` inside the hook, rather than an early return
+   * here, because a hook cannot be called conditionally. The query's own cache is what makes a
+   * revisit instant, and what keeps the loading branch below unreached on the way back.
+   */
+  const tenant = useTenantBySlug(slug);
+  const pending = resolution.kind === 'resolving' || (slug !== null && tenant.isPending);
+  const showSpinner = useDeferredFlag(pending, SPINNER_DELAY_MS);
+
+  if (pending) {
+    /*
+     * Nothing at all for the first quarter second. A cached tenant never reaches this branch —
+     * TanStack answers from the cache and `isPending` is false on the first render — and a fast
+     * fetch reaches it and leaves it before the timer, so neither flashes. What used to be the
+     * default, a spinner rendered the instant a query starts, is the flicker itself.
+     */
+    return showSpinner ? (
+      <Screen testID="tenant-loading">
+        <SkeletonGroup label="Loading this event">
+          <Skeleton width="60%" height={32} />
+          <Skeleton width="90%" height={20} />
+          <Skeleton width="80%" height={20} />
+        </SkeletonGroup>
+      </Screen>
+    ) : null;
+  }
+
+  if (slug === null) {
+    /* Nothing identified an event: a first native launch, or the bare origin on web. Not an
+       error, and the same way out serves it. */
+    return (
+      <Screen testID="tenant-unresolved">
+        <EmptyState
+          title="No event yet"
+          message="Open the link you were sent, or find your event to get started."
+          action={<Button label={leaveLabel} onPress={onLeave} />}
+        />
+      </Screen>
+    );
+  }
+
+  if (tenant.isError) {
+    const missing = isNotFoundError(tenant.error);
+
+    /*
+     * Two different failures wearing one screen would be a lie in one of the two cases. A
+     * mistyped address is the person's to fix and retrying it will never work; a request that
+     * failed is ours, and retrying is the entire remedy. So they differ in what they say and in
+     * which control they offer.
+     */
+    return (
+      <Screen testID={missing ? 'tenant-not-found' : 'tenant-error'}>
+        <EmptyState
+          title={missing ? 'No such event' : 'Could not load this event'}
+          message={
+            missing
+              ? `Nothing lives at “${slug}”. Check the link you were sent — it is easy to lose a character.`
+              : 'Something went wrong reaching this event. It may be the connection.'
+          }
+          action={
+            missing ? (
+              <Button label={leaveLabel} onPress={onLeave} />
+            ) : (
+              <Button
+                label="Try again"
+                onPress={() => {
+                  void tenant.refetch();
+                }}
+              />
+            )
+          }
+        />
+      </Screen>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/apps/mobile/src/tenant/useDeferredFlag.dom.test.tsx
+++ b/apps/mobile/src/tenant/useDeferredFlag.dom.test.tsx
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { act, renderHook } from '@testing-library/react';
+import { useDeferredFlag } from './useDeferredFlag';
+
+/**
+ * The whole value of this hook is what it does *not* render, which is invisible to every other
+ * kind of test. Fake timers make the two edges checkable exactly: nothing before the delay,
+ * something after it, and nothing at all when the wait ends first.
+ */
+
+describe('useDeferredFlag', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('shows nothing while the wait is still short', () => {
+    const { result } = renderHook(() => useDeferredFlag(true, 250));
+
+    expect(result.current).toBe(false);
+
+    act(() => {
+      jest.advanceTimersByTime(249);
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it('shows once the wait has gone on long enough to be worth admitting', () => {
+    const { result } = renderHook(() => useDeferredFlag(true, 250));
+
+    act(() => {
+      jest.advanceTimersByTime(250);
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it('never shows for a wait that ends before the delay', () => {
+    /* The flash this exists to prevent: a fast fetch that would otherwise paint a spinner and
+       remove it a frame later, so the only thing anybody notices is the page moving. */
+    const { rerender, result } = renderHook(({ active }) => useDeferredFlag(active, 250), {
+      initialProps: { active: true },
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+    rerender({ active: false });
+
+    expect(result.current).toBe(false);
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    /* The cancelled timer must not fire later and light up a spinner over content that has
+       already arrived. */
+    expect(result.current).toBe(false);
+  });
+
+  it('hides immediately, without waiting out a second delay', () => {
+    /* Only the rising edge is deferred. Holding a spinner on after the answer arrives would be
+       adding the delay this hook exists to remove. */
+    const { rerender, result } = renderHook(({ active }) => useDeferredFlag(active, 250), {
+      initialProps: { active: true },
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+    expect(result.current).toBe(true);
+
+    rerender({ active: false });
+    expect(result.current).toBe(false);
+  });
+
+  it('defers again on a second wait rather than staying on from the first', () => {
+    const { rerender, result } = renderHook(({ active }) => useDeferredFlag(active, 250), {
+      initialProps: { active: true },
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+    rerender({ active: false });
+    rerender({ active: true });
+
+    expect(result.current).toBe(false);
+
+    act(() => {
+      jest.advanceTimersByTime(250);
+    });
+    expect(result.current).toBe(true);
+  });
+});

--- a/apps/mobile/src/tenant/useDeferredFlag.ts
+++ b/apps/mobile/src/tenant/useDeferredFlag.ts
@@ -1,0 +1,48 @@
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * A flag that only becomes true once it has stayed true for long enough to be worth showing.
+ *
+ * A loading state that appears and disappears inside a frame or two is worse than no loading
+ * state: the page moves for no reason, and what somebody notices is the flicker rather than the
+ * content that arrived. A cached tenant never reaches the loading branch at all — that is
+ * TanStack's doing, not this hook's — but a fast fetch does, and it is the one that flashes.
+ *
+ * Only the rising edge is delayed. Going false is immediate, because the reason to stop showing
+ * a spinner is that the answer arrived, and holding it a moment longer to satisfy a timer would
+ * be adding the delay this exists to remove.
+ */
+export const useDeferredFlag = (active: boolean, delayMs: number): boolean => {
+  const [shown, setShown] = useState(false);
+  /* Held in a ref so a caller passing a literal cannot restart the timer on every render. */
+  const delay = useRef(delayMs);
+  delay.current = delayMs;
+
+  useEffect(() => {
+    if (!active) {
+      setShown(false);
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      setShown(true);
+    }, delay.current);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [active]);
+
+  /*
+   * `active` gates the result as well as the timer: a flag that has gone false must stop being
+   * shown on *that* render, not one render later when the effect runs. Without it there is a
+   * single frame where the spinner is painted over content that has already arrived — which is
+   * the flash this hook exists to remove, arriving at the other end.
+   *
+   * Not separately covered by a test, and worth saying rather than implying: React runs effects
+   * before `rerender` returns under `act`, so the stale frame the conjunct removes is invisible
+   * to anything @testing-library can observe. Deleting it passes the suite. It is kept on the
+   * reasoning above, not on a green run.
+   */
+  return active && shown;
+};


### PR DESCRIPTION
Closes #40.

A mistyped slug is the first thing anyone will hit — a link read off a printed invitation, a character dropped in a message. So "no such event" is a screen with a way out rather than an error boundary: being told a request failed helps nobody whose address is simply wrong, and retrying is the one thing that can never work.

`TenantGate` sits under `/e/[slug]` and renders one of four things — the event, a themed not-found quoting the slug back, a retryable error, or nothing yet.

It holds no router. The layout hands it a label and a destination, which is what keeps it renderable in a test and, later, in the theme editor's preview. Web sends people to discover, native to join-by-code, because a phone with no URL bar cannot be handed an address.

## A not-found is not retried

The root layout asks for two retries — right for a phone on venue wifi, wrong for a settled answer. Left alone it would put three round trips of spinner in front of somebody before telling them the link is wrong.

## The loading state does not flash, in the strong sense

Two different mechanisms, because there are two different cases:

- **A cached tenant never reaches the loading branch.** TanStack answers from the cache and `isPending` is false on the first render, so the content appears synchronously. Asserted **without `waitFor`** — using it would have hidden the very flash the test is supposed to disprove.
- **A fast fetch does reach it**, and `useDeferredFlag` renders nothing for the first 250ms, so it leaves again before anything is painted.

Only the rising edge is deferred. Hiding is immediate, because holding a spinner after the answer arrives would be adding back the delay this removes.

## Verification

| mutation | result |
|---|---|
| show the spinner immediately | 1 test fails |
| treat a not-found as a generic error | 1 test fails |
| drop the way out | 1 test fails |
| retry a not-found | 1 test fails |

**One guard is deliberately not covered, and I'd rather say so than imply otherwise.** The `active &&` conjunct in `useDeferredFlag` stops a stale spinner painting for one frame after content arrives. React runs effects before `rerender` returns under `act`, so that frame is invisible to anything @testing-library can observe — deleting the conjunct passes the suite. It is kept on the reasoning, which is written at the line, rather than on a green run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145VPJXGgJA9PWqeNXDr1DG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added tenant-aware event access using event slugs.
  - Event pages now show loading placeholders while tenant details are resolved.
  - Added clear handling for unresolved or unavailable events, with options to retry or leave.
  - Added platform-specific navigation: web users return to Discover, while native users continue to Join.
  - Reduced loading flicker by delaying transient loading indicators.

- **Tests**
  - Added coverage for tenant loading, error states, navigation actions, caching, and deferred loading behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->