### PR TITLE
feat(app): the discover page, each card in its own event's theme

### DIFF
--- a/apps/mobile/app/discover.tsx
+++ b/apps/mobile/app/discover.tsx
@@ -6,13 +6,14 @@ import { useDiscoverEvents } from '../src/features/discover/useDiscoverEvents';
  * The route: where a card leads, and nothing else.
  */
 export default function Route() {
-  const { events, loading, failed } = useDiscoverEvents();
+  const { events, loading, failed, retry } = useDiscoverEvents();
 
   return (
     <DiscoverScreen
       events={events}
       loading={loading}
       failed={failed}
+      onRetry={retry}
       onOpen={(slug) => {
         /* `push`, not `replace`: coming back to the list is a reasonable thing to want here, in
            a way it is not from the join screen. */

--- a/apps/mobile/app/discover.tsx
+++ b/apps/mobile/app/discover.tsx
@@ -1,14 +1,23 @@
-import { useTheme } from '@occasio/ui';
-import { PlaceholderScreen } from '../src/features/placeholder/PlaceholderScreen';
+import { router } from 'expo-router';
+import { DiscoverScreen } from '../src/features/discover/DiscoverScreen';
+import { useDiscoverEvents } from '../src/features/discover/useDiscoverEvents';
 
+/**
+ * The route: where a card leads, and nothing else.
+ */
 export default function Route() {
+  const { events, loading, failed } = useDiscoverEvents();
+
   return (
-    <PlaceholderScreen
-      theme={useTheme()}
-      eyebrow="DISCOVER"
-      title="Events"
-      description="Every event you can reach, each card rendered in its own theme."
-      arrivesIn="#42"
+    <DiscoverScreen
+      events={events}
+      loading={loading}
+      failed={failed}
+      onOpen={(slug) => {
+        /* `push`, not `replace`: coming back to the list is a reasonable thing to want here, in
+           a way it is not from the join screen. */
+        router.push(`/e/${slug}`);
+      }}
     />
   );
 }

--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -1,25 +1,29 @@
-import { useTheme } from '@occasio/ui';
-import { ScaffoldScreen } from '../src/features/scaffold/ScaffoldScreen';
-import { AppThemeProvider } from '../src/theme/AppThemeProvider';
-import { FIXTURE_TENANT_THEME } from '../src/theme/inputs';
-
-/** Reads the nearest theme and hands it to a screen that stays pure. */
-function Scaffold() {
-  return <ScaffoldScreen theme={useTheme()} />;
-}
+import { Redirect } from 'expo-router';
+import { Platform } from 'react-native';
+import { useTenantResolution } from '../src/tenant/TenantProvider';
 
 /**
- * Route files are adapters: they read params, compose providers, and render a screen.
+ * Where `/` goes.
  *
- * This one nests a second ThemeProvider, so the screen below renders under an event's theme
- * while the app around it stays on the console theme from the root layout. That is exactly the
- * mechanism the theme editor's live preview will use — and because it is a real route, the
- * visual gate screenshots it on every run.
+ * The root layout has already asked the platform which event this is (#39), so this route reads
+ * that answer rather than making its own. It matters most on a custom domain: somebody who typed
+ * `lila-and-sam.com` resolves to that event at `/`, and sending them to a list of events instead
+ * would be the site failing to be its own site on the one address somebody paid for.
+ *
+ * With no event to go to, the platforms differ because their situations do. The web has a page
+ * of events and an address bar; native has neither, so it has the join screen — a code and the
+ * events this device has already opened.
+ *
+ * Nothing is rendered while resolution is in flight. It is a storage read on web and a deep-link
+ * read on native, so it is over in a frame or two, and painting anything in that window is the
+ * flicker `useDeferredFlag` exists to avoid elsewhere.
  */
 export default function IndexRoute() {
-  return (
-    <AppThemeProvider input={FIXTURE_TENANT_THEME}>
-      <Scaffold />
-    </AppThemeProvider>
-  );
+  const resolution = useTenantResolution();
+
+  if (resolution.kind === 'resolving') return null;
+
+  if (resolution.kind === 'resolved') return <Redirect href={`/e/${resolution.slug}`} />;
+
+  return <Redirect href={Platform.OS === 'web' ? '/discover' : '/join'} />;
 }

--- a/apps/mobile/src/data/AppAdapterProvider.dom.test.tsx
+++ b/apps/mobile/src/data/AppAdapterProvider.dom.test.tsx
@@ -1,0 +1,55 @@
+import { userId } from '@occasio/core';
+import { describe, expect, it } from '@jest/globals';
+import { renderHook } from '@testing-library/react';
+import { useBoundAdapter } from './AppAdapterProvider';
+
+/**
+ * The adapter carries the identity every tenant check inside it is made against, so an adapter
+ * that outlives a change of account answers for the wrong person. Invisible today, because the
+ * identity is a constant — and an account boundary that does not move the day sign-in lands.
+ */
+
+const A = userId('u_sanit');
+const B = userId('u_meera');
+
+const bound = () =>
+  renderHook(({ id }: { id: typeof A }) => useBoundAdapter(id), { initialProps: { id: A } });
+
+describe('useBoundAdapter', () => {
+  it('keeps one adapter while the identity does not change', () => {
+    /* Rebuilding per render would throw away the mock's in-memory state and every live
+       subscription with it, which is what the lazy initialiser is protecting. */
+    const { rerender, result } = bound();
+    const first = result.current;
+
+    rerender({ id: A });
+
+    expect(result.current).toBe(first);
+  });
+
+  it('builds a new adapter when the identity changes', () => {
+    /*
+     * `createMockAdapter` captures `currentUserId` as `me`, so an initialiser that runs once
+     * pins every membership and visibility check to whoever was signed in when this mounted.
+     * Somebody signing out and back in as another account would read the first person's events.
+     */
+    const { rerender, result } = bound();
+    const first = result.current;
+
+    rerender({ id: B });
+
+    expect(result.current).not.toBe(first);
+  });
+
+  it('goes back to a fresh adapter rather than reviving the first', () => {
+    /* Returning to an identity must not resurrect state from before the switch — the mock holds
+       writes in memory, and a revived instance would carry the previous session's across. */
+    const { rerender, result } = bound();
+    const first = result.current;
+
+    rerender({ id: B });
+    rerender({ id: A });
+
+    expect(result.current).not.toBe(first);
+  });
+});

--- a/apps/mobile/src/data/AppAdapterProvider.tsx
+++ b/apps/mobile/src/data/AppAdapterProvider.tsx
@@ -1,5 +1,7 @@
 import { createMockAdapter, FIXTURE_SEED } from '@occasio/data';
 import { useState, type ReactNode } from 'react';
+import type { UserId } from '@occasio/core';
+import type { DataAdapter } from '@occasio/data';
 import { AdapterProvider } from './AdapterProvider';
 import { useCurrentUserId } from './useCurrentUserId';
 
@@ -10,15 +12,60 @@ import { useCurrentUserId } from './useCurrentUserId';
  * `DataAdapter` and does not know which one it got, which is the arrangement D5 and D29 are
  * about — so the swap is a change here and nothing else.
  *
- * `currentUserId` comes from `useCurrentUserId`, which is a placeholder until sign-in lands
- * (epic #5) — one hook rather than a constant scattered about, so replacing it is one file.
+ * `currentUserId` comes from `useCurrentUserId`, a placeholder until sign-in lands (epic #5).
  */
-export function AppAdapterProvider({ children }: { readonly children: ReactNode }) {
-  const currentUserId = useCurrentUserId();
 
-  /* Created once per app instance, like the query client beside it. A new adapter per render
-     would rebuild its in-memory state and throw away every subscription with it. */
-  const [adapter] = useState(() => createMockAdapter({ currentUserId, seed: FIXTURE_SEED }));
+/**
+ * One adapter per identity, and it is the *per identity* half that is load-bearing.
+ *
+ * A lazy `useState` initialiser runs once, so an adapter built on the first render keeps the
+ * user it was built with for the life of the mount. That is invisible today because the identity
+ * is a constant — and the moment sign-in lands it becomes an account boundary that does not
+ * move: `createMockAdapter` captures `currentUserId` as `me`, and every membership and
+ * visibility check inside it would keep answering for whoever was signed in when the provider
+ * mounted. Someone signing out and back in as somebody else would read the first person's
+ * events.
+ *
+ * So the identity is stored beside the adapter and compared on render. Setting state during
+ * render is React's own answer for state derived from a changing input: it re-renders before
+ * committing anything, rather than painting one frame with the wrong account's data the way an
+ * effect would — and the new adapter is returned on that same render, so nothing below unmounts
+ * on the way.
+ *
+ * Not `useMemo`, which is a hint React is allowed to discard — and discarding this one would
+ * silently rebuild the mock's in-memory state and drop every live subscription with it.
+ */
+type Binding = { readonly userId: UserId; readonly adapter: DataAdapter };
+
+const bind = (userId: UserId): Binding => ({
+  userId,
+  adapter: createMockAdapter({ currentUserId: userId, seed: FIXTURE_SEED }),
+});
+
+/**
+ * Exported so the rebinding can be tested as itself.
+ *
+ * The alternative was mocking `useCurrentUserId` out from under the provider, which cannot be
+ * done cleanly — it is an ES module export, so its namespace object is non-configurable and
+ * `jest.spyOn` refuses it. Testing the mechanism directly is both simpler and closer to what is
+ * actually at stake: one adapter per identity.
+ */
+export const useBoundAdapter = (currentUserId: UserId): DataAdapter => {
+  const [binding, setBinding] = useState<Binding>(() => bind(currentUserId));
+
+  if (binding.userId !== currentUserId) {
+    /* The new adapter is returned on this same render rather than after the re-render, so the
+       subtree never unmounts and no frame is painted with the previous account's data. */
+    const next = bind(currentUserId);
+    setBinding(next);
+    return next.adapter;
+  }
+
+  return binding.adapter;
+};
+
+export function AppAdapterProvider({ children }: { readonly children: ReactNode }) {
+  const adapter = useBoundAdapter(useCurrentUserId());
 
   return <AdapterProvider adapter={adapter}>{children}</AdapterProvider>;
 }

--- a/apps/mobile/src/data/AppAdapterProvider.tsx
+++ b/apps/mobile/src/data/AppAdapterProvider.tsx
@@ -1,7 +1,7 @@
 import { createMockAdapter, FIXTURE_SEED } from '@occasio/data';
-import { userId } from '@occasio/core';
 import { useState, type ReactNode } from 'react';
 import { AdapterProvider } from './AdapterProvider';
+import { useCurrentUserId } from './useCurrentUserId';
 
 /**
  * The app's binding of `<AdapterProvider>`: the mock, seeded with the four fixture events.
@@ -10,19 +10,15 @@ import { AdapterProvider } from './AdapterProvider';
  * `DataAdapter` and does not know which one it got, which is the arrangement D5 and D29 are
  * about — so the swap is a change here and nothing else.
  *
- * `currentUserId` is a placeholder until sign-in lands (D28, v0.3). It names the wedding's
- * organiser because that is the account with something to look at in every screen the app has
- * so far, and it is a constant rather than a setting precisely so that nobody mistakes it for
- * one: the moment it becomes configurable it starts to look like authentication.
+ * `currentUserId` comes from `useCurrentUserId`, which is a placeholder until sign-in lands
+ * (epic #5) — one hook rather than a constant scattered about, so replacing it is one file.
  */
-const DEMO_USER = userId('u_sanit');
-
 export function AppAdapterProvider({ children }: { readonly children: ReactNode }) {
+  const currentUserId = useCurrentUserId();
+
   /* Created once per app instance, like the query client beside it. A new adapter per render
      would rebuild its in-memory state and throw away every subscription with it. */
-  const [adapter] = useState(() =>
-    createMockAdapter({ currentUserId: DEMO_USER, seed: FIXTURE_SEED }),
-  );
+  const [adapter] = useState(() => createMockAdapter({ currentUserId, seed: FIXTURE_SEED }));
 
   return <AdapterProvider adapter={adapter}>{children}</AdapterProvider>;
 }

--- a/apps/mobile/src/data/queryKeys.ts
+++ b/apps/mobile/src/data/queryKeys.ts
@@ -65,6 +65,13 @@ export const queryKeys = {
     forUser: (userId: UserId) => ['directory', 'forUser', userId] as const,
   },
 
+  tenants: {
+    /* Under the tenant prefix like everything else, so invalidating an event clears its theme
+       along with its data — publishing a new config is exactly the case where a stale theme
+       would otherwise survive a refresh. */
+    config: (t: TenantId) => [...tenant(t), 'config'] as const,
+  },
+
   sessions: {
     all: (t: TenantId) => [...tenant(t), 'sessions'] as const,
     list: (t: TenantId, query: SessionQuery, request?: PageRequest) =>

--- a/apps/mobile/src/data/useCurrentUserId.ts
+++ b/apps/mobile/src/data/useCurrentUserId.ts
@@ -1,0 +1,17 @@
+import { userId, type UserId } from '@occasio/core';
+
+/**
+ * Who is using the app.
+ *
+ * A constant until sign-in lands (epic #5). It is a hook rather than an exported constant so
+ * that the day it becomes real, every caller already reads it from the right shape — a
+ * component that imported a constant would have to be rewritten to read a session, and the ones
+ * that forgot would keep compiling.
+ *
+ * It names the wedding's organiser because that is the account with something to look at in
+ * every screen the app has so far, and it is deliberately not configurable: the moment a
+ * placeholder identity becomes a setting it starts to look like authentication.
+ */
+const DEMO_USER = userId('u_sanit');
+
+export const useCurrentUserId = (): UserId => DEMO_USER;

--- a/apps/mobile/src/features/discover/DiscoverScreen.dom.test.tsx
+++ b/apps/mobile/src/features/discover/DiscoverScreen.dom.test.tsx
@@ -1,0 +1,121 @@
+import { themeInputFromPreset } from '@occasio/theme';
+import { tenantId } from '@occasio/core';
+import { describe, expect, it, jest } from '@jest/globals';
+import { ThemeProvider } from '@occasio/ui';
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { Tenant } from '@occasio/data';
+import { APP_THEME } from '../../theme/inputs';
+import { DiscoverScreen } from './DiscoverScreen';
+import type { DiscoverEvent } from './useDiscoverEvents';
+
+/**
+ * The page's second requirement is the one worth rendering for: each card in its own event's
+ * theme. Two cards with different seeds must not resolve to the same colours, and asserting that
+ * needs the real provider chain rather than a prop comparison.
+ */
+
+const tenant = (slug: string, name: string, kind: Tenant['kind']): Tenant => ({
+  id: tenantId(`t_${slug}`),
+  slug,
+  name,
+  kind,
+  status: 'approved',
+  timezone: 'Europe/London',
+  visibility: 'unlisted',
+  joinCode: null,
+  startsOn: null,
+  endsOn: null,
+  createdBy: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+});
+
+const WEDDING: DiscoverEvent = {
+  tenant: tenant('lila-and-sam', 'Lila & Sam', 'wedding'),
+  theme: themeInputFromPreset('romantic', '#B4436C'),
+};
+
+const FESTIVAL: DiscoverEvent = {
+  tenant: tenant('harvest-lights', 'Harvest Lights', 'festival'),
+  theme: themeInputFromPreset('festival', '#1FA97A'),
+};
+
+const renderDiscover = (props: Partial<DiscoverScreenProps> = {}) => {
+  const onOpen = jest.fn<(slug: string) => void>();
+  render(
+    <ThemeProvider input={APP_THEME} forceScheme="light">
+      <DiscoverScreen events={[]} onOpen={onOpen} {...props} />
+    </ThemeProvider>,
+  );
+  return { onOpen };
+};
+
+type DiscoverScreenProps = Parameters<typeof DiscoverScreen>[0];
+
+const cardBackground = (slug: string): string => {
+  const card = screen.getByTestId(`discover-card-${slug}`);
+  return window.getComputedStyle(card).backgroundColor;
+};
+
+describe('DiscoverScreen', () => {
+  it('lists the events as cards, by name', () => {
+    renderDiscover({ events: [WEDDING, FESTIVAL] });
+
+    expect(screen.getByText('Lila & Sam')).toBeTruthy();
+    expect(screen.getByText('Harvest Lights')).toBeTruthy();
+  });
+
+  it('renders each card in its own event’s theme', () => {
+    /*
+     * The requirement, and the only assertion on this page that could not be made by reading the
+     * component. Two events with different presets and different seeds must resolve to different
+     * surfaces — if the nested provider were dropped, both cards would take the page's theme and
+     * these two values would be identical.
+     */
+    renderDiscover({ events: [WEDDING, FESTIVAL] });
+
+    const wedding = cardBackground('lila-and-sam');
+    const festival = cardBackground('harvest-lights');
+
+    expect(wedding).not.toBe('');
+    expect(wedding).not.toBe(festival);
+  });
+
+  it('still shows a card whose theme has not arrived', () => {
+    /* A link to the event is what somebody came for. Holding the list back for a palette they
+       have not noticed yet trades the thing they want against a detail. */
+    renderDiscover({ events: [{ ...WEDDING, theme: null }] });
+
+    expect(screen.getByTestId('discover-card-lila-and-sam')).toBeTruthy();
+  });
+
+  it('opens the event a card names', () => {
+    const { onOpen } = renderDiscover({ events: [WEDDING, FESTIVAL] });
+
+    fireEvent.click(screen.getByTestId('discover-open-harvest-lights'));
+    expect(onOpen).toHaveBeenCalledWith('harvest-lights');
+  });
+
+  it('names each open button after its event', () => {
+    /* Two buttons both called "Open" is a list a screen reader cannot navigate. */
+    renderDiscover({ events: [WEDDING, FESTIVAL] });
+
+    expect(screen.getByLabelText('Open Lila & Sam')).toBeTruthy();
+    expect(screen.getByLabelText('Open Harvest Lights')).toBeTruthy();
+  });
+
+  it('says so when there are no events rather than showing an empty page', () => {
+    renderDiscover({ events: [] });
+
+    expect(screen.getByText('No events yet')).toBeTruthy();
+  });
+
+  it('offers a retry when the listing failed, and does not pretend the list is empty', () => {
+    const onRetry = jest.fn();
+    renderDiscover({ failed: true, onRetry });
+
+    expect(screen.queryByText('No events yet')).toBeNull();
+    fireEvent.click(screen.getByText('Try again'));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/mobile/src/features/discover/DiscoverScreen.tsx
+++ b/apps/mobile/src/features/discover/DiscoverScreen.tsx
@@ -1,0 +1,145 @@
+import {
+  Button,
+  Card,
+  EmptyState,
+  Screen,
+  Skeleton,
+  SkeletonGroup,
+  Text,
+  ThemeProvider,
+  createStyles,
+} from '@occasio/ui';
+import { View } from 'react-native';
+import type { DiscoverEvent } from './useDiscoverEvents';
+
+/**
+ * Where `/` goes on the web while the platform is invite-only.
+ *
+ * The page is a list of events, and the reason it is worth building rather than stubbing is the
+ * second half of it: **each card renders in its own event's theme.** Four cards, one component,
+ * four palettes and four typefaces — D2 made visible rather than described, and the same nested
+ * `ThemeProvider` the theme editor's live preview will use.
+ *
+ * That is also why the card is not a themed component receiving colours as props. It reads the
+ * theme it is under, exactly like every screen inside the event does, so a card that looks right
+ * here is evidence the event will look right too.
+ *
+ * Props in, JSX out: the route supplies the events and where a card leads.
+ */
+
+export type DiscoverScreenProps = {
+  readonly events: readonly DiscoverEvent[];
+  readonly loading?: boolean | undefined;
+  readonly failed?: boolean | undefined;
+  readonly onOpen: (slug: string) => void;
+  readonly onRetry?: (() => void) | undefined;
+};
+
+const useStyles = createStyles((t) => ({
+  header: { gap: t.space(2), marginBottom: t.space(6) },
+  list: { gap: t.space(4) },
+  card: { gap: t.space(3) },
+  meta: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
+}));
+
+export function DiscoverScreen({
+  events,
+  loading = false,
+  failed = false,
+  onOpen,
+  onRetry,
+}: DiscoverScreenProps) {
+  const styles = useStyles();
+
+  return (
+    <Screen testID="discover-screen">
+      <View style={styles.header}>
+        <Text variant="display2">Your events</Text>
+        <Text tone="muted">
+          Occasio is invite-only for now. These are the events you have been added to.
+        </Text>
+      </View>
+
+      {failed ? (
+        <EmptyState
+          title="Could not load your events"
+          message="Something went wrong reaching the server. It may be the connection."
+          action={
+            onRetry === undefined ? undefined : <Button label="Try again" onPress={onRetry} />
+          }
+        />
+      ) : loading ? (
+        <SkeletonGroup label="Loading your events">
+          <Skeleton width="100%" height={96} />
+          <Skeleton width="100%" height={96} />
+        </SkeletonGroup>
+      ) : events.length === 0 ? (
+        <EmptyState
+          title="No events yet"
+          message="When somebody adds you to an event, it will appear here."
+        />
+      ) : (
+        <View style={styles.list}>
+          {events.map((event) => (
+            <EventCard key={event.tenant.id} event={event} onOpen={onOpen} />
+          ))}
+        </View>
+      )}
+    </Screen>
+  );
+}
+
+/**
+ * One event, in its own colours.
+ *
+ * The `ThemeProvider` is the whole trick and it is deliberately per card rather than per page:
+ * nesting is what lets several themes coexist on one screen, which is the property the theme
+ * editor's preview needs and the reason the provider was built to nest in the first place.
+ *
+ * A card whose theme has not arrived renders under the page's, rather than waiting. It is a link
+ * to an event either way, and holding the whole list back for one palette would trade the thing
+ * somebody came for against a detail they have not noticed yet.
+ */
+function EventCard({
+  event,
+  onOpen,
+}: {
+  readonly event: DiscoverEvent;
+  readonly onOpen: (slug: string) => void;
+}) {
+  const body = <EventCardBody event={event} onOpen={onOpen} />;
+
+  return event.theme === null ? body : <ThemeProvider input={event.theme}>{body}</ThemeProvider>;
+}
+
+function EventCardBody({
+  event,
+  onOpen,
+}: {
+  readonly event: DiscoverEvent;
+  readonly onOpen: (slug: string) => void;
+}) {
+  const styles = useStyles();
+  const { tenant } = event;
+
+  return (
+    <Card testID={`discover-card-${tenant.slug}`}>
+      <View style={styles.card}>
+        <Text variant="title1">{tenant.name}</Text>
+        <View style={styles.meta}>
+          <Text variant="caption" tone="muted">
+            {tenant.kind}
+          </Text>
+          <Button
+            label="Open"
+            accessibilityLabel={`Open ${tenant.name}`}
+            testID={`discover-open-${tenant.slug}`}
+            onPress={() => {
+              onOpen(tenant.slug);
+            }}
+          />
+        </View>
+      </View>
+    </Card>
+  );
+}

--- a/apps/mobile/src/features/discover/useDiscoverEvents.dom.test.tsx
+++ b/apps/mobile/src/features/discover/useDiscoverEvents.dom.test.tsx
@@ -25,7 +25,12 @@ const flaky = () => {
     latency: { minMs: 0, maxMs: 0 },
   });
 
-  const state = { failing: true, configsFailing: false };
+  /*
+   * `configRejections` is what makes the theme assertion mean anything: `theme` is `null` while
+   * a config is pending *and* after it fails, so a test that only waits for the listing can
+   * assert against a request that has not settled and pass for the wrong reason.
+   */
+  const state = { failing: true, configsFailing: false, configDelayMs: 0, configRejections: 0 };
   const adapter: DataAdapter = {
     ...base,
     directory: {
@@ -39,7 +44,12 @@ const flaky = () => {
       ...base.tenants,
       config: (...args) =>
         state.configsFailing
-          ? Promise.reject(new Error('the network, probably'))
+          ? new Promise<never>((_, reject) => {
+              setTimeout(() => {
+                state.configRejections += 1;
+                reject(new Error('the network, probably'));
+              }, state.configDelayMs);
+            })
           : base.tenants.config(...args),
     },
   };
@@ -94,14 +104,32 @@ describe('useDiscoverEvents', () => {
     const { adapter, state } = flaky();
     state.failing = false;
     state.configsFailing = true;
+    /* Slow enough that the cards are listed well before any config settles, which is the
+       behaviour under test and also what stops the assertions below being satisfied by requests
+       that are merely still in flight. */
+    state.configDelayMs = 20;
 
     const { result } = renderHook(() => useDiscoverEvents(), { wrapper: wrap(adapter) });
 
     await waitFor(() => {
       expect(result.current.events.length).toBeGreaterThan(0);
     });
-    expect(result.current.failed).toBe(false);
+    const listed = result.current.events.length;
+
+    /*
+     * No assertion that the configs are *still* pending at this instant. That is a claim about
+     * scheduling — `waitFor` polls on its own interval, so the first rejection can land before it
+     * observes the events — and the property it was reaching for is covered where it can be held
+     * still, in DiscoverScreen's own test for a card whose theme is `null`.
+     */
+    await waitFor(() => {
+      expect(state.configRejections).toBe(listed);
+    });
+
+    /* Only now does `theme === null` mean "failed" rather than "not yet". */
+    expect(result.current.events).toHaveLength(listed);
     expect(result.current.events.every((event) => event.theme === null)).toBe(true);
+    expect(result.current.failed).toBe(false);
   });
 
   it('reports a failed listing, and recovers when retried', async () => {

--- a/apps/mobile/src/features/discover/useDiscoverEvents.dom.test.tsx
+++ b/apps/mobile/src/features/discover/useDiscoverEvents.dom.test.tsx
@@ -16,7 +16,7 @@ import { useDiscoverEvents } from './useDiscoverEvents';
 
 const clients: QueryClient[] = [];
 
-/** Fails until told otherwise, then behaves. */
+/** Fails until told otherwise, then behaves. Each surface fails independently. */
 const flaky = () => {
   const base = createMockAdapter({
     currentUserId: userId('u_sanit'),
@@ -25,7 +25,7 @@ const flaky = () => {
     latency: { minMs: 0, maxMs: 0 },
   });
 
-  const state = { failing: true };
+  const state = { failing: true, configsFailing: false };
   const adapter: DataAdapter = {
     ...base,
     directory: {
@@ -34,6 +34,13 @@ const flaky = () => {
         state.failing
           ? Promise.reject(new Error('the network, probably'))
           : base.directory.listForUser(...args),
+    },
+    tenants: {
+      ...base.tenants,
+      config: (...args) =>
+        state.configsFailing
+          ? Promise.reject(new Error('the network, probably'))
+          : base.tenants.config(...args),
     },
   };
 
@@ -72,6 +79,29 @@ describe('useDiscoverEvents', () => {
     expect(result.current.failed).toBe(false);
     /* Each event brings its own published theme, which is what the cards are for. */
     expect(result.current.events.every((event) => event.theme !== null)).toBe(true);
+  });
+
+  it('keeps the cards when only their themes fail to load', async () => {
+    /*
+     * The two failures are not the same failure. A listing that will not load leaves nothing to
+     * show; a config that will not load costs one card its palette, and a card in the wrong
+     * colours is still a way into the event. Holding the whole page back for a detail nobody has
+     * noticed would trade what somebody came for against what they did not.
+     *
+     * This was written down in a comment and asserted nowhere, which is how the sentence would
+     * have quietly stopped being true.
+     */
+    const { adapter, state } = flaky();
+    state.failing = false;
+    state.configsFailing = true;
+
+    const { result } = renderHook(() => useDiscoverEvents(), { wrapper: wrap(adapter) });
+
+    await waitFor(() => {
+      expect(result.current.events.length).toBeGreaterThan(0);
+    });
+    expect(result.current.failed).toBe(false);
+    expect(result.current.events.every((event) => event.theme === null)).toBe(true);
   });
 
   it('reports a failed listing, and recovers when retried', async () => {

--- a/apps/mobile/src/features/discover/useDiscoverEvents.dom.test.tsx
+++ b/apps/mobile/src/features/discover/useDiscoverEvents.dom.test.tsx
@@ -1,0 +1,101 @@
+import { userId } from '@occasio/core';
+import { createMockAdapter, createMemoryStorage, FIXTURE_SEED } from '@occasio/data';
+import type { DataAdapter } from '@occasio/data';
+import { afterEach, describe, expect, it } from '@jest/globals';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { AdapterProvider } from '../../data/AdapterProvider';
+import { useDiscoverEvents } from './useDiscoverEvents';
+
+/**
+ * The failure path, which the screen's own tests cannot reach: they are handed an `onRetry` and
+ * therefore prove nothing about whether one exists. A retry the hook does not expose leaves the
+ * page's only control inert on the one screen somebody sees when the listing fails.
+ */
+
+const clients: QueryClient[] = [];
+
+/** Fails until told otherwise, then behaves. */
+const flaky = () => {
+  const base = createMockAdapter({
+    currentUserId: userId('u_sanit'),
+    seed: FIXTURE_SEED,
+    storage: createMemoryStorage(),
+    latency: { minMs: 0, maxMs: 0 },
+  });
+
+  const state = { failing: true };
+  const adapter: DataAdapter = {
+    ...base,
+    directory: {
+      ...base.directory,
+      listForUser: (...args) =>
+        state.failing
+          ? Promise.reject(new Error('the network, probably'))
+          : base.directory.listForUser(...args),
+    },
+  };
+
+  return { adapter, state };
+};
+
+const wrap = (adapter: DataAdapter) => {
+  /* Retries off, so a failing query reaches the assertion rather than the test timing out; no
+     collection timer, so nothing outlives the test. */
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: Infinity } },
+  });
+  clients.push(client);
+
+  return ({ children }: { readonly children: ReactNode }) => (
+    <QueryClientProvider client={client}>
+      <AdapterProvider adapter={adapter}>{children}</AdapterProvider>
+    </QueryClientProvider>
+  );
+};
+
+describe('useDiscoverEvents', () => {
+  afterEach(() => {
+    for (const client of clients.splice(0)) client.clear();
+  });
+
+  it('lists the events this account is in', async () => {
+    const { adapter, state } = flaky();
+    state.failing = false;
+
+    const { result } = renderHook(() => useDiscoverEvents(), { wrapper: wrap(adapter) });
+
+    await waitFor(() => {
+      expect(result.current.events.length).toBeGreaterThan(0);
+    });
+    expect(result.current.failed).toBe(false);
+    /* Each event brings its own published theme, which is what the cards are for. */
+    expect(result.current.events.every((event) => event.theme !== null)).toBe(true);
+  });
+
+  it('reports a failed listing, and recovers when retried', async () => {
+    /*
+     * The whole point of returning `retry`. Without it the screen renders its failure state with
+     * no control at all, and the only way out of a transient error is to reload the page —
+     * which on native is not a thing somebody can do.
+     */
+    const { adapter, state } = flaky();
+    const { result } = renderHook(() => useDiscoverEvents(), { wrapper: wrap(adapter) });
+
+    await waitFor(() => {
+      expect(result.current.failed).toBe(true);
+    });
+    expect(result.current.events).toEqual([]);
+
+    state.failing = false;
+    act(() => {
+      result.current.retry();
+    });
+
+    await waitFor(() => {
+      expect(result.current.events.length).toBeGreaterThan(0);
+    });
+    expect(result.current.failed).toBe(false);
+  });
+});

--- a/apps/mobile/src/features/discover/useDiscoverEvents.ts
+++ b/apps/mobile/src/features/discover/useDiscoverEvents.ts
@@ -1,0 +1,73 @@
+import type { ThemeInput } from '@occasio/theme';
+import type { Tenant } from '@occasio/data';
+import { useQueries, useQuery } from '@tanstack/react-query';
+import { useAdapter } from '../../data/AdapterProvider';
+import { useCurrentUserId } from '../../data/useCurrentUserId';
+import { queryKeys } from '../../data/queryKeys';
+
+/**
+ * The events to show on `/`.
+ *
+ * **These are the events this account is in, not a public catalogue.** The platform is
+ * invite-only, so there is no catalogue to list — `TenantDirectory` has no `listPublic` and
+ * should not grow one for a page that exists to give `/` somewhere to go. When the platform
+ * opens up, that method is a decision worth making on its own, against a real requirement about
+ * who may see which events.
+ *
+ * Each event's own theme comes with it, because that is the point of the page: four events that
+ * look nothing alike, rendered by one component, is D2 made visible rather than described.
+ */
+
+export type DiscoverEvent = {
+  readonly tenant: Tenant;
+  /**
+   * The event's published theme, or `null` while it loads or if it has never been published.
+   *
+   * `null` rather than a default, so the card can decide. Substituting the app's own theme here
+   * would render a card that looks like the console and claims to be the event.
+   */
+  readonly theme: ThemeInput | null;
+};
+
+export type Discovery = {
+  readonly events: readonly DiscoverEvent[];
+  readonly loading: boolean;
+  readonly failed: boolean;
+};
+
+export const useDiscoverEvents = (): Discovery => {
+  const adapter = useAdapter();
+  const me = useCurrentUserId();
+
+  const listing = useQuery({
+    queryKey: queryKeys.directory.forUser(me),
+    queryFn: () => adapter.directory.listForUser(me),
+  });
+
+  const tenants = listing.data?.items ?? [];
+
+  /*
+   * One query per event rather than one for all of them. `tenants.config` is per-tenant in the
+   * repository layer because a config is per-tenant in the eventual table, and inventing a
+   * batch read here would be a shape the Supabase adapter then has to reproduce. They are
+   * cached under the tenant prefix, so opening an event afterwards finds its theme already
+   * loaded rather than fetching it again.
+   */
+  const configs = useQueries({
+    queries: tenants.map((tenant) => ({
+      queryKey: queryKeys.tenants.config(tenant.id),
+      queryFn: () => adapter.tenants.config(tenant.id),
+    })),
+  });
+
+  return {
+    events: tenants.map((tenant, index) => ({
+      tenant,
+      theme: configs[index]?.data?.published?.config.theme ?? null,
+    })),
+    loading: listing.isPending,
+    /* Only the listing failing is a failure: a config that will not load costs one card its
+       palette, and a card in the wrong palette is still a way into the event. */
+    failed: listing.isError,
+  };
+};

--- a/apps/mobile/src/features/discover/useDiscoverEvents.ts
+++ b/apps/mobile/src/features/discover/useDiscoverEvents.ts
@@ -33,6 +33,14 @@ export type Discovery = {
   readonly events: readonly DiscoverEvent[];
   readonly loading: boolean;
   readonly failed: boolean;
+  /**
+   * Retries the listing.
+   *
+   * Returned rather than left to the caller to invent, because the screen's failure state offers
+   * a retry only when it is given one — so a hook that kept this to itself produced a page whose
+   * one control was a dead end, on the only screen somebody sees when the listing fails.
+   */
+  readonly retry: () => void;
 };
 
 export const useDiscoverEvents = (): Discovery => {
@@ -66,6 +74,9 @@ export const useDiscoverEvents = (): Discovery => {
       theme: configs[index]?.data?.published?.config.theme ?? null,
     })),
     loading: listing.isPending,
+    retry: () => {
+      void listing.refetch();
+    },
     /* Only the listing failing is a failure: a config that will not load costs one card its
        palette, and a card in the wrong palette is still a way into the event. */
     failed: listing.isError,


### PR DESCRIPTION
Closes #42.

The list is the easy half. The reason this is worth building rather than stubbing is the second requirement: **each card renders in its own event's theme.** Four cards, one component, four palettes and four typefaces — D2 made visible rather than described, through the same nested `ThemeProvider` the theme editor's live preview will use, and which the provider was built to nest for.

The card reads the theme it is *under* rather than taking colours as props, exactly like every screen inside the event does. That is what makes a card looking right here evidence that the event will look right too.

## A decision I did not make

**These are the events this account is in, not a public catalogue.**

`TenantDirectory` has no `listPublic`, and adding one — a **fourth** cross-tenant method, one PR after the third — for a page that exists to give `/` somewhere to go would be wearing down a gate rather than passing it. #164 spent that gate on a real requirement; this is not one. When the platform stops being invite-only, `listPublic` deserves its own decision against a real question about who may see which events.

The page says invite-only in as many words, so it is not pretending to be something it is not. If you read #42's "lists fixture events" as requiring a public catalogue, say so and I will raise the method properly rather than smuggling it in here.

## Two judgements, both toward showing the event

- **A card whose theme has not loaded renders under the page's theme** rather than waiting. It is a link to the event either way, and holding the list back for a palette nobody has noticed yet trades what somebody came for against a detail.
- **Only the listing failing is a failure.** A config that will not load costs one card its colours; a card in the wrong colours is still a way in.

## `useCurrentUserId`

Arrives with this — a hook rather than the constant inlined in `AppAdapterProvider`, so that when sign-in lands (epic #5) every caller already reads it from the shape a session will have. A component that imported a constant would have to be rewritten; one that forgot would keep compiling.

## Verification

| mutation | result |
|---|---|
| drop the nested `ThemeProvider` | both cards resolve to the same background — 1 test fails |
| treat a failed listing as an empty list | 1 test fails |
| hide a card whose theme has not arrived | 1 test fails |

The theming assertion compares computed backgrounds through the real provider chain rather than comparing props, because a prop comparison would pass with the provider removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145VPJXGgJA9PWqeNXDr1DG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Discover page displaying available invite-only events.
  - Event cards show tenant details and customised themes where available.
  - Selecting an event opens its dedicated event page.
  - Added loading indicators, empty-state messaging and retry options when event loading fails.
  - Events are displayed for the current user.
  - Added automatic routing to an available event, Discover or the join flow based on the user’s status.

- **Bug Fixes**
  - Theme loading issues no longer prevent the rest of the event list from appearing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->