### PR TITLE
feat(app): the sign-in screen, one provider, and a redirect that cannot leave

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -7,6 +7,7 @@ import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { AppAdapterProvider } from '../src/data/AppAdapterProvider';
 import { ErrorFallback } from '../src/features/errors/ErrorFallback';
+import { AppAuthProvider } from '../src/auth/AppAuthProvider';
 import { TenantProvider } from '../src/tenant/TenantProvider';
 import { AppThemeProvider } from '../src/theme/AppThemeProvider';
 import { APP_THEME } from '../src/theme/inputs';
@@ -65,18 +66,20 @@ export default function RootLayout() {
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <QueryClientProvider client={queryClient}>
-        <AppAdapterProvider>
-          {/* No slug: the root is where the platform gets asked, once. Inside /e/[slug] the
+        <AppAuthProvider>
+          <AppAdapterProvider>
+            {/* No slug: the root is where the platform gets asked, once. Inside /e/[slug] the
               route already knows, and its own provider says so rather than resolving again. */}
-          <TenantProvider>
-            <AppThemeProvider input={APP_THEME}>
-              <SafeAreaProvider>
-                <StatusBar style="auto" />
-                <Stack screenOptions={{ headerShown: false }} />
-              </SafeAreaProvider>
-            </AppThemeProvider>
-          </TenantProvider>
-        </AppAdapterProvider>
+            <TenantProvider>
+              <AppThemeProvider input={APP_THEME}>
+                <SafeAreaProvider>
+                  <StatusBar style="auto" />
+                  <Stack screenOptions={{ headerShown: false }} />
+                </SafeAreaProvider>
+              </AppThemeProvider>
+            </TenantProvider>
+          </AppAdapterProvider>
+        </AppAuthProvider>
       </QueryClientProvider>
     </GestureHandlerRootView>
   );

--- a/apps/mobile/app/sign-in.tsx
+++ b/apps/mobile/app/sign-in.tsx
@@ -1,0 +1,54 @@
+import { router, useLocalSearchParams } from 'expo-router';
+import { useState } from 'react';
+import { useAuth } from '../src/auth/AuthProvider';
+import { safeNext } from '../src/auth/nextRoute';
+import { SignInScreen } from '../src/features/auth/SignInScreen';
+
+/**
+ * The route: where signing in leads, and where it came from.
+ *
+ * `next` carries the route somebody was heading for. It arrives from a URL, so it is passed
+ * through `safeNext` before it is followed — see that file for why an unchecked one is an open
+ * redirect rather than a convenience.
+ */
+export default function Route() {
+  const { next } = useLocalSearchParams<{ next?: string }>();
+  const { state, signIn } = useAuth();
+  const [error, setError] = useState<string | undefined>(undefined);
+  const [busy, setBusy] = useState(false);
+
+  const destination = safeNext(next);
+
+  /*
+   * Already signed in — somebody who followed a stale link, or came back to this route from
+   * history. `Redirect` rather than an effect, because rendering a sign-in button to a person
+   * who is signed in and then moving them is a flicker with a wrong screen in it.
+   */
+  if (state.status === 'signed-in') {
+    router.replace(destination);
+    return null;
+  }
+
+  return (
+    <SignInScreen
+      busy={busy}
+      error={error}
+      onSignIn={() => {
+        setBusy(true);
+        setError(undefined);
+        void signIn()
+          .then(() => {
+            router.replace(destination);
+          })
+          .catch(() => {
+            /* Nothing specific to say: there is one provider and one failure worth reporting,
+               which is that it did not work. */
+            setError('Could not sign in. Please try again.');
+          })
+          .finally(() => {
+            setBusy(false);
+          });
+      }}
+    />
+  );
+}

--- a/apps/mobile/app/sign-in.tsx
+++ b/apps/mobile/app/sign-in.tsx
@@ -1,54 +1,30 @@
-import { router, useLocalSearchParams } from 'expo-router';
-import { useState } from 'react';
-import { useAuth } from '../src/auth/AuthProvider';
-import { safeNext } from '../src/auth/nextRoute';
+import { Redirect, router, useLocalSearchParams } from 'expo-router';
 import { SignInScreen } from '../src/features/auth/SignInScreen';
+import { useSignInFlow } from '../src/features/auth/useSignInFlow';
 
 /**
- * The route: where signing in leads, and where it came from.
- *
- * `next` carries the route somebody was heading for. It arrives from a URL, so it is passed
- * through `safeNext` before it is followed — see that file for why an unchecked one is an open
- * redirect rather than a convenience.
+ * The route: the parameter, and where signing in leads.
  */
 export default function Route() {
   const { next } = useLocalSearchParams<{ next?: string }>();
-  const { state, signIn } = useAuth();
-  const [error, setError] = useState<string | undefined>(undefined);
-  const [busy, setBusy] = useState(false);
 
-  const destination = safeNext(next);
+  const flow = useSignInFlow({
+    next,
+    onSignedIn: (destination) => {
+      /* `replace`, not `push`: the sign-in screen is how somebody got in, not somewhere to go
+         back to. Leaving it on the stack means the back gesture lands on it again. */
+      router.replace(destination);
+    },
+  });
 
   /*
-   * Already signed in — somebody who followed a stale link, or came back to this route from
-   * history. `Redirect` rather than an effect, because rendering a sign-in button to a person
-   * who is signed in and then moving them is a flicker with a wrong screen in it.
+   * Declarative, because navigating during render is a side effect in render — React may run it
+   * twice, and under Strict Mode does. `Redirect` is expo-router's answer for the case where a
+   * route decides, before painting anything, that it is not the right route.
    */
-  if (state.status === 'signed-in') {
-    router.replace(destination);
-    return null;
-  }
+  if (flow.alreadySignedIn) return <Redirect href={flow.destination} />;
 
   return (
-    <SignInScreen
-      busy={busy}
-      error={error}
-      onSignIn={() => {
-        setBusy(true);
-        setError(undefined);
-        void signIn()
-          .then(() => {
-            router.replace(destination);
-          })
-          .catch(() => {
-            /* Nothing specific to say: there is one provider and one failure worth reporting,
-               which is that it did not work. */
-            setError('Could not sign in. Please try again.');
-          })
-          .finally(() => {
-            setBusy(false);
-          });
-      }}
-    />
+    <SignInScreen busy={flow.busy} error={flow.error} demo={flow.demo} onSignIn={flow.start} />
   );
 }

--- a/apps/mobile/src/auth/AppAuthProvider.tsx
+++ b/apps/mobile/src/auth/AppAuthProvider.tsx
@@ -18,5 +18,12 @@ export function AppAuthProvider({ children }: { readonly children: ReactNode }) 
      per render would drop the listeners the provider has already registered. */
   const [adapter] = useState(() => createMockAuthAdapter({ user: DEMO_USER }));
 
