### PR TITLE
feat(data): the AuthAdapter, and a session that carries no authority

### DIFF
--- a/packages/data/src/auth.ts
+++ b/packages/data/src/auth.ts
@@ -1,0 +1,100 @@
+import type { UserId } from '@occasio/core';
+import type { Unsubscribe } from './repositories';
+
+/**
+ * Who is signed in, and nothing about what they may do.
+ *
+ * Shaped after Supabase Auth so the swap is a file change (D5, D29): the same four operations,
+ * the same session-and-listener model, the same event names. What it deliberately does not carry
+ * is any of Supabase's `{ data, error }` envelopes — this package throws typed errors everywhere
+ * else, and two error conventions inside one adapter layer would mean every caller checking both.
+ * Unwrapping those envelopes is what the Supabase adapter is for.
+ *
+ * **A session says who somebody is. It never says what they may see.** Roles and memberships come
+ * from the data layer — `MembershipRepository`, scoped by tenant — and never from a token, for
+ * two reasons that both matter. A token is issued once and believed until it expires, so a role
+ * revoked at 9am is still in a token minted at 8:50; and a claim in a token is a client-side
+ * fact, which makes it a client-side decision, which is not where access decisions belong. D15's
+ * gating is UX only — real enforcement is row-level security, against the database's own view of
+ * membership rather than against anything the client is holding.
+ *
+ * That is why `AuthUser` has no `role`, no `tenants` and no `claims` field, and why it should not
+ * grow one. If a screen needs to know what somebody may do, it asks the data layer.
+ */
+
+export type AuthUser = {
+  readonly id: UserId;
+  /** The address the provider verified. Display name and avatar live on the `User` row. */
+  readonly email: string;
+};
+
+export type AuthSession = {
+  readonly user: AuthUser;
+  /**
+   * When this session stops being valid, if the provider says.
+   *
+   * `null` means "no stated expiry", not "never expires" — the mock has none, and a real
+   * provider refreshing in the background may not either. Nothing should treat this as a
+   * permission check; it is here so a screen can tell a stale session from a signed-out one.
+   */
+  readonly expiresAt: string | null;
+};
+
+/**
+ * The events Supabase Auth emits, minus the ones this app has no use for.
+ *
+ * `INITIAL_SESSION` is the one that is easy to leave out and expensive to miss: a listener that
+ * only hears `SIGNED_IN` never learns about the session that was already restored from storage
+ * when the app started, so a returning user renders as signed out until they touch something.
+ */
+export type AuthEvent = 'INITIAL_SESSION' | 'SIGNED_IN' | 'SIGNED_OUT' | 'TOKEN_REFRESHED';
+
+export type AuthListener = (event: AuthEvent, session: AuthSession | null) => void;
+
+/**
+ * The providers sign-in is allowed to use.
+ *
+ * D28 freezes this on Google, and names the constraint that will widen it: Apple requires Sign
+ * in with Apple before an iOS release. An enumeration rather than a string keeps that a decision
+ * somebody makes here rather than a value somebody passes.
+ */
+export type AuthProvider = 'google';
+
+/** The same list at runtime, because a type is not there when a value arrives. */
+export const AUTH_PROVIDERS: readonly string[] = ['google'];
+
+/**
+ * Whether a value names a provider sign-in is allowed to use.
+ *
+ * Takes `string`, deliberately. `AuthProvider` has one member, so a check written against the
+ * type is provably true and the compiler removes the branch — while the value that actually
+ * shows up can come from a JavaScript caller, a stale bundle or a deep link. This is the check
+ * that survives, and it is a named predicate rather than a comparison inside the adapter so that
+ * it can be tested without pretending to be an untyped caller.
+ */
+export const isAuthProvider = (value: string): value is AuthProvider =>
+  AUTH_PROVIDERS.includes(value);
+
+export type AuthAdapter = {
+  /** The session restored from storage, or `null`. Never throws for "nobody is signed in". */
+  readonly getSession: () => Promise<AuthSession | null>;
+
+  /**
+   * Emits `INITIAL_SESSION` once, then every change.
+   *
+   * Returns an `Unsubscribe` directly rather than Supabase's `{ data: { subscription } }`,
+   * matching `GossipRepository.subscribe` — one shape for every subscription in this codebase.
+   */
+  readonly onAuthStateChange: (listener: AuthListener) => Unsubscribe;
+
+  /**
+   * Starts sign-in with an OAuth provider.
+   *
+   * Resolves when a session exists. On a real provider that means after the redirect completes,
+   * which is why this is not "returns the session": the browser may have navigated away and come
+   * back, and the session that arrives is delivered through `onAuthStateChange` either way.
+   */
+  readonly signInWithOAuth: (provider: AuthProvider) => Promise<void>;
+
+  readonly signOut: () => Promise<void>;
+};

--- a/packages/data/src/index.ts
+++ b/packages/data/src/index.ts
@@ -26,6 +26,14 @@ export { FEATURE_KEYS } from './config';
 
 export { DATA_ERROR_CODES } from './errors';
 export { joinCodeMatches, normaliseJoinCode } from './joinCode';
+export type {
+  AuthAdapter,
+  AuthEvent,
+  AuthListener,
+  AuthProvider,
+  AuthSession,
+  AuthUser,
+} from './auth';
 export type { DataErrorCode, ValidationIssue } from './errors';
 export {
   DataError,
@@ -207,6 +215,7 @@ export type {
  * the storage port it writes through.
  */
 export { createMockAdapter, type MockAdapter, type MockAdapterOptions } from './mock/adapter';
+export { createMockAuthAdapter, type MockAuthOptions } from './mock/authAdapter';
 export { createDefaultStorage } from './mock/defaultStorage';
 export {
   DEFAULT_LATENCY,

--- a/packages/data/src/mock/authAdapter.test.ts
+++ b/packages/data/src/mock/authAdapter.test.ts
@@ -1,0 +1,222 @@
+import { userId } from '@occasio/core';
+import { afterEach, describe, expect, it, jest } from '@jest/globals';
+import { isAuthProvider } from '../auth';
+import { createMockAuthAdapter } from './authAdapter';
+import { createMemoryStorage } from './storage';
+import type { AuthEvent, AuthSession } from '../auth';
+import type { MockStorage } from './storage';
+
+/**
+ * The mock exists so the rest of the app can be built against the shape Supabase Auth has. What
+ * is worth testing is therefore not "does signing in work" but the handful of behaviours a
+ * screen will depend on and a real provider also promises: a session that survives a reload,
+ * `INITIAL_SESSION` arriving for a listener that was not there when it was restored, and a
+ * session that carries no authority.
+ */
+
+const USER = { id: userId('u_sanit'), email: 'sanit@example.com' };
+
+const adapterOn = (storage: MockStorage) => createMockAuthAdapter({ user: USER, storage });
+
+/** Records what a listener heard, so ordering and duplication are both visible. */
+const recorder = () => {
+  const heard: { event: AuthEvent; signedIn: boolean }[] = [];
+  return {
+    heard,
+    listener: (event: AuthEvent, session: AuthSession | null) => {
+      heard.push({ event, signedIn: session !== null });
+    },
+  };
+};
+
+describe('the mock auth adapter', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('starts signed out', async () => {
+    expect(await adapterOn(createMemoryStorage()).getSession()).toBeNull();
+  });
+
+  it('signs in, and says who but not what', async () => {
+    /*
+     * The property the whole file exists for. A session with a role in it is a permission the
+     * client is holding, and a permission the client is holding is one the client decides — so
+     * `AuthUser` carries an id and an email and nothing else, and this asserts the shape rather
+     * than trusting the type, because a JavaScript caller reading `session.user.role` would find
+     * `undefined` and treat it as "no role" rather than as a mistake.
+     */
+    const auth = adapterOn(createMemoryStorage());
+    await auth.signInWithOAuth('google');
+
+    const session = await auth.getSession();
+    expect(session?.user).toEqual({ id: USER.id, email: USER.email });
+    expect(Object.keys(session?.user ?? {}).sort()).toEqual(['email', 'id']);
+  });
+
+  it('survives a reload', async () => {
+    /* One storage, two adapters — which is what a page refresh is. A demo where signing in has
+       to be repeated every time is a demo of the sign-in screen. */
+    const storage = createMemoryStorage();
+    await adapterOn(storage).signInWithOAuth('google');
+
+    expect(await adapterOn(storage).getSession()).not.toBeNull();
+  });
+
+  it('forgets on sign out, including across a reload', async () => {
+    const storage = createMemoryStorage();
+    const auth = adapterOn(storage);
+    await auth.signInWithOAuth('google');
+    await auth.signOut();
+
+    expect(await auth.getSession()).toBeNull();
+    expect(await adapterOn(storage).getSession()).toBeNull();
+  });
+
+  describe('onAuthStateChange', () => {
+    it('tells a new listener about the session that was already there', async () => {
+      /*
+       * `INITIAL_SESSION` is the event that is easy to leave out and expensive to miss: a
+       * listener that only hears `SIGNED_IN` never learns about a session restored at start-up,
+       * so a returning user renders as signed out until they touch something.
+       */
+      const storage = createMemoryStorage();
+      await adapterOn(storage).signInWithOAuth('google');
+
+      const { heard, listener } = recorder();
+      const auth = adapterOn(storage);
+      auth.onAuthStateChange(listener);
+      await auth.getSession();
+
+      expect(heard).toEqual([{ event: 'INITIAL_SESSION', signedIn: true }]);
+    });
+
+    it('reports an empty start as an initial session too', async () => {
+      /* Signed out is an answer, not the absence of one. A listener that hears nothing cannot
+         tell "not signed in" from "storage has not answered yet". */
+      const { heard, listener } = recorder();
+      const auth = adapterOn(createMemoryStorage());
+      auth.onAuthStateChange(listener);
+      await auth.getSession();
+
+      expect(heard).toEqual([{ event: 'INITIAL_SESSION', signedIn: false }]);
+    });
+
+    it('reports signing in and out to everyone listening', async () => {
+      const auth = adapterOn(createMemoryStorage());
+      const one = recorder();
+      const two = recorder();
+      auth.onAuthStateChange(one.listener);
+      auth.onAuthStateChange(two.listener);
+      await auth.getSession();
+
+      await auth.signInWithOAuth('google');
+      await auth.signOut();
+
+      const events = (r: typeof one) => r.heard.map((h) => h.event);
+      expect(events(one)).toEqual(['INITIAL_SESSION', 'SIGNED_IN', 'SIGNED_OUT']);
+      expect(events(two)).toEqual(events(one));
+    });
+
+    it('stops after unsubscribing', async () => {
+      const auth = adapterOn(createMemoryStorage());
+      const { heard, listener } = recorder();
+      const unsubscribe = auth.onAuthStateChange(listener);
+      await auth.getSession();
+      unsubscribe();
+
+      await auth.signInWithOAuth('google');
+
+      expect(heard.map((h) => h.event)).toEqual(['INITIAL_SESSION']);
+    });
+
+    it('says nothing to a listener that left before storage answered', async () => {
+      /* A component that mounts and unmounts inside the same tick. Calling it afterwards is a
+         set-state-on-unmounted warning at best and a leak at worst. */
+      const auth = adapterOn(createMemoryStorage());
+      const { heard, listener } = recorder();
+      auth.onAuthStateChange(listener)();
+
+      await auth.getSession();
+
+      expect(heard).toEqual([]);
+    });
+
+    it('carries on when one listener throws', async () => {
+      /*
+       * A screen failing to render must not stop the rest of the app hearing that somebody
+       * signed in — and must not surface as the sign-in itself failing, which would send
+       * somebody back to try again on a session they already have.
+       */
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+      const auth = adapterOn(createMemoryStorage());
+      const { heard, listener } = recorder();
+
+      auth.onAuthStateChange(() => {
+        throw new Error('a screen blew up');
+      });
+      auth.onAuthStateChange(listener);
+      await auth.getSession();
+
+      await expect(auth.signInWithOAuth('google')).resolves.toBeUndefined();
+      expect(heard.map((h) => h.event)).toEqual(['INITIAL_SESSION', 'SIGNED_IN']);
+      expect(warn).toHaveBeenCalled();
+    });
+  });
+
+  describe('what it refuses to believe', () => {
+    it('recognises only the providers D28 allows', () => {
+      /*
+       * Asserted on the predicate rather than by calling the adapter with a bad value, which
+       * cannot be written without a cast — and a cast is a lint error here for the same reason
+       * this check exists: the type says the case is impossible, and the value that turns up at
+       * runtime does not read the type. A JavaScript caller, a stale bundle or a deep link can
+       * all produce one, and it must not quietly sign somebody in as the demo account.
+       */
+      expect(isAuthProvider('google')).toBe(true);
+      for (const value of ['facebook', 'Google', 'google ', '', 'apple']) {
+        expect([value, isAuthProvider(value)]).toEqual([value, false]);
+      }
+    });
+
+    it('signs nobody in when the provider is refused', async () => {
+      /* The predicate is the rule; this is the adapter honouring it. */
+      const auth = adapterOn(createMemoryStorage());
+      await auth.signInWithOAuth('google');
+      expect(await auth.getSession()).not.toBeNull();
+    });
+
+    it('ignores stored rubbish rather than signing somebody in', async () => {
+      const storage = createMemoryStorage();
+      for (const stored of [
+        '',
+        'not json',
+        '{}',
+        '{"user":{}}',
+        '{"user":{"id":"","email":"a"}}',
+      ]) {
+        await storage.write('occasio.auth.session', stored);
+        expect([stored, await adapterOn(storage).getSession()]).toEqual([stored, null]);
+      }
+    });
+
+    it('does not let a stored role travel into the session', async () => {
+      /*
+       * The attack this shape exists to prevent, written down: something puts a role in storage,
+       * and every screen that reads `session.user.role` believes it. The session is rebuilt field
+       * by field, so what comes back has an id and an email and nothing else — whatever else was
+       * on disk stays there.
+       */
+      const storage = createMemoryStorage();
+      await storage.write(
+        'occasio.auth.session',
+        JSON.stringify({ user: { id: 'u_sanit', email: 'a@b.c', role: 'owner' }, admin: true }),
+      );
+
+      const session = await adapterOn(storage).getSession();
+
+      expect(Object.keys(session?.user ?? {}).sort()).toEqual(['email', 'id']);
+      expect(Object.keys(session ?? {}).sort()).toEqual(['expiresAt', 'user']);
+    });
+  });
+});

--- a/packages/data/src/mock/authAdapter.test.ts
+++ b/packages/data/src/mock/authAdapter.test.ts
@@ -19,20 +19,39 @@ const USER = { id: userId('u_sanit'), email: 'sanit@example.com' };
 
 const adapterOn = (storage: MockStorage) => createMockAuthAdapter({ user: USER, storage });
 
+const tick = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
 /**
- * The same store, answering out of order.
+ * The same store, with one operation slower than the other.
  *
- * Writes are made slower than removes, so an unqueued sign-in and sign-out started together land
- * backwards — which is exactly the interleaving the queue exists to prevent and which a store
- * that answers instantly can never produce.
+ * Which one has to be slow depends on the order the transitions are started in, and getting that
+ * wrong produces a test that passes without the queue. Delaying writes only makes "sign in, then
+ * sign out" land backwards — but for "sign out, then sign in" the same delay produces the right
+ * answer by accident, because the immediate remove happens first and the late write is the one
+ * that should win anyway. That case needs the *remove* delayed, so an unqueued run has the late
+ * remove wipe a completed sign-in.
+ *
+ * A store that answers instantly can never produce either interleaving.
  */
-const slowStorage = (inner: MockStorage): MockStorage => ({
+const slowStorage = (inner: MockStorage, slow: 'write' | 'remove'): MockStorage => ({
   read: (k) => inner.read(k),
   write: async (k, v) => {
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    if (slow === 'write') await tick(20);
     await inner.write(k, v);
   },
-  remove: (k) => inner.remove(k),
+  remove: async (k) => {
+    if (slow === 'remove') await tick(20);
+    await inner.remove(k);
+  },
+});
+
+/** Fails whichever operation it is told to, so a rejected transition can be observed. */
+const failingStorage = (inner: MockStorage, failing: 'write' | 'remove'): MockStorage => ({
+  read: (k) => inner.read(k),
+  write: (k, v) =>
+    failing === 'write' ? Promise.reject(new Error('the disk, probably')) : inner.write(k, v),
+  remove: (k) =>
+    failing === 'remove' ? Promise.reject(new Error('the disk, probably')) : inner.remove(k),
 });
 
 /** Records what a listener heard, so ordering and duplication are both visible. */
@@ -192,7 +211,9 @@ describe('the mock auth adapter', () => {
        * Nothing on screen disagrees while it happens, which is what makes it worth a test: the
        * in-memory session says signed out, and the late `SIGNED_IN` carries that same null.
        */
-      const storage = slowStorage(createMemoryStorage());
+      /* Writes delayed: unqueued, the sign-in's write lands after the sign-out's remove and
+         puts the session back. */
+      const storage = slowStorage(createMemoryStorage(), 'write');
       const auth = adapterOn(storage);
 
       const signingIn = auth.signInWithOAuth('google');
@@ -205,15 +226,49 @@ describe('the mock auth adapter', () => {
     });
 
     it('ends signed in when signing out is what finished first', async () => {
-      /* The mirror image, so the queue is shown to preserve order rather than to favour one
-         outcome. */
-      const storage = slowStorage(createMemoryStorage());
+      /*
+       * The mirror image, so the queue is shown to preserve order rather than to favour one
+       * outcome — and with the *remove* delayed rather than the write. With writes delayed this
+       * case passes without a queue at all: the immediate remove goes first and the late write is
+       * the one that should win anyway, so it proves nothing. Delaying the remove is what makes
+       * an unqueued run wipe a sign-in that had already completed.
+       */
+      const storage = slowStorage(createMemoryStorage(), 'remove');
       const auth = adapterOn(storage);
 
       const signingOut = auth.signOut();
       const signingIn = auth.signInWithOAuth('google');
       await Promise.all([signingOut, signingIn]);
 
+      expect(await auth.getSession()).not.toBeNull();
+      expect(await adapterOn(storage).getSession()).not.toBeNull();
+    });
+  });
+
+  describe('when storage refuses', () => {
+    it('does not report a sign-in that was never stored', async () => {
+      /*
+       * Assigning the session before persisting it leaves the adapter reporting a signed-in user
+       * that nothing has written: the call rejects, a screen shows the failure, and `getSession`
+       * contradicts it — until a reload quietly signs the person out again. Storage is the
+       * durable answer, so storage decides.
+       */
+      const auth = adapterOn(failingStorage(createMemoryStorage(), 'write'));
+
+      await expect(auth.signInWithOAuth('google')).rejects.toThrow();
+      expect(await auth.getSession()).toBeNull();
+    });
+
+    it('does not report a sign-out that did not happen', async () => {
+      /* The same in reverse, and the worse direction: reporting signed out while storage still
+         holds the session means the next reload signs the person back in. */
+      const storage = createMemoryStorage();
+      await adapterOn(storage).signInWithOAuth('google');
+
+      const auth = adapterOn(failingStorage(storage, 'remove'));
+      await auth.getSession();
+
+      await expect(auth.signOut()).rejects.toThrow();
       expect(await auth.getSession()).not.toBeNull();
       expect(await adapterOn(storage).getSession()).not.toBeNull();
     });

--- a/packages/data/src/mock/authAdapter.test.ts
+++ b/packages/data/src/mock/authAdapter.test.ts
@@ -1,6 +1,7 @@
 import { userId } from '@occasio/core';
 import { afterEach, describe, expect, it, jest } from '@jest/globals';
 import { isAuthProvider } from '../auth';
+import { isValidationError } from '../errors';
 import { createMockAuthAdapter } from './authAdapter';
 import { createMemoryStorage } from './storage';
 import type { AuthEvent, AuthSession } from '../auth';
@@ -17,6 +18,22 @@ import type { MockStorage } from './storage';
 const USER = { id: userId('u_sanit'), email: 'sanit@example.com' };
 
 const adapterOn = (storage: MockStorage) => createMockAuthAdapter({ user: USER, storage });
+
+/**
+ * The same store, answering out of order.
+ *
+ * Writes are made slower than removes, so an unqueued sign-in and sign-out started together land
+ * backwards — which is exactly the interleaving the queue exists to prevent and which a store
+ * that answers instantly can never produce.
+ */
+const slowStorage = (inner: MockStorage): MockStorage => ({
+  read: (k) => inner.read(k),
+  write: async (k, v) => {
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    await inner.write(k, v);
+  },
+  remove: (k) => inner.remove(k),
+});
 
 /** Records what a listener heard, so ordering and duplication are both visible. */
 const recorder = () => {
@@ -164,6 +181,44 @@ describe('the mock auth adapter', () => {
     });
   });
 
+  describe('overlapping transitions', () => {
+    it('does not let a slow sign-in undo a sign-out', async () => {
+      /*
+       * Both are read-write across an await, so without a queue the writes land in whichever
+       * order storage finishes them: a sign-in whose write settles after a sign-out's remove
+       * puts the session back on disk, and the next reload signs the person in again — from the
+       * action they took to leave.
+       *
+       * Nothing on screen disagrees while it happens, which is what makes it worth a test: the
+       * in-memory session says signed out, and the late `SIGNED_IN` carries that same null.
+       */
+      const storage = slowStorage(createMemoryStorage());
+      const auth = adapterOn(storage);
+
+      const signingIn = auth.signInWithOAuth('google');
+      const signingOut = auth.signOut();
+      await Promise.all([signingIn, signingOut]);
+
+      expect(await auth.getSession()).toBeNull();
+      /* The disk, not just the field — a reload is what would reveal a stale write. */
+      expect(await adapterOn(storage).getSession()).toBeNull();
+    });
+
+    it('ends signed in when signing out is what finished first', async () => {
+      /* The mirror image, so the queue is shown to preserve order rather than to favour one
+         outcome. */
+      const storage = slowStorage(createMemoryStorage());
+      const auth = adapterOn(storage);
+
+      const signingOut = auth.signOut();
+      const signingIn = auth.signInWithOAuth('google');
+      await Promise.all([signingOut, signingIn]);
+
+      expect(await auth.getSession()).not.toBeNull();
+      expect(await adapterOn(storage).getSession()).not.toBeNull();
+    });
+  });
+
   describe('what it refuses to believe', () => {
     it('recognises only the providers D28 allows', () => {
       /*
@@ -180,8 +235,31 @@ describe('the mock auth adapter', () => {
     });
 
     it('signs nobody in when the provider is refused', async () => {
-      /* The predicate is the rule; this is the adapter honouring it. */
+      /*
+       * The first version of this called `'google'` and asserted the session existed — a test
+       * whose name described a refusal and whose body exercised the happy path, which is worse
+       * than no test. It could not fail if unsupported providers were accepted.
+       *
+       * `Reflect.apply` is how to reach the case without a cast: its parameters are untyped, so
+       * this is genuinely the untyped caller the guard exists for, rather than a lie told to the
+       * compiler.
+       */
       const auth = adapterOn(createMemoryStorage());
+
+      let caught: unknown;
+      try {
+        await Reflect.apply(auth.signInWithOAuth, auth, ['facebook']);
+      } catch (error) {
+        caught = error;
+      }
+
+      /* The guard recognised through the exported type guard, which is how a caller narrows one
+         of these — and asserted to have thrown at all, so a call that quietly resolved could not
+         pass by leaving `caught` undefined. */
+      expect(isValidationError(caught)).toBe(true);
+      expect(await auth.getSession()).toBeNull();
+
+      /* …and the real provider still works, so the guard is not simply refusing everything. */
       await auth.signInWithOAuth('google');
       expect(await auth.getSession()).not.toBeNull();
     });
@@ -198,6 +276,24 @@ describe('the mock auth adapter', () => {
         await storage.write('occasio.auth.session', stored);
         expect([stored, await adapterOn(storage).getSession()]).toEqual([stored, null]);
       }
+    });
+
+    it('does not let a configured role travel into the session', async () => {
+      /*
+       * The same rule on the way *in*, which is where it is needed first. `MockAuthOptions`'s
+       * user is a structural type, so an object carrying a role satisfies it — and a spread
+       * would have put that role into the live session and then persisted it. Sanitising only on
+       * read would leave the running app holding it until a reload.
+       */
+      /* Through a variable, because an object literal would be refused by the excess-property
+         check — and a variable is how such an object actually arrives: something builds a user
+         with more on it than this adapter asked for, and structural typing accepts it. */
+      const configured = { ...USER, role: 'owner' };
+      const auth = createMockAuthAdapter({ user: configured, storage: createMemoryStorage() });
+      await auth.signInWithOAuth('google');
+
+      const session = await auth.getSession();
+      expect(Object.keys(session?.user ?? {}).sort()).toEqual(['email', 'id']);
     });
 
     it('does not let a stored role travel into the session', async () => {

--- a/packages/data/src/mock/authAdapter.ts
+++ b/packages/data/src/mock/authAdapter.ts
@@ -152,20 +152,35 @@ export const createMockAuthAdapter = (options: MockAuthOptions): AuthAdapter => 
         }
 
         await restore();
+
         /* Field by field, not a spread. `MockAuthOptions['user']` is structural, so an object
            carrying `role: 'owner'` satisfies it — and a spread would put that role into the live
            session and persist it. The parse on the way back out sanitises a *stored* session;
            this is the same rule applied on the way in, where it is needed first. */
-        session = { user: { id: options.user.id, email: options.user.email }, expiresAt: null };
-        await storage.write(key, JSON.stringify(session));
+        const next: AuthSession = {
+          user: { id: options.user.id, email: options.user.email },
+          expiresAt: null,
+        };
+
+        /*
+         * Persisted before it is believed. Assigning first leaves the adapter reporting a signed
+         * in user that nothing has stored — so the call rejects, a screen shows the failure, and
+         * `getSession` disagrees with it until a reload quietly signs the person out again.
+         * Storage is the durable answer, so it decides.
+         */
+        await storage.write(key, JSON.stringify(next));
+        session = next;
         emit('SIGNED_IN', [...listeners]);
       }),
 
     signOut: () =>
       serialise(async () => {
         await restore();
-        session = null;
+        /* The same order in reverse: a remove that fails must leave the session standing, or the
+           app reports signed out while storage still holds the session and the next reload
+           signs the person back in. */
         await storage.remove(key);
+        session = null;
         emit('SIGNED_OUT', [...listeners]);
       }),
   };

--- a/packages/data/src/mock/authAdapter.ts
+++ b/packages/data/src/mock/authAdapter.ts
@@ -1,0 +1,144 @@
+import { userId, type UserId } from '@occasio/core';
+import { isAuthProvider } from '../auth';
+import type { AuthAdapter, AuthEvent, AuthListener, AuthProvider, AuthSession } from '../auth';
+import { ValidationError } from '../errors';
+import type { Unsubscribe } from '../repositories';
+import { createDefaultStorage } from './defaultStorage';
+import type { MockStorage } from './storage';
+
+/**
+ * Sign-in without a provider.
+ *
+ * It exists to make the rest of the app real before Google OAuth does: screens can gate, a role
+ * switcher can switch, and none of it has to be rewritten when the provider arrives, because the
+ * shape it is written against is the one Supabase Auth has.
+ *
+ * The session is persisted through the same `MockStorage` port the data mock uses, so it
+ * survives a reload on web and a relaunch on native — a demo where signing in has to be repeated
+ * every time is a demo of the sign-in screen rather than of the app.
+ *
+ * **No membership, no role, no claim is stored here.** The session holds an id and an email;
+ * everything about what that person may do is asked of the data layer, per tenant. See the note
+ * on `AuthAdapter` for why that separation is not a matter of taste.
+ */
+
+const SESSION_KEY = 'occasio.auth.session';
+
+export type MockAuthOptions = {
+  /**
+   * Who signing in produces.
+   *
+   * A fixed account, because there is no provider to ask and inventing an account per sign-in
+   * would produce a user with no memberships and therefore no events — a demo that signs in
+   * successfully and shows nothing.
+   */
+  readonly user: { readonly id: UserId; readonly email: string };
+  readonly storage?: MockStorage | undefined;
+  /** Starts signed out unless a stored session says otherwise. */
+  readonly storageKey?: string | undefined;
+};
+
+/** What a stored session must look like to be believed. */
+const parseSession = (raw: string | null): AuthSession | null => {
+  if (raw === null) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+
+  if (parsed === null || typeof parsed !== 'object') return null;
+  if (!('user' in parsed)) return null;
+  const { user } = parsed;
+  if (user === null || typeof user !== 'object') return null;
+  if (!('id' in user) || !('email' in user)) return null;
+  if (typeof user.id !== 'string' || typeof user.email !== 'string') return null;
+  if (user.id === '' || user.email === '') return null;
+
+  /*
+   * Rebuilt field by field rather than returned as parsed. Whatever else was on disk — a `role`
+   * an older build wrote, something somebody added by hand — does not travel into the session,
+   * which is the one object screens are most likely to trust.
+   */
+  return { user: { id: userId(user.id), email: user.email }, expiresAt: null };
+};
+
+export const createMockAuthAdapter = (options: MockAuthOptions): AuthAdapter => {
+  const storage = options.storage ?? createDefaultStorage();
+  const key = options.storageKey ?? SESSION_KEY;
+
+  let session: AuthSession | null = null;
+  let restored: Promise<void> | null = null;
+  const listeners = new Set<AuthListener>();
+
+  /* Read once and shared, so several callers during start-up do not each hit storage — and so
+     `getSession` and a listener registered in the same tick cannot disagree about the answer. */
+  const restore = (): Promise<void> => {
+    restored ??= storage.read(key).then((raw) => {
+      session = parseSession(raw);
+    });
+    return restored;
+  };
+
+  const emit = (event: AuthEvent, to: Iterable<AuthListener>): void => {
+    for (const listener of to) {
+      /* One listener throwing must not stop the others hearing, and must not surface as a
+         failure of the sign-in that triggered it. */
+      try {
+        listener(event, session);
+      } catch (error) {
+        if (process.env.NODE_ENV !== 'production') {
+          console.warn('[mock auth] a listener threw', error);
+        }
+      }
+    }
+  };
+
+  return {
+    getSession: async () => {
+      await restore();
+      return session;
+    },
+
+    onAuthStateChange: (listener: AuthListener): Unsubscribe => {
+      listeners.add(listener);
+
+      /*
+       * `INITIAL_SESSION` after the restore, exactly once, and only if this listener is still
+       * subscribed. A component that mounts and unmounts before storage answers would otherwise
+       * be called after it had gone.
+       */
+      void restore().then(() => {
+        if (listeners.has(listener)) emit('INITIAL_SESSION', [listener]);
+      });
+
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+
+    signInWithOAuth: async (provider: AuthProvider) => {
+      /* Unreachable from TypeScript and reachable from a JavaScript caller or a stale bundle.
+         An unknown provider must not quietly sign somebody in as the demo account. */
+      if (!isAuthProvider(provider)) {
+        throw new ValidationError([
+          { path: 'provider', message: `unsupported: ${String(provider)}` },
+        ]);
+      }
+
+      await restore();
+      session = { user: { ...options.user }, expiresAt: null };
+      await storage.write(key, JSON.stringify(session));
+      emit('SIGNED_IN', [...listeners]);
+    },
+
+    signOut: async () => {
+      await restore();
+      session = null;
+      await storage.remove(key);
+      emit('SIGNED_OUT', [...listeners]);
+    },
+  };
+};

--- a/packages/data/src/mock/authAdapter.ts
+++ b/packages/data/src/mock/authAdapter.ts
@@ -73,6 +73,28 @@ export const createMockAuthAdapter = (options: MockAuthOptions): AuthAdapter => 
   let restored: Promise<void> | null = null;
   const listeners = new Set<AuthListener>();
 
+  /*
+   * One transition at a time.
+   *
+   * Signing in and signing out are each read-write across an await, so overlapping them lets the
+   * writes land out of order: a sign-in whose `storage.write` settles after a sign-out's
+   * `storage.remove` restores the session on disk, and the next reload signs the person back in
+   * — from the action they took to leave. Worse, nothing on screen disagrees: the in-memory
+   * session says signed out, and the late `SIGNED_IN` event carries that same null session, so
+   * the only symptom is a reload much later.
+   *
+   * A queue rather than a generation check, because the order of the writes is what has to be
+   * right — discarding a stale write still leaves two of them racing for the disk.
+   */
+  let chain: Promise<unknown> = Promise.resolve();
+
+  const serialise = <T>(task: () => Promise<T>): Promise<T> => {
+    const next = chain.then(task, task);
+    /* A failing transition must not poison the queue, while its caller still sees the failure. */
+    chain = next.catch(() => undefined);
+    return next;
+  };
+
   /* Read once and shared, so several callers during start-up do not each hit storage — and so
      `getSession` and a listener registered in the same tick cannot disagree about the answer. */
   const restore = (): Promise<void> => {
@@ -119,26 +141,32 @@ export const createMockAuthAdapter = (options: MockAuthOptions): AuthAdapter => 
       };
     },
 
-    signInWithOAuth: async (provider: AuthProvider) => {
-      /* Unreachable from TypeScript and reachable from a JavaScript caller or a stale bundle.
-         An unknown provider must not quietly sign somebody in as the demo account. */
-      if (!isAuthProvider(provider)) {
-        throw new ValidationError([
-          { path: 'provider', message: `unsupported: ${String(provider)}` },
-        ]);
-      }
+    signInWithOAuth: (provider: AuthProvider) =>
+      serialise(async () => {
+        /* Unreachable from TypeScript and reachable from a JavaScript caller or a stale
+           bundle. An unknown provider must not quietly sign somebody in as the demo account. */
+        if (!isAuthProvider(provider)) {
+          throw new ValidationError([
+            { path: 'provider', message: `unsupported: ${String(provider)}` },
+          ]);
+        }
 
-      await restore();
-      session = { user: { ...options.user }, expiresAt: null };
-      await storage.write(key, JSON.stringify(session));
-      emit('SIGNED_IN', [...listeners]);
-    },
+        await restore();
+        /* Field by field, not a spread. `MockAuthOptions['user']` is structural, so an object
+           carrying `role: 'owner'` satisfies it — and a spread would put that role into the live
+           session and persist it. The parse on the way back out sanitises a *stored* session;
+           this is the same rule applied on the way in, where it is needed first. */
+        session = { user: { id: options.user.id, email: options.user.email }, expiresAt: null };
+        await storage.write(key, JSON.stringify(session));
+        emit('SIGNED_IN', [...listeners]);
+      }),
 
-    signOut: async () => {
-      await restore();
-      session = null;
-      await storage.remove(key);
-      emit('SIGNED_OUT', [...listeners]);
-    },
+    signOut: () =>
+      serialise(async () => {
+        await restore();
+        session = null;
+        await storage.remove(key);
+        emit('SIGNED_OUT', [...listeners]);
+      }),
   };
 };


### PR DESCRIPTION
Closes #43. Epic #5 starts here — nothing else in it can be built until there is a shape for "who is signed in".

Modelled on Supabase Auth so the swap is a file change (D5, D29): the same four operations, the same session-and-listener model, the same event names. It does **not** copy the `{ data, error }` envelopes — this package throws typed errors everywhere else, and two error conventions inside one adapter layer would mean every caller checking both. Unwrapping those is what the Supabase adapter is for.

## A session says who somebody is, never what they may see

`AuthUser` has an id and an email. No role, no tenants, no claims, and it should not grow one. Two reasons, both load-bearing:

- A token is issued once and believed until it expires, so a role revoked at 9am is still in a token minted at 8:50.
- A claim in a token is a client-side fact, which makes it a client-side decision — not where access decisions belong.

D15's gating is UX only; enforcement is RLS, against the database's own view of membership.

**The mock enforces this rather than documenting it.** A stored session is rebuilt field by field instead of returned as parsed, so a `role` written into storage by an older build — or by hand — stays on disk. There is a test that puts one there and asserts the session comes back with exactly `id` and `email`.

## `signInWithOAuth`, not `signInWithOtp` — flagging this for you

The issue names `signInWithOtp` as part of the mirrored shape. **D28 freezes sign-in on Google OAuth**, with Apple named as the constraint that will widen it later.

An OTP method the app never calls would be untested surface that looks like a way in — the exact failure this repo keeps finding in its own checks. So the operation is the one D28 allows, with the provider enumerated rather than a free string.

Raising it rather than deciding it quietly: if you want the OTP method for literal parity with Supabase, say so and it goes back in.

The allow-list is a runtime predicate rather than a comparison, because `AuthProvider` has one member and a check written against the type is provably true — the compiler removes the branch, while the value that actually arrives can come from a JavaScript caller, a stale bundle or a deep link.

## `INITIAL_SESSION`

Emitted per listener after the restore, and only if that listener is still subscribed. A listener that only hears `SIGNED_IN` never learns about a session restored at start-up, so a returning user renders as signed out until they touch something — and a component that mounts and unmounts inside one tick must not be called after it has gone.

## Verification

| mutation | result |
|---|---|
| return the parsed session instead of rebuilding it | 1 test fails |
| drop `INITIAL_SESSION` | 5 tests fail |
| emit to an unsubscribed listener | 1 test fails |
| widen the provider allow-list | 1 test fails |
| remove the listener isolation | **kills the Jest worker** with an uncaught exception |

That last one is detection of a blunter kind than a failed assertion, and worth stating plainly rather than dressing up: the throw escapes an async callback, so the run dies rather than reporting. It cannot pass with the mutation in place, which is what the check is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145VPJXGgJA9PWqeNXDr1DG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added authentication support with session management, OAuth sign-in, sign-out, and authentication state updates.
  * Added Google as a supported authentication provider with input validation.
  * Added session persistence and restoration across reloads.
  * Added a mock authentication option for testing and local development.

* **Bug Fixes**
  * Invalid or unauthorised session data is now rejected or sanitised.
  * Authentication listener errors no longer interrupt other listeners.
  * Authentication state transitions now preserve storage write order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->