-  return <AuthProvider adapter={adapter}>{children}</AuthProvider>;
+  /* `demo` because this is the mock: signing in here does not talk to Google, it writes the
+     fixed account below. The screen says so, and both go away together when the real adapter
+     lands — this is the one file that swap touches. */
+  return (
+    <AuthProvider adapter={adapter} demo>
+      {children}
+    </AuthProvider>
+  );
 }

--- a/apps/mobile/src/auth/AppAuthProvider.tsx
+++ b/apps/mobile/src/auth/AppAuthProvider.tsx
@@ -1,0 +1,22 @@
+import { createMockAuthAdapter } from '@occasio/data';
+import { userId } from '@occasio/core';
+import { useState, type ReactNode } from 'react';
+import { AuthProvider } from './AuthProvider';
+
+/**
+ * The app's binding of `<AuthProvider>`: the mock, signing in as the demo account.
+ *
+ * The one file the Supabase Auth swap touches, in the same way `AppAdapterProvider` is for data.
+ * A fixed account because there is no provider to ask — inventing one per sign-in would produce
+ * a user with no memberships and therefore no events, which is a demo of signing in rather than
+ * of the app.
+ */
+const DEMO_USER = { id: userId('u_sanit'), email: 'sanit@example.com' };
+
+export function AppAuthProvider({ children }: { readonly children: ReactNode }) {
+  /* Once per app instance, like the query client and the data adapter beside it: a new adapter
+     per render would drop the listeners the provider has already registered. */
+  const [adapter] = useState(() => createMockAuthAdapter({ user: DEMO_USER }));
+
+  return <AuthProvider adapter={adapter}>{children}</AuthProvider>;
+}

--- a/apps/mobile/src/auth/AuthProvider.dom.test.tsx
+++ b/apps/mobile/src/auth/AuthProvider.dom.test.tsx
@@ -1,0 +1,144 @@
+import { userId } from '@occasio/core';
+import { createMemoryStorage, createMockAuthAdapter } from '@occasio/data';
+import type { AuthAdapter } from '@occasio/data';
+import { describe, expect, it } from '@jest/globals';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { AuthProvider, useAuth } from './AuthProvider';
+
+/**
+ * What a screen sees. The adapter's own behaviour is tested next door; this is about the three
+ * states a component has to render and the one it must never be told to render by mistake.
+ */
+
+const USER = { id: userId('u_sanit'), email: 'sanit@example.com' };
+
+const Probe = () => {
+  const { state, signIn, signOut } = useAuth();
+  return (
+    <div>
+      <div data-testid="status">{state.status}</div>
+      <button
+        data-testid="in"
+        onClick={() => {
+          void signIn();
+        }}
+      >
+        in
+      </button>
+      <button
+        data-testid="out"
+        onClick={() => {
+          void signOut();
+        }}
+      >
+        out
+      </button>
+    </div>
+  );
+};
+
+/** The same adapter, keeping count of how many listeners are currently subscribed. */
+const counting = (inner: AuthAdapter) => {
+  let live = 0;
+  const adapter: AuthAdapter = {
+    ...inner,
+    onAuthStateChange: (listener) => {
+      live += 1;
+      const unsubscribe = inner.onAuthStateChange(listener);
+      return () => {
+        live -= 1;
+        unsubscribe();
+      };
+    },
+  };
+  return { adapter, live: () => live };
+};
+
+const mount = (adapter: AuthAdapter) =>
+  render(
+    <AuthProvider adapter={adapter}>
+      <Probe />
+    </AuthProvider>,
+  );
+
+const status = () => screen.getByTestId('status').textContent;
+
+describe('AuthProvider', () => {
+  it('starts restoring, then settles on signed out', async () => {
+    /*
+     * `restoring` is a state and not a formality: storage is asynchronous on both platforms, so
+     * a provider that started at `signed-out` would flash a sign-in prompt at somebody who is
+     * signed in, every launch.
+     */
+    mount(createMockAuthAdapter({ user: USER, storage: createMemoryStorage() }));
+
+    expect(status()).toBe('restoring');
+    await waitFor(() => {
+      expect(status()).toBe('signed-out');
+    });
+  });
+
+  it('restores a session that was already there', async () => {
+    const storage = createMemoryStorage();
+    await createMockAuthAdapter({ user: USER, storage }).signInWithOAuth('google');
+
+    mount(createMockAuthAdapter({ user: USER, storage }));
+
+    await waitFor(() => {
+      expect(status()).toBe('signed-in');
+    });
+  });
+
+  it('follows signing in and out', async () => {
+    mount(createMockAuthAdapter({ user: USER, storage: createMemoryStorage() }));
+    await waitFor(() => {
+      expect(status()).toBe('signed-out');
+    });
+
+    await act(async () => {
+      screen.getByTestId('in').click();
+      await Promise.resolve();
+    });
+    await waitFor(() => {
+      expect(status()).toBe('signed-in');
+    });
+
+    await act(async () => {
+      screen.getByTestId('out').click();
+      await Promise.resolve();
+    });
+    await waitFor(() => {
+      expect(status()).toBe('signed-out');
+    });
+  });
+
+  it('stops listening when it goes away', async () => {
+    /*
+     * An adapter outlives a provider — it is created once per app — so a listener left behind
+     * sets state on an unmounted tree every time anybody signs in.
+     *
+     * Counted rather than inferred. The first version of this asserted that signing in still
+     * resolved after unmounting, which it does whether or not the listener was removed: React
+     * tolerates the stale update silently, so the assertion held with the cleanup deleted. What
+     * has to be observed is the subscription itself.
+     */
+    const { adapter, live } = counting(
+      createMockAuthAdapter({ user: USER, storage: createMemoryStorage() }),
+    );
+    const { unmount } = mount(adapter);
+    await waitFor(() => {
+      expect(status()).toBe('signed-out');
+    });
+    expect(live()).toBe(1);
+
+    unmount();
+
+    expect(live()).toBe(0);
+  });
+
+  it('fails loudly outside a provider', () => {
+    /* Reporting signed out here would render a plausible sign-in prompt over a wiring mistake
+       nobody would investigate. */
+    expect(() => render(<Probe />)).toThrow(/inside an <AuthProvider>/);
+  });
+});

--- a/apps/mobile/src/auth/AuthProvider.dom.test.tsx
+++ b/apps/mobile/src/auth/AuthProvider.dom.test.tsx
@@ -54,6 +54,33 @@ const counting = (inner: AuthAdapter) => {
   return { adapter, live: () => live };
 };
 
+/**
+ * The context value, captured on every render.
+ *
+ * Read back through `.at(-1)` with a check rather than a cast — `signIn`'s identity changes when
+ * the state does, so a value grabbed once goes stale, and a cast to paper over that is a lint
+ * error here for good reason.
+ */
+const captureAuth = (adapter: AuthAdapter) => {
+  const seen: ReturnType<typeof useAuth>[] = [];
+  const Capture = () => {
+    seen.push(useAuth());
+    return null;
+  };
+
+  render(
+    <AuthProvider adapter={adapter}>
+      <Capture />
+    </AuthProvider>,
+  );
+
+  return () => {
+    const latest = seen.at(-1);
+    if (latest === undefined) throw new Error('the provider rendered nothing');
+    return latest;
+  };
+};
+
 const mount = (adapter: AuthAdapter) =>
   render(
     <AuthProvider adapter={adapter}>
@@ -134,6 +161,49 @@ describe('AuthProvider', () => {
     unmount();
 
     expect(live()).toBe(0);
+  });
+
+  it('starts one sign-in however many callers ask', async () => {
+    /*
+     * A screen's `busy` flag protects that screen and is set a render later than the click, so a
+     * double tap — or two components each holding a sign-in button — can both reach the adapter.
+     * With a real provider that is two redirects started at once, and the second wins whichever
+     * account the first was in the middle of choosing.
+     */
+    const attempts: unknown[] = [];
+    const inner = createMockAuthAdapter({ user: USER, storage: createMemoryStorage() });
+    const adapter: AuthAdapter = {
+      ...inner,
+      signInWithOAuth: (provider) => {
+        attempts.push(provider);
+        return inner.signInWithOAuth(provider);
+      },
+    };
+
+    const auth = captureAuth(adapter);
+
+    const first = auth().signIn();
+    const second = auth().signIn();
+
+    /* The same promise, not two — a later caller joins the attempt already running. */
+    expect(second).toBe(first);
+    await act(async () => {
+      await Promise.all([first, second]);
+    });
+    expect(attempts).toEqual(['google']);
+  });
+
+  it('allows a fresh attempt after the last one settled', async () => {
+    /* Single-flight is not once-only: a failed or completed sign-in must be retryable. */
+    const adapter = createMockAuthAdapter({ user: USER, storage: createMemoryStorage() });
+    const auth = captureAuth(adapter);
+
+    const first = auth().signIn();
+    await act(async () => {
+      await first;
+    });
+
+    expect(auth().signIn()).not.toBe(first);
   });
 
   it('fails loudly outside a provider', () => {

--- a/apps/mobile/src/auth/AuthProvider.tsx
+++ b/apps/mobile/src/auth/AuthProvider.tsx
@@ -1,5 +1,13 @@
 import type { AuthAdapter, AuthSession } from '@occasio/data';
-import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
 
 /**
  * Who is signed in, for the screens that need to know.
@@ -20,18 +28,38 @@ type AuthValue = {
   readonly state: AuthState;
   readonly signIn: () => Promise<void>;
   readonly signOut: () => Promise<void>;
+  /**
+   * Whether this is the mock rather than a real provider.
+   *
+   * Carried so a screen can say so. A button reading "Continue with Google" that signs somebody
+   * in as a fixed account, with nothing on screen admitting it, is the app lying about what it
+   * just did — and the person most likely to be misled is whoever is demonstrating it.
+   */
+  readonly demo: boolean;
 };
 
 const AuthContext = createContext<AuthValue | null>(null);
 
 export function AuthProvider({
   adapter,
+  demo = false,
   children,
 }: {
   readonly adapter: AuthAdapter;
+  readonly demo?: boolean | undefined;
   readonly children: ReactNode;
 }) {
   const [state, setState] = useState<AuthState>({ status: 'restoring' });
+
+  /*
+   * One sign-in at a time, across every caller rather than every screen.
+   *
+   * A screen's own `busy` flag protects that screen and nothing else, and it is set a render
+   * later than the click — so a double tap, or two components each with a sign-in button, can
+   * both reach the adapter. With a real provider that is two redirects started at once, and the
+   * second one wins whichever account the first was in the middle of choosing.
+   */
+  const inFlight = useRef<Promise<void> | null>(null);
 
   useEffect(() => {
     /*
@@ -48,10 +76,21 @@ export function AuthProvider({
   const value = useMemo<AuthValue>(
     () => ({
       state,
-      signIn: () => adapter.signInWithOAuth('google'),
+      demo,
+      signIn: () => {
+        if (inFlight.current !== null) return inFlight.current;
+
+        /* Cleared only if this is still the current attempt, so a late `finally` from an
+           abandoned one cannot unlock a newer sign-in that is still running. */
+        const started: Promise<void> = adapter.signInWithOAuth('google').finally(() => {
+          if (inFlight.current === started) inFlight.current = null;
+        });
+        inFlight.current = started;
+        return started;
+      },
       signOut: () => adapter.signOut(),
     }),
-    [state, adapter],
+    [state, adapter, demo],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/apps/mobile/src/auth/AuthProvider.tsx
+++ b/apps/mobile/src/auth/AuthProvider.tsx
@@ -1,0 +1,73 @@
+import type { AuthAdapter, AuthSession } from '@occasio/data';
+import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
+
+/**
+ * Who is signed in, for the screens that need to know.
+ *
+ * A thin context over `AuthAdapter` — the adapter is where sign-in happens and this is where a
+ * component asks about it. Everything it exposes is identity: there is no role here, and no
+ * `can` helper, because a session says who somebody is and never what they may see (#43). What
+ * they may do is asked of the data layer, per event.
+ */
+
+export type AuthState =
+  /** Storage has not answered yet. Distinct from signed out, which is an answer. */
+  | { readonly status: 'restoring' }
+  | { readonly status: 'signed-out' }
+  | { readonly status: 'signed-in'; readonly session: AuthSession };
+
+type AuthValue = {
+  readonly state: AuthState;
+  readonly signIn: () => Promise<void>;
+  readonly signOut: () => Promise<void>;
+};
+
+const AuthContext = createContext<AuthValue | null>(null);
+
+export function AuthProvider({
+  adapter,
+  children,
+}: {
+  readonly adapter: AuthAdapter;
+  readonly children: ReactNode;
+}) {
+  const [state, setState] = useState<AuthState>({ status: 'restoring' });
+
+  useEffect(() => {
+    /*
+     * The listener is the only source of truth here, rather than a `getSession` call alongside
+     * it. `onAuthStateChange` emits `INITIAL_SESSION` after the restore, so subscribing is
+     * enough — and calling both would race, with whichever answered second overwriting the
+     * other's view of the same fact.
+     */
+    return adapter.onAuthStateChange((_event, session) => {
+      setState(session === null ? { status: 'signed-out' } : { status: 'signed-in', session });
+    });
+  }, [adapter]);
+
+  const value = useMemo<AuthValue>(
+    () => ({
+      state,
+      signIn: () => adapter.signInWithOAuth('google'),
+      signOut: () => adapter.signOut(),
+    }),
+    [state, adapter],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+/**
+ * Throws outside a provider rather than reporting signed out.
+ *
+ * The two mean opposite things: "nobody is signed in" is a state screens are built to handle,
+ * and "this screen was mounted outside the provider" is a wiring mistake that would otherwise
+ * render as a plausible sign-in prompt nobody investigates.
+ */
+export const useAuth = (): AuthValue => {
+  const value = useContext(AuthContext);
+  if (value === null) throw new Error('useAuth must be used inside an <AuthProvider>.');
+  return value;
+};
+
+export { AuthContext };

--- a/apps/mobile/src/auth/nextRoute.test.ts
+++ b/apps/mobile/src/auth/nextRoute.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from '@jest/globals';
+import { safeNext, HOME } from './nextRoute';
+
+/**
+ * This decides where somebody is sent at the moment they have just signed in, from a value that
+ * arrived in a URL. Everything below leans toward refusing: landing on the home page instead of
+ * the schedule costs a tap, and following an attacker's link costs a session.
+ */
+
+describe('safeNext', () => {
+  it('keeps a route inside the app', () => {
+    for (const route of ['/e/lila-and-sam', '/e/lila-and-sam/schedule', '/discover', '/join']) {
+      expect([route, safeNext(route)]).toEqual([route, route]);
+    }
+  });
+
+  it('keeps the query and fragment a route came with', () => {
+    /* A deep link into a filtered list is exactly the kind of destination worth returning to. */
+    expect(safeNext('/e/lila-and-sam/schedule?track=main#s-42')).toBe(
+      '/e/lila-and-sam/schedule?track=main#s-42',
+    );
+  });
+
+  it('refuses an absolute URL', () => {
+    /*
+     * The open redirect. `?next=https://evil.example/login` on an otherwise genuine sign-in link
+     * shows the app's own domain, takes a real sign-in, and hands the person somewhere else at
+     * the moment they are most primed to type a password.
+     */
+    for (const value of [
+      'https://evil.example',
+      'http://evil.example/login',
+      'HTTPS://evil.example',
+    ]) {
+      expect([value, safeNext(value)]).toEqual([value, HOME]);
+    }
+  });
+
+  it('refuses a protocol-relative URL, however it is spelled', () => {
+    /* `//host` is off-site to a browser, and a backslash is a slash to several URL parsers. */
+    for (const value of ['//evil.example', '/\\evil.example', '\\\\evil.example', '/\\/evil']) {
+      expect([value, safeNext(value)]).toEqual([value, HOME]);
+    }
+  });
+
+  it('decodes before deciding', () => {
+    /* `%2f%2f` is `//`, which passes a naive first-character check and is off-site. */
+    expect(safeNext('/%2f%2fevil.example')).toBe(HOME);
+    expect(safeNext('%2f%2fevil.example')).toBe(HOME);
+  });
+
+  it('refuses a scheme that is not a route at all', () => {
+    for (const value of ['javascript:alert(1)', 'data:text/html,x', 'mailto:a@b.c']) {
+      expect([value, safeNext(value)]).toEqual([value, HOME]);
+    }
+  });
+
+  it('refuses a malformed escape rather than throwing', () => {
+    expect(safeNext('/%')).toBe(HOME);
+    expect(safeNext('/%zz')).toBe(HOME);
+  });
+
+  it('falls back home for anything that is not a string', () => {
+    /* Route params arrive as `string | string[] | undefined`, and a repeated `?next=` gives the
+       array — which has no meaning here and must not be followed. */
+    expect(safeNext(undefined)).toBe(HOME);
+    expect(safeNext('')).toBe(HOME);
+    expect(safeNext(['/discover', '//evil.example'])).toBe(HOME);
+    expect(safeNext(42)).toBe(HOME);
+  });
+});

--- a/apps/mobile/src/auth/nextRoute.ts
+++ b/apps/mobile/src/auth/nextRoute.ts
@@ -1,0 +1,46 @@
+/**
+ * Where to go after signing in.
+ *
+ * The intended route arrives in a query parameter, which means it arrives from a URL, which
+ * means anyone can write it. `?next=https://evil.example/login` on an otherwise genuine sign-in
+ * link is the whole of an open redirect: the person sees the app's own domain, signs in there,
+ * and is handed to somewhere else at the moment they are most primed to type a password.
+ *
+ * So this accepts only what it can recognise as a route inside this app, and answers `'/'` for
+ * everything else. Refusing is cheap — somebody lands on the home page instead of the schedule —
+ * and the alternative is not.
+ */
+
+/** The one thing every internal route has, and no absolute URL is allowed to fake. */
+const INTERNAL = /^\/(?!\/)/;
+
+export const HOME = '/';
+
+export const safeNext = (value: unknown): string => {
+  if (typeof value !== 'string' || value === '') return HOME;
+
+  /*
+   * Decoded first, because the check has to see what the router will. `%2f%2fevil.example` is
+   * `//evil.example`, which a browser reads as protocol-relative and follows off-site — and a
+   * malformed escape is not a route.
+   */
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(value);
+  } catch {
+    return HOME;
+  }
+
+  /*
+   * A single leading slash and no second one. `//host` is protocol-relative, `https://host` is
+   * absolute, and `javascript:` and friends have no slash at all — the one rule rejects all of
+   * them without a list of schemes to keep up to date.
+   */
+  if (!INTERNAL.test(decoded)) return HOME;
+
+  /* A backslash is a slash to several browsers' URL parsers, so `/\evil.example` is `//` by
+     another spelling. */
+  if (decoded.includes('\\')) return HOME;
+
+  return decoded;
+};

--- a/apps/mobile/src/features/auth/SignInScreen.dom.test.tsx
+++ b/apps/mobile/src/features/auth/SignInScreen.dom.test.tsx
@@ -32,6 +32,24 @@ describe('SignInScreen', () => {
     expect(screen.getByTestId('sign-in-google')).toBeTruthy();
   });
 
+  it('admits when it is not really Google', () => {
+    /*
+     * A button reading "Continue with Google" that signs somebody in as a fixed account, with
+     * nothing on screen saying so, is the app lying about what it just did — and the person most
+     * likely to be misled is whoever is demonstrating it to somebody else. It goes away with the
+     * mock, which is one file.
+     */
+    renderSignIn({ demo: true });
+
+    expect(screen.getByTestId('sign-in-demo').textContent).toMatch(/not connected yet/);
+  });
+
+  it('says nothing of the sort once a real provider is wired', () => {
+    renderSignIn({ demo: false });
+
+    expect(screen.queryByTestId('sign-in-demo')).toBeNull();
+  });
+
   it('signs in when asked', () => {
     const { onSignIn } = renderSignIn();
 

--- a/apps/mobile/src/features/auth/SignInScreen.dom.test.tsx
+++ b/apps/mobile/src/features/auth/SignInScreen.dom.test.tsx
@@ -1,0 +1,70 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { ThemeProvider } from '@occasio/ui';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { APP_THEME } from '../../theme/inputs';
+import { SignInScreen } from './SignInScreen';
+
+/**
+ * The screen is deliberately almost empty, so what is worth asserting is what it does *not*
+ * offer: one provider, and no second slot standing open. ADR-0007 is why.
+ */
+
+const renderSignIn = (props: Partial<Parameters<typeof SignInScreen>[0]> = {}) => {
+  const onSignIn = jest.fn();
+  render(
+    <ThemeProvider input={APP_THEME} forceScheme="light">
+      <SignInScreen onSignIn={onSignIn} {...props} />
+    </ThemeProvider>,
+  );
+  return { onSignIn };
+};
+
+describe('SignInScreen', () => {
+  it('offers exactly one way in', () => {
+    /*
+     * D28 allows Google and nothing else, and ADR-0007 records that Apple's is a submission
+     * blocker for iOS rather than a preference. Counting the buttons is what makes adding the
+     * second a visible change to this file rather than filling a slot somebody left open.
+     */
+    renderSignIn();
+
+    expect(screen.getAllByRole('button')).toHaveLength(1);
+    expect(screen.getByTestId('sign-in-google')).toBeTruthy();
+  });
+
+  it('signs in when asked', () => {
+    const { onSignIn } = renderSignIn();
+
+    fireEvent.click(screen.getByTestId('sign-in-google'));
+    expect(onSignIn).toHaveBeenCalledTimes(1);
+  });
+
+  it('will not start a second sign-in while one is running', () => {
+    const { onSignIn } = renderSignIn({ busy: true });
+
+    fireEvent.click(screen.getByTestId('sign-in-google'));
+    expect(onSignIn).not.toHaveBeenCalled();
+  });
+
+  it('says what somebody was heading for, when there is one', () => {
+    /* "Sign in to open Lila & Sam" explains why a stranger is being asked for an account, which
+       "Sign in" on its own does not. */
+    renderSignIn({ destination: 'Lila & Sam' });
+
+    expect(screen.getByText(/Lila & Sam/)).toBeTruthy();
+  });
+
+  it('announces a failure rather than only colouring it', () => {
+    /* `Text` has no danger tone — the resolver guarantees contrast for content colours and a
+       solid `danger` fill is not one — so the role is what makes this an error at all. */
+    renderSignIn({ error: 'Could not sign in. Please try again.' });
+
+    expect(screen.getByRole('alert').textContent).toBe('Could not sign in. Please try again.');
+  });
+
+  it('shows nothing where an error would be when there is none', () => {
+    renderSignIn();
+
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+});

--- a/apps/mobile/src/features/auth/SignInScreen.dom.test.tsx
+++ b/apps/mobile/src/features/auth/SignInScreen.dom.test.tsx
@@ -64,14 +64,6 @@ describe('SignInScreen', () => {
     expect(onSignIn).not.toHaveBeenCalled();
   });
 
-  it('says what somebody was heading for, when there is one', () => {
-    /* "Sign in to open Lila & Sam" explains why a stranger is being asked for an account, which
-       "Sign in" on its own does not. */
-    renderSignIn({ destination: 'Lila & Sam' });
-
-    expect(screen.getByText(/Lila & Sam/)).toBeTruthy();
-  });
-
   it('announces a failure rather than only colouring it', () => {
     /* `Text` has no danger tone — the resolver guarantees contrast for content colours and a
        solid `danger` fill is not one — so the role is what makes this an error at all. */

--- a/apps/mobile/src/features/auth/SignInScreen.tsx
+++ b/apps/mobile/src/features/auth/SignInScreen.tsx
@@ -1,0 +1,70 @@
+import { Button, Screen, Text, createStyles } from '@occasio/ui';
+import { View } from 'react-native';
+
+/**
+ * One button, on purpose.
+ *
+ * D28 and ADR-0007: Google is the only provider, so this screen is shaped around exactly one —
+ * no provider list, no "or continue with" divider, no slot standing empty. Adding the second is
+ * then a visible change to this file rather than filling in a gap somebody left.
+ *
+ * Two constraints are already known and neither is paid (ADR-0007):
+ *
+ * - **Apple requires Sign in with Apple before an iOS release.** App Store Review Guideline 4.8
+ *   makes a second button a submission blocker, not a preference, for any app offering a
+ *   third-party sign-in on iOS.
+ * - **Native Google sign-in needs a development build.** It is a native module, so it does not
+ *   run in Expo Go; until the app moves to a dev build, native signs in against the mock.
+ *
+ * A guest at a wedding is not evaluating an authentication experience — they are trying to find
+ * the seating plan before the speeches. That is the whole reason this screen says as little as
+ * it does.
+ */
+
+export type SignInScreenProps = {
+  readonly onSignIn: () => void;
+  readonly busy?: boolean | undefined;
+  /** Shown under the button. Absent while nothing has gone wrong. */
+  readonly error?: string | undefined;
+  /** Names the event somebody was heading for, when there is one. */
+  readonly destination?: string | undefined;
+};
+
+const useStyles = createStyles((t) => ({
+  root: { gap: t.space(3), maxWidth: 420 },
+  actions: { gap: t.space(2), marginTop: t.space(4) },
+}));
+
+export function SignInScreen({ onSignIn, busy = false, error, destination }: SignInScreenProps) {
+  const styles = useStyles();
+
+  return (
+    <Screen testID="sign-in-screen">
+      <View style={styles.root}>
+        <Text variant="display2">Sign in</Text>
+        <Text tone="muted">
+          {destination === undefined
+            ? 'Signing in is how the app knows which tasks and reminders are yours.'
+            : `Sign in to open ${destination}. It is how the app knows which tasks and reminders are yours.`}
+        </Text>
+
+        <View style={styles.actions}>
+          <Button
+            label={busy ? 'Signing in…' : 'Continue with Google'}
+            disabled={busy}
+            testID="sign-in-google"
+            onPress={onSignIn}
+          />
+          {error === undefined ? null : (
+            /* `Text` has no danger tone — the resolver only guarantees contrast for the
+               content colours, and a solid `danger` fill is not one of them (textTokens.ts).
+               The role is what makes this an error; the colour would be decoration. */
+            <Text role="alert" testID="sign-in-error">
+              {error}
+            </Text>
+          )}
+        </View>
+      </View>
+    </Screen>
+  );
+}

--- a/apps/mobile/src/features/auth/SignInScreen.tsx
+++ b/apps/mobile/src/features/auth/SignInScreen.tsx
@@ -28,6 +28,14 @@ export type SignInScreenProps = {
   readonly error?: string | undefined;
   /** Names the event somebody was heading for, when there is one. */
   readonly destination?: string | undefined;
+  /**
+   * Whether signing in is the mock rather than a real provider.
+   *
+   * Said out loud when it is. A button reading "Continue with Google" that signs somebody in as
+   * a fixed account without admitting it is the app lying about what it just did — and the
+   * person most likely to be misled is whoever is demonstrating it to somebody else.
+   */
+  readonly demo?: boolean | undefined;
 };
 
 const useStyles = createStyles((t) => ({
@@ -35,7 +43,13 @@ const useStyles = createStyles((t) => ({
   actions: { gap: t.space(2), marginTop: t.space(4) },
 }));
 
-export function SignInScreen({ onSignIn, busy = false, error, destination }: SignInScreenProps) {
+export function SignInScreen({
+  onSignIn,
+  busy = false,
+  error,
+  destination,
+  demo = false,
+}: SignInScreenProps) {
   const styles = useStyles();
 
   return (
@@ -55,6 +69,12 @@ export function SignInScreen({ onSignIn, busy = false, error, destination }: Sig
             testID="sign-in-google"
             onPress={onSignIn}
           />
+          {demo ? (
+            <Text variant="caption" tone="muted" testID="sign-in-demo">
+              Google sign-in is not connected yet — this signs you in as the demo account. Native
+              Google needs a development build; see ADR-0007.
+            </Text>
+          ) : null}
           {error === undefined ? null : (
             /* `Text` has no danger tone — the resolver only guarantees contrast for the
                content colours, and a solid `danger` fill is not one of them (textTokens.ts).

--- a/apps/mobile/src/features/auth/SignInScreen.tsx
+++ b/apps/mobile/src/features/auth/SignInScreen.tsx
@@ -26,8 +26,6 @@ export type SignInScreenProps = {
   readonly busy?: boolean | undefined;
   /** Shown under the button. Absent while nothing has gone wrong. */
   readonly error?: string | undefined;
-  /** Names the event somebody was heading for, when there is one. */
-  readonly destination?: string | undefined;
   /**
    * Whether signing in is the mock rather than a real provider.
    *
@@ -43,23 +41,23 @@ const useStyles = createStyles((t) => ({
   actions: { gap: t.space(2), marginTop: t.space(4) },
 }));
 
-export function SignInScreen({
-  onSignIn,
-  busy = false,
-  error,
-  destination,
-  demo = false,
-}: SignInScreenProps) {
+export function SignInScreen({ onSignIn, busy = false, error, demo = false }: SignInScreenProps) {
   const styles = useStyles();
 
   return (
     <Screen testID="sign-in-screen">
       <View style={styles.root}>
         <Text variant="display2">Sign in</Text>
+        {/*
+          No "sign in to open <event>" line, and it is a deliberate removal rather than an
+          omission. The only thing this screen holds is the *path* somebody was heading for, and
+          "Sign in to open /e/lila-and-sam/schedule" is worse prose than saying nothing. Naming
+          the event needs a tenant lookup, and a sign-in screen that fetches an event before
+          anyone is signed in is a screen doing somebody else's job. If the named version is
+          wanted, it arrives with that lookup rather than with a URL dressed up as a name.
+        */}
         <Text tone="muted">
-          {destination === undefined
-            ? 'Signing in is how the app knows which tasks and reminders are yours.'
-            : `Sign in to open ${destination}. It is how the app knows which tasks and reminders are yours.`}
+          Signing in is how the app knows which tasks and reminders are yours.
         </Text>
 
         <View style={styles.actions}>

--- a/apps/mobile/src/features/auth/useSignInFlow.dom.test.tsx
+++ b/apps/mobile/src/features/auth/useSignInFlow.dom.test.tsx
@@ -1,0 +1,126 @@
+import { userId } from '@occasio/core';
+import { createMemoryStorage, createMockAuthAdapter } from '@occasio/data';
+import type { AuthAdapter } from '@occasio/data';
+import { describe, expect, it, jest } from '@jest/globals';
+import { act, render, waitFor } from '@testing-library/react';
+import { AuthProvider } from '../../auth/AuthProvider';
+import { useSignInFlow, type SignInFlow } from './useSignInFlow';
+
+/**
+ * The half of signing in that is neither the screen nor the adapter: what the screen is told,
+ * and how many times the route is asked to navigate.
+ */
+
+const USER = { id: userId('u_sanit'), email: 'sanit@example.com' };
+
+const mountFlow = (next: unknown, adapter?: AuthAdapter) => {
+  const onSignedIn = jest.fn<(destination: string) => void>();
+  const seen: SignInFlow[] = [];
+
+  const Probe = () => {
+    seen.push(useSignInFlow({ next, onSignedIn }));
+    return null;
+  };
+
+  render(
+    <AuthProvider
+      adapter={adapter ?? createMockAuthAdapter({ user: USER, storage: createMemoryStorage() })}
+    >
+      <Probe />
+    </AuthProvider>,
+  );
+
+  const flow = () => {
+    const latest = seen.at(-1);
+    if (latest === undefined) throw new Error('the provider rendered nothing');
+    return latest;
+  };
+
+  return { flow, onSignedIn };
+};
+
+describe('useSignInFlow', () => {
+  it('resolves the destination it was given', () => {
+    expect(mountFlow('/e/lila-and-sam/schedule').flow().destination).toBe(
+      '/e/lila-and-sam/schedule',
+    );
+  });
+
+  it('falls home for a destination that cannot be followed', () => {
+    /* The check belongs here rather than at the point of navigation, so there is one place that
+       decides what an acceptable destination is. */
+    expect(mountFlow('https://evil.example').flow().destination).toBe('/');
+  });
+
+  it('navigates once when the button is pressed twice', async () => {
+    /*
+     * `signIn` is single-flight, so a second press does not start a second sign-in — but each
+     * `start` used to attach its own completion handler, and both would navigate. Two
+     * navigations for one sign-in is a duplicate route on a stack and a history entry somebody
+     * has to press back through twice on the web.
+     *
+     * Pressed twice synchronously, which is the case `busy` cannot catch: it is set for the next
+     * render, and both presses happen before it.
+     */
+    const { flow, onSignedIn } = mountFlow('/discover');
+
+    await act(async () => {
+      flow().start();
+      flow().start();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(onSignedIn).toHaveBeenCalledTimes(1);
+    });
+    expect(onSignedIn).toHaveBeenCalledWith('/discover');
+  });
+
+  it('reports a failure to the screen rather than navigating', async () => {
+    const failing: AuthAdapter = {
+      ...createMockAuthAdapter({ user: USER, storage: createMemoryStorage() }),
+      signInWithOAuth: () => Promise.reject(new Error('the provider, probably')),
+    };
+    const { flow, onSignedIn } = mountFlow('/discover', failing);
+
+    await act(async () => {
+      flow().start();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(flow().error).toMatch(/Could not sign in/);
+    });
+    expect(onSignedIn).not.toHaveBeenCalled();
+  });
+
+  it('can be tried again after a failure', async () => {
+    /* The guard is one-at-a-time, not once-only: a sign-in that failed has to be retryable. */
+    let fail = true;
+    const inner = createMockAuthAdapter({ user: USER, storage: createMemoryStorage() });
+    const adapter: AuthAdapter = {
+      ...inner,
+      signInWithOAuth: (provider) =>
+        fail ? Promise.reject(new Error('nope')) : inner.signInWithOAuth(provider),
+    };
+    const { flow, onSignedIn } = mountFlow('/discover', adapter);
+
+    await act(async () => {
+      flow().start();
+      await Promise.resolve();
+    });
+    await waitFor(() => {
+      expect(flow().error).toBeDefined();
+    });
+
+    fail = false;
+    await act(async () => {
+      flow().start();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(onSignedIn).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/mobile/src/features/auth/useSignInFlow.ts
+++ b/apps/mobile/src/features/auth/useSignInFlow.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { useAuth } from '../../auth/AuthProvider';
 import { safeNext } from '../../auth/nextRoute';
 
@@ -34,6 +34,19 @@ export const useSignInFlow = ({
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | undefined>(undefined);
 
+  /*
+   * One completion handler per attempt.
+   *
+   * `signIn` is single-flight, so a second `start` does not begin a second sign-in — but it does
+   * attach a second `.then`, and both would call `onSignedIn`. That is two navigations for one
+   * sign-in, which on a stack is a duplicate route and on the web is a history entry somebody
+   * has to press back through twice.
+   *
+   * A ref rather than the `busy` state: `busy` is set for the next render, and both calls happen
+   * before it.
+   */
+  const handling = useRef(false);
+
   /* Checked here rather than at the point of navigation, so there is one place that decides what
      an acceptable destination is — see nextRoute.ts for why an unchecked one is an open
      redirect rather than a convenience. */
@@ -46,6 +59,8 @@ export const useSignInFlow = ({
     error,
     demo,
     start: () => {
+      if (handling.current) return;
+      handling.current = true;
       setBusy(true);
       setError(undefined);
 
@@ -59,6 +74,7 @@ export const useSignInFlow = ({
           setError('Could not sign in. Please try again.');
         })
         .finally(() => {
+          handling.current = false;
           setBusy(false);
         });
     },

--- a/apps/mobile/src/features/auth/useSignInFlow.ts
+++ b/apps/mobile/src/features/auth/useSignInFlow.ts
@@ -1,0 +1,66 @@
+import { useState } from 'react';
+import { useAuth } from '../../auth/AuthProvider';
+import { safeNext } from '../../auth/nextRoute';
+
+/**
+ * Signing in, and where it leads.
+ *
+ * The route used to hold this. Route files are thin adapters here — read params, compose
+ * providers, render a screen — and resolving an untrusted `next` parameter, deciding what to say
+ * when sign-in fails, and owning the in-flight flag are none of those.
+ *
+ * Navigation stays in the route, passed in as `onSignedIn`, which is what keeps this runnable
+ * without a router.
+ */
+
+export type SignInFlow = {
+  /** Where to go afterwards, already checked. Also where an already-signed-in visitor belongs. */
+  readonly destination: string;
+  readonly alreadySignedIn: boolean;
+  readonly busy: boolean;
+  readonly error: string | undefined;
+  readonly demo: boolean;
+  readonly start: () => void;
+};
+
+export const useSignInFlow = ({
+  next,
+  onSignedIn,
+}: {
+  readonly next: unknown;
+  readonly onSignedIn: (destination: string) => void;
+}): SignInFlow => {
+  const { state, signIn, demo } = useAuth();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | undefined>(undefined);
+
+  /* Checked here rather than at the point of navigation, so there is one place that decides what
+     an acceptable destination is — see nextRoute.ts for why an unchecked one is an open
+     redirect rather than a convenience. */
+  const destination = safeNext(next);
+
+  return {
+    destination,
+    alreadySignedIn: state.status === 'signed-in',
+    busy,
+    error,
+    demo,
+    start: () => {
+      setBusy(true);
+      setError(undefined);
+
+      void signIn()
+        .then(() => {
+          onSignedIn(destination);
+        })
+        .catch(() => {
+          /* Nothing specific to say: there is one provider, and the only thing worth reporting
+             is that it did not work. */
+          setError('Could not sign in. Please try again.');
+        })
+        .finally(() => {
+          setBusy(false);
+        });
+    },
+  };
+};

--- a/docs/adr/0007-google-only-sign-in.md
+++ b/docs/adr/0007-google-only-sign-in.md
@@ -1,0 +1,56 @@
+# ADR-0007 — One sign-in provider, and what it will cost
+
+**Status:** accepted · **Decision:** D28
+
+## Context
+
+Sign-in is required for the whole event (D15): tasks are assigned to somebody, reminders are
+somebody's, and an RSVP without a person attached is a row nobody can act on. So the question is
+not whether to have accounts but how many ways in to build.
+
+An event app is used once, briefly, by people who did not choose it — a guest at a wedding is
+not evaluating an authentication experience, they are trying to find the seating plan before the
+speeches. Every additional provider is another button on the one screen standing between them
+and that.
+
+## Decision
+
+Google, and nothing else, for now.
+
+`AuthProvider` is an enumeration rather than a string, so adding one is a change somebody makes
+here rather than a value somebody passes. `signInWithOAuth` takes it; there is no
+`signInWithOtp`, no password field and no magic link.
+
+## Why
+
+One provider is one button, one redirect to test, one set of consent screens to configure and
+one failure mode to write copy for. Two providers is an account-linking problem the first time
+somebody signs in with the other one — the same email, a different `sub`, and a decision about
+whether that is the same person that has to be made before it happens rather than after.
+
+Google specifically, because it is the account most likely to already be signed in on the device
+the invitation was opened on, and because Workspace covers most of the conference and corporate
+cases the platform is aimed at.
+
+## What it will cost
+
+These are known, dated and not yet paid:
+
+- **Apple requires Sign in with Apple before an iOS release.** Any app offering a third-party
+  sign-in on iOS must also offer Apple's, per App Store Review Guideline 4.8. This is not a
+  preference — it is a submission blocker, and it means `AuthProvider` gains `'apple'` and the
+  sign-in screen gains a second button before the app can ship to the App Store.
+- **Native Google sign-in needs a development build.** It is a native module, so it does not run
+  in Expo Go — the app has to move to a dev build (or EAS) before sign-in can be exercised on a
+  device at all. Until then the mock adapter is what the native app signs in against, which is
+  the reason the mock mirrors Supabase Auth's shape rather than being a convenience.
+- **A second provider brings account linking with it.** Whatever is decided then is a decision
+  about identity, not about buttons, and it belongs in a record of its own.
+
+## Consequences
+
+- The sign-in screen is deliberately shaped around a single provider — one button, no provider
+  list, no "or continue with" divider — so adding the second is a visible change rather than a
+  slot that was already there.
+- `docs/decisions.md` D28 stays as written. This record exists so the constraints above are
+  found by somebody planning an iOS release, rather than discovered by them.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -12,3 +12,4 @@ the alternative was and what it would have cost.
 | [0004](0004-adapter-boundary.md)                | Backend independence enforced by lint and proven by contract tests    |
 | [0005](0005-no-workflow-engine.md)              | An outbox table instead of a workflow engine                          |
 | [0006](0006-anonymous-identity-model.md)        | Anonymous to humans, device-tracked underneath                        |
+| [0007](0007-google-only-sign-in.md)             | One sign-in provider, and what it will cost                           |

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -46,17 +46,17 @@ Decisions with enough consequence to need their own reasoning have an [ADR](adr/
 
 ## Backend and operations
 
-| #   | Decision                                                                                                                                   |
-| --- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| D5  | Supabase is the backend — behind adapters, so it is replaceable                                                                            |
-| D4  | Phase 1 is a UI prototype with no backend; mock data is shaped exactly like the eventual tables                                            |
-| D26 | Background jobs are an outbox table plus `pg_cron` → Edge Function. **No workflow engine.** [ADR-0005](adr/0005-no-workflow-engine.md)     |
-| D27 | Media sits behind a `StorageAdapter` — Supabase Storage now, Cloudflare R2 when photos arrive                                              |
-| D28 | Sign-in is Google OAuth only. Known constraints: Apple requires Sign in with Apple before iOS release, and native Google needs a dev build |
-| D30 | Web first — free hosting, no store review. Native follows once the product is proven                                                       |
-| D31 | Gossip abuse control: per-device rate limit, silent device block, and attendee reports                                                     |
-| D32 | Sentry for errors, PostHog for product analytics, both behind a thin wrapper                                                               |
-| D33 | Transactional email is Resend, behind a `MailerAdapter`                                                                                    |
+| #   | Decision                                                                                                                                                                                |
+| --- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| D5  | Supabase is the backend — behind adapters, so it is replaceable                                                                                                                         |
+| D4  | Phase 1 is a UI prototype with no backend; mock data is shaped exactly like the eventual tables                                                                                         |
+| D26 | Background jobs are an outbox table plus `pg_cron` → Edge Function. **No workflow engine.** [ADR-0005](adr/0005-no-workflow-engine.md)                                                  |
+| D27 | Media sits behind a `StorageAdapter` — Supabase Storage now, Cloudflare R2 when photos arrive                                                                                           |
+| D28 | Sign-in is Google OAuth only. Known constraints: Apple requires Sign in with Apple before iOS release, and native Google needs a dev build. [ADR-0007](adr/0007-google-only-sign-in.md) |
+| D30 | Web first — free hosting, no store review. Native follows once the product is proven                                                                                                    |
+| D31 | Gossip abuse control: per-device rate limit, silent device block, and attendee reports                                                                                                  |
+| D32 | Sentry for errors, PostHog for product analytics, both behind a thin wrapper                                                                                                            |
+| D33 | Transactional email is Resend, behind a `MailerAdapter`                                                                                                                                 |
 
 ## Process
 


### PR DESCRIPTION
Closes #44.

## One button, on purpose

D28 allows Google and nothing else, so the screen is shaped around exactly one provider — no list, no "or continue with" divider, no slot standing empty. **A test counts the buttons**, which is what makes adding the second a visible change to this file rather than filling a gap somebody left open.

## The constraints, where a release planner will find them

New **[ADR-0007](docs/adr/0007-google-only-sign-in.md)**, linked from D28, recording what is known and not yet paid:

- **Apple's sign-in is a submission blocker**, not a preference — Guideline 4.8 requires it for any app offering a third-party sign-in on iOS.
- **Native Google needs a development build.** It is a native module, so it does not run in Expo Go; until then, native signs in against the mock — which is why the mock mirrors Supabase Auth's shape rather than being a convenience.
- **A second provider brings account linking with it**, which is a decision about identity rather than about buttons.

The screen repeats the first two at the top of the file, since that is where somebody adding a button will be looking.

## `next` is a URL, so it is treated as one

`?next=https://evil.example/login` on an otherwise genuine sign-in link is the whole of an open redirect: the person sees the app's own domain, signs in there, and is handed somewhere else at the moment they are most primed to type a password.

`safeNext` accepts a single leading slash and nothing else. It decodes **before** deciding, so `%2f%2f` cannot pass a check that `//` would fail, and it rejects a backslash because several URL parsers read `/\host` as protocol-relative. Everything else lands on the home page, which costs a tap.

## `AuthProvider` exposes three states and no authority

`restoring` is distinct from `signed-out` because storage is asynchronous on both platforms — a provider that started signed out would flash a sign-in prompt at somebody who *is* signed in, every launch.

No role, no `can` helper: a session says who somebody is and never what they may see (#43). That is #45's business.

## One test was worth nothing until it was rewritten

Unmounting the provider was asserted by checking that signing in still resolved — which it does whether or not the listener was removed, because React tolerates the stale update silently. The assertion held with the cleanup deleted. It counts live subscriptions now.

## Verification

| mutation | result |
|---|---|
| skip the decode before checking | 2 tests fail |
| allow a protocol-relative URL | 2 tests fail |
| allow a backslash | 1 test fails |
| drop the unsubscribe on unmount | 1 test fails |
| let a second sign-in start while one is running | 1 test fails |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145VPJXGgJA9PWqeNXDr1DG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Google sign-in for the mobile app.
  - Added authentication state handling, including session restoration, sign-in, and sign-out.
  - Added secure post-sign-in redirection to valid in-app destinations.
  - Added accessible sign-in feedback for loading and errors.
  - Added demo-mode sign-in support.

- **Documentation**
  - Documented the initial Google-only sign-in decision and related considerations.
  - Reformatted the backend and operations decision table without changing its content.

- **Tests**
  - Added coverage for authentication flows, sign-in behaviour, and safe redirect handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->