### PR TITLE
feat(app): useRole, RoleGate, and gating at the layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,15 +32,19 @@ Roles gate what the app **offers**, not what it **allows**.
 
 `RoleGate` and `useRole` decide which screens somebody is shown, and they run on a device that
 person controls — the bundle can be edited and the check deleted, and the request that follows is
-made by their machine either way. What actually stops a guest reading a moderation queue is
-row-level security in the database, which is why every repository method takes a tenant as its
-first argument and why the RLS policies are the thing to review when the Supabase adapter lands.
+made by their machine either way.
+
+**There is no enforcement behind them today.** D4 puts the backend in a later phase, so there is
+no Supabase adapter and no row-level security: the mock adapter applies tenant and membership
+checks in memory, which is a rehearsal of the eventual policy and not a substitute for it. When
+the Supabase adapter and its RLS policies land, the database will be what actually stops a guest
+reading a moderation queue — and those policies are the thing to review, which is why every
+repository method takes a tenant as its first argument.
 
 Two consequences worth stating plainly while this is a prototype:
 
-- **The gates are honest UX and nothing more.** They exist so people are not shown doors that
-  will not open. Treating them as security would be a mistake, and there is no enforcement layer
-  behind them yet.
+- **The gates are UX and nothing more.** They exist so people are not shown doors that will not
+  open. Treating them as security would be a mistake today and is meant to stop being one.
 - **A session carries no authority.** Roles are read from the data layer per event, never from a
   token — so revoking somebody's access takes effect on their next read rather than on their
   next sign-in. `AuthUser` has an id and an email and deliberately nothing else.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,25 @@ behaviour of the app.** There is no per-event code. A new event is a new row.
 One TypeScript codebase renders iOS, Android and web from a single Expo tree. Web ships first —
 free to host, no store review, and a link that works the moment you send it.
 
+## Access control in the prototype
+
+Roles gate what the app **offers**, not what it **allows**.
+
+`RoleGate` and `useRole` decide which screens somebody is shown, and they run on a device that
+person controls — the bundle can be edited and the check deleted, and the request that follows is
+made by their machine either way. What actually stops a guest reading a moderation queue is
+row-level security in the database, which is why every repository method takes a tenant as its
+first argument and why the RLS policies are the thing to review when the Supabase adapter lands.
+
+Two consequences worth stating plainly while this is a prototype:
+
+- **The gates are honest UX and nothing more.** They exist so people are not shown doors that
+  will not open. Treating them as security would be a mistake, and there is no enforcement layer
+  behind them yet.
+- **A session carries no authority.** Roles are read from the data layer per event, never from a
+  token — so revoking somebody's access takes effect on their next read rather than on their
+  next sign-in. `AuthUser` has an id and an email and deliberately nothing else.
+
 ## Reviewing
 
 Every PR is reviewed by [CodeRabbit](https://coderabbit.ai), configured in

--- a/apps/mobile/app/(super)/_layout.tsx
+++ b/apps/mobile/app/(super)/_layout.tsx
@@ -1,5 +1,6 @@
 import { useTheme } from '@occasio/ui';
-import { Stack } from 'expo-router';
+import { Stack, router } from 'expo-router';
+import { PlatformGate } from '../../src/access/PlatformGate';
 import { AppThemeProvider } from '../../src/theme/AppThemeProvider';
 import { APP_THEME } from '../../src/theme/inputs';
 
@@ -23,7 +24,16 @@ function Chrome() {
 export default function AdminLayout() {
   return (
     <AppThemeProvider input={APP_THEME}>
-      <Chrome />
+      {/* Not a `RoleGate`: memberships are per event and this area is not. See PlatformGate for
+          the gap that leaves and why it is an allow-list rather than a schema field. */}
+      <PlatformGate
+        leaveLabel="Back to your events"
+        onLeave={() => {
+          router.replace('/discover');
+        }}
+      >
+        <Chrome />
+      </PlatformGate>
     </AppThemeProvider>
   );
 }

--- a/apps/mobile/app/e/[slug]/(admin)/_layout.tsx
+++ b/apps/mobile/app/e/[slug]/(admin)/_layout.tsx
@@ -1,8 +1,6 @@
 import { useTheme } from '@occasio/ui';
 import { Stack, router } from 'expo-router';
-import { RoleGate } from '../../../../src/access/RoleGate';
-import { useTenantBySlug } from '../../../../src/data/hooks';
-import { useTenantResolution } from '../../../../src/tenant/TenantProvider';
+import { EventAdminGate } from '../../../../src/features/access/EventAdminGate';
 import { AppThemeProvider } from '../../../../src/theme/AppThemeProvider';
 import { APP_THEME } from '../../../../src/theme/inputs';
 
@@ -23,33 +21,21 @@ function Chrome() {
  * Nests the app theme back over the tenant theme: editing a dark festival theme inside a
  * dark editor is unusable. Only the preview pane will wear the tenant theme.
  *
- * One `RoleGate` here covers every admin screen, which is the whole point of gating at a layout
- * — a screen added under this directory is gated by existing rather than by somebody remembering
- * to gate it. `event_admin` only: a moderator moderates a queue and does not edit the theme or
- * the schedule, and widening that list is a visible change to this line.
- *
- * It is UX rather than enforcement. What actually stops a guest reading this is row-level
- * security; this stops them being shown a door that will not open.
+ * One gate here covers every admin screen, which is the whole point of gating at a layout — a
+ * screen added under this directory is gated by existing rather than by somebody remembering to
+ * gate it. Which roles are allowed, and how the tenant is resolved, live in `EventAdminGate`;
+ * this file keeps the router callback, which is the part that belongs to a route.
  */
 export default function AdminLayout() {
-  const resolution = useTenantResolution();
-  const slug = resolution.kind === 'resolved' ? resolution.slug : null;
-  /* A cache hit: `TenantGate` above this already loaded the event to decide whether it exists,
-     and both reads share a key. The role query is what actually goes out from here. */
-  const tenantId = useTenantBySlug(slug).data?.id ?? null;
-
   return (
     <AppThemeProvider input={APP_THEME}>
-      <RoleGate
-        tenantId={tenantId}
-        allow={['event_admin']}
-        leaveLabel="Back to the event"
-        onLeave={() => {
-          if (slug !== null) router.replace(`/e/${slug}`);
+      <EventAdminGate
+        onLeave={(slug) => {
+          router.replace(`/e/${slug}`);
         }}
       >
         <Chrome />
-      </RoleGate>
+      </EventAdminGate>
     </AppThemeProvider>
   );
 }

--- a/apps/mobile/app/e/[slug]/(admin)/_layout.tsx
+++ b/apps/mobile/app/e/[slug]/(admin)/_layout.tsx
@@ -1,5 +1,8 @@
 import { useTheme } from '@occasio/ui';
-import { Stack } from 'expo-router';
+import { Stack, router } from 'expo-router';
+import { RoleGate } from '../../../../src/access/RoleGate';
+import { useTenantBySlug } from '../../../../src/data/hooks';
+import { useTenantResolution } from '../../../../src/tenant/TenantProvider';
 import { AppThemeProvider } from '../../../../src/theme/AppThemeProvider';
 import { APP_THEME } from '../../../../src/theme/inputs';
 
@@ -19,11 +22,34 @@ function Chrome() {
 /**
  * Nests the app theme back over the tenant theme: editing a dark festival theme inside a
  * dark editor is unusable. Only the preview pane will wear the tenant theme.
+ *
+ * One `RoleGate` here covers every admin screen, which is the whole point of gating at a layout
+ * — a screen added under this directory is gated by existing rather than by somebody remembering
+ * to gate it. `event_admin` only: a moderator moderates a queue and does not edit the theme or
+ * the schedule, and widening that list is a visible change to this line.
+ *
+ * It is UX rather than enforcement. What actually stops a guest reading this is row-level
+ * security; this stops them being shown a door that will not open.
  */
 export default function AdminLayout() {
+  const resolution = useTenantResolution();
+  const slug = resolution.kind === 'resolved' ? resolution.slug : null;
+  /* A cache hit: `TenantGate` above this already loaded the event to decide whether it exists,
+     and both reads share a key. The role query is what actually goes out from here. */
+  const tenantId = useTenantBySlug(slug).data?.id ?? null;
+
   return (
     <AppThemeProvider input={APP_THEME}>
-      <Chrome />
+      <RoleGate
+        tenantId={tenantId}
+        allow={['event_admin']}
+        leaveLabel="Back to the event"
+        onLeave={() => {
+          if (slug !== null) router.replace(`/e/${slug}`);
+        }}
+      >
+        <Chrome />
+      </RoleGate>
     </AppThemeProvider>
   );
 }

--- a/apps/mobile/src/access/PlatformGate.dom.test.tsx
+++ b/apps/mobile/src/access/PlatformGate.dom.test.tsx
@@ -1,0 +1,73 @@
+import { userId } from '@occasio/core';
+import { createMemoryStorage, createMockAuthAdapter } from '@occasio/data';
+import { describe, expect, it } from '@jest/globals';
+import { ThemeProvider } from '@occasio/ui';
+import { render, screen, waitFor } from '@testing-library/react';
+import { AuthProvider } from '../auth/AuthProvider';
+import { APP_THEME } from '../theme/inputs';
+import { PlatformGate } from './PlatformGate';
+
+/**
+ * A cross-tenant area with no cross-tenant role in the model, so the gate is an allow-list — and
+ * the thing worth testing is what it compares against. Comparing a placeholder identity rather
+ * than a session let a signed-out visitor through, which is the case below.
+ */
+
+const ADMIN = { id: userId('u_sanit'), email: 'sanit@example.com' };
+const NOT_ADMIN = { id: userId('u_meera'), email: 'meera@example.com' };
+
+const mount = async (user: typeof ADMIN, signedIn: boolean) => {
+  const storage = createMemoryStorage();
+  if (signedIn) await createMockAuthAdapter({ user, storage }).signInWithOAuth('google');
+
+  render(
+    <AuthProvider adapter={createMockAuthAdapter({ user, storage })}>
+      <ThemeProvider input={APP_THEME} forceScheme="light">
+        <PlatformGate>
+          <div data-testid="super-admin">the platform screens</div>
+        </PlatformGate>
+      </ThemeProvider>
+    </AuthProvider>,
+  );
+};
+
+describe('PlatformGate', () => {
+  it('shows nothing but a placeholder while the session is still being restored', async () => {
+    await mount(ADMIN, true);
+
+    expect(screen.getByTestId('platform-gate-loading')).toBeTruthy();
+    expect(screen.queryByTestId('super-admin')).toBeNull();
+  });
+
+  it('lets a platform administrator through', async () => {
+    await mount(ADMIN, true);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('super-admin')).toBeTruthy();
+    });
+  });
+
+  it('refuses somebody signed in who is not on the list', async () => {
+    await mount(NOT_ADMIN, true);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('platform-gate-refused')).toBeTruthy();
+    });
+    expect(screen.queryByTestId('super-admin')).toBeNull();
+  });
+
+  it('refuses a visitor who is not signed in at all', async () => {
+    /*
+     * The case that was open. The gate compared `useCurrentUserId`, a placeholder constant that
+     * answers the same thing whether or not anybody has signed in — so a signed-out visitor
+     * matched the allow-list and rendered the platform screens. Nobody is a platform
+     * administrator until they are somebody.
+     */
+    await mount(ADMIN, false);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('platform-gate-refused')).toBeTruthy();
+    });
+    expect(screen.queryByTestId('super-admin')).toBeNull();
+  });
+});

--- a/apps/mobile/src/access/PlatformGate.tsx
+++ b/apps/mobile/src/access/PlatformGate.tsx
@@ -1,0 +1,55 @@
+import { Button, EmptyState, Screen } from '@occasio/ui';
+import { userId, type UserId } from '@occasio/core';
+import type { ReactNode } from 'react';
+import { useCurrentUserId } from '../data/useCurrentUserId';
+
+/**
+ * The super-admin area, which is cross-tenant and therefore not a membership question.
+ *
+ * **There is no platform-level role in the data model.** `MEMBERSHIP_ROLES` is per event —
+ * `event_admin` runs one wedding, not the platform — and `UserRow` carries no staff flag. So
+ * this gate is an allow-list of user ids, in the same spirit as `useCurrentUserId`: a constant
+ * that is honest about being one, rather than a schema field invented in a feature PR.
+ *
+ * That gap is real and worth naming rather than papering over. Adding a platform role touches
+ * `rows.ts`, which mirrors the eventual Postgres tables exactly, and it is the sort of change
+ * that should arrive with the RLS policy that enforces it — not with a screen that wants to be
+ * hidden. Until then this fails closed for everybody not named below, which is the right
+ * direction for a gate to be wrong in.
+ *
+ * Like `RoleGate`, this is UX and not enforcement: it decides what is offered, and the database
+ * decides what is allowed.
+ */
+
+/** The demo account, so the super-admin screens are reachable in the prototype at all. */
+const PLATFORM_ADMINS: readonly UserId[] = [userId('u_sanit')];
+
+export function PlatformGate({
+  onLeave,
+  leaveLabel,
+  children,
+}: {
+  readonly onLeave?: (() => void) | undefined;
+  readonly leaveLabel?: string | undefined;
+  readonly children: ReactNode;
+}) {
+  const me = useCurrentUserId();
+
+  if (!PLATFORM_ADMINS.includes(me)) {
+    return (
+      <Screen testID="platform-gate-refused">
+        <EmptyState
+          title="You do not have access to this"
+          message="These screens are for platform administrators."
+          action={
+            onLeave === undefined ? undefined : (
+              <Button label={leaveLabel ?? 'Go back'} onPress={onLeave} />
+            )
+          }
+        />
+      </Screen>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/apps/mobile/src/access/PlatformGate.tsx
+++ b/apps/mobile/src/access/PlatformGate.tsx
@@ -1,24 +1,24 @@
-import { Button, EmptyState, Screen } from '@occasio/ui';
+import { Button, EmptyState, Screen, Skeleton, SkeletonGroup } from '@occasio/ui';
 import { userId, type UserId } from '@occasio/core';
 import type { ReactNode } from 'react';
-import { useCurrentUserId } from '../data/useCurrentUserId';
+import { useAuth } from '../auth/AuthProvider';
 
 /**
  * The super-admin area, which is cross-tenant and therefore not a membership question.
  *
  * **There is no platform-level role in the data model.** `MEMBERSHIP_ROLES` is per event —
  * `event_admin` runs one wedding, not the platform — and `UserRow` carries no staff flag. So
- * this gate is an allow-list of user ids, in the same spirit as `useCurrentUserId`: a constant
- * that is honest about being one, rather than a schema field invented in a feature PR.
+ * this is an allow-list of user ids: a constant that is honest about being one, rather than a
+ * schema field invented in a feature PR. Adding a platform role touches `rows.ts`, which mirrors
+ * the eventual Postgres tables exactly, and it should arrive with the policy that enforces it.
  *
- * That gap is real and worth naming rather than papering over. Adding a platform role touches
- * `rows.ts`, which mirrors the eventual Postgres tables exactly, and it is the sort of change
- * that should arrive with the RLS policy that enforces it — not with a screen that wants to be
- * hidden. Until then this fails closed for everybody not named below, which is the right
- * direction for a gate to be wrong in.
+ * It reads the **session**, not `useCurrentUserId`. That distinction is the whole gate: the
+ * latter is a placeholder constant that answers the same thing whether or not anybody has signed
+ * in, so comparing it to an allow-list let a signed-out visitor straight through. Nobody is a
+ * platform administrator until they are somebody.
  *
  * Like `RoleGate`, this is UX and not enforcement: it decides what is offered, and the database
- * decides what is allowed.
+ * will decide what is allowed.
  */
 
 /** The demo account, so the super-admin screens are reachable in the prototype at all. */
@@ -33,9 +33,24 @@ export function PlatformGate({
   readonly leaveLabel?: string | undefined;
   readonly children: ReactNode;
 }) {
-  const me = useCurrentUserId();
+  const { state } = useAuth();
 
-  if (!PLATFORM_ADMINS.includes(me)) {
+  /* Nothing while storage is still answering — rendering the refusal first would tell a platform
+     administrator they have no access every time they open the page. */
+  if (state.status === 'restoring') {
+    return (
+      <Screen testID="platform-gate-loading">
+        <SkeletonGroup label="Checking your access">
+          <Skeleton width="70%" height={28} />
+          <Skeleton width="100%" height={120} />
+        </SkeletonGroup>
+      </Screen>
+    );
+  }
+
+  const allowed = state.status === 'signed-in' && PLATFORM_ADMINS.includes(state.session.user.id);
+
+  if (!allowed) {
     return (
       <Screen testID="platform-gate-refused">
         <EmptyState

--- a/apps/mobile/src/access/RoleGate.dom.test.tsx
+++ b/apps/mobile/src/access/RoleGate.dom.test.tsx
@@ -1,0 +1,188 @@
+import { tenantId as toTenantId, userId } from '@occasio/core';
+import { createMemoryStorage, createMockAdapter, FIXTURE_SEED } from '@occasio/data';
+import type { DataAdapter } from '@occasio/data';
+import { afterEach, describe, expect, it } from '@jest/globals';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ThemeProvider } from '@occasio/ui';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { AdapterProvider } from '../data/AdapterProvider';
+import { APP_THEME } from '../theme/inputs';
+import { RoleGate } from './RoleGate';
+import type { Role } from './useRole';
+
+/**
+ * A gate has two ways to be wrong and only one of them is visible: refusing somebody who should
+ * be let in is a complaint, and letting somebody through for even a moment is a screen they were
+ * never meant to see, with a request already sent. So the cases below are about *when* the
+ * children render as much as whether they do.
+ */
+
+const WEDDING = toTenantId('t_sanit-riyanks');
+const clients: QueryClient[] = [];
+
+const base = () =>
+  createMockAdapter({
+    currentUserId: userId('u_sanit'),
+    seed: FIXTURE_SEED,
+    storage: createMemoryStorage(),
+    latency: { minMs: 0, maxMs: 0 },
+  });
+
+/**
+ * The adapter answering as though a different fixture person were signed in.
+ *
+ * `useCurrentUserId` is a module-level constant until sign-in lands, and mocking it after import
+ * does not take — so the identity is varied where the role actually comes from: the membership
+ * lookup. That is also the more faithful test, since what `RoleGate` does is decide what to do
+ * with the data layer's answer.
+ */
+const asPerson = (who: string): DataAdapter => {
+  const inner = base();
+  return {
+    ...inner,
+    memberships: {
+      ...inner.memberships,
+      findForUser: (tenant) => inner.memberships.findForUser(tenant, userId(who)),
+    },
+  };
+};
+
+const renderGate = (who: string, allow: readonly Role[] = ['event_admin']) =>
+  mount(asPerson(who), allow);
+
+const mount = (adapter: DataAdapter, allow: readonly Role[]) => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: Infinity } },
+  });
+  clients.push(client);
+
+  const Wrapper = ({ children }: { readonly children: ReactNode }) => (
+    <QueryClientProvider client={client}>
+      <AdapterProvider adapter={adapter}>
+        <ThemeProvider input={APP_THEME} forceScheme="light">
+          {children}
+        </ThemeProvider>
+      </AdapterProvider>
+    </QueryClientProvider>
+  );
+
+  render(
+    <Wrapper>
+      <RoleGate tenantId={WEDDING} allow={allow}>
+        <div data-testid="behind-the-gate">the admin screens</div>
+      </RoleGate>
+    </Wrapper>,
+  );
+
+  return { client };
+};
+
+describe('RoleGate', () => {
+  afterEach(() => {
+    for (const client of clients.splice(0)) client.clear();
+  });
+
+  it('shows nothing but a placeholder while the answer is unknown', () => {
+    /*
+     * The failure this ordering prevents: rendering the children first and hiding them on
+     * refusal means the request they make has already left, and on a slow connection somebody
+     * sees the admin screen for a second. Rendering the refusal first is the opposite mistake,
+     * telling a genuine organiser they have no access every time they open the page.
+     */
+    renderGate('u_sanit');
+
+    expect(screen.getByTestId('role-gate-loading')).toBeTruthy();
+    expect(screen.queryByTestId('behind-the-gate')).toBeNull();
+    expect(screen.queryByTestId('role-gate-refused')).toBeNull();
+  });
+
+  it('lets an event admin through', async () => {
+    renderGate('u_sanit');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('behind-the-gate')).toBeTruthy();
+    });
+  });
+
+  it('refuses a role that is in the event but not on the list', async () => {
+    /* A moderator moderates a queue; they do not edit the theme or the schedule. */
+    renderGate('u_meera');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('role-gate-refused')).toBeTruthy();
+    });
+    expect(screen.queryByTestId('behind-the-gate')).toBeNull();
+  });
+
+  it('refuses somebody who is not in the event at all', async () => {
+    /* The same screen as the wrong role, deliberately: distinguishing them would tell a stranger
+       which events exist and who runs them. */
+    renderGate('u_lena');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('role-gate-refused')).toBeTruthy();
+    });
+  });
+
+  it('lets a moderator through when moderators are allowed', async () => {
+    /* The allow-list is what decides, so a gate that refused everybody would pass the cases
+       above for the wrong reason. */
+    renderGate('u_meera', ['event_admin', 'moderator']);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('behind-the-gate')).toBeTruthy();
+    });
+  });
+
+  it('refuses a membership that is no longer active', async () => {
+    /*
+     * The case the fixtures cannot produce, and the one that matters most: every membership in
+     * them is `active`, so the status check was never exercised — deleting it passed the whole
+     * suite. A revoked organiser whose row still says `event_admin` would have kept the admin
+     * screens, and an invited one who has not accepted would have had them early.
+     */
+    for (const status of ['revoked', 'invited'] as const) {
+      const inner = base();
+      const stale: DataAdapter = {
+        ...inner,
+        memberships: {
+          ...inner.memberships,
+          findForUser: async (tenant, who) => {
+            const membership = await inner.memberships.findForUser(tenant, who);
+            return membership === null ? null : { ...membership, status };
+          },
+        },
+      };
+
+      mount(stale, ['event_admin']);
+
+      await waitFor(() => {
+        expect([status, screen.getAllByTestId('role-gate-refused').length]).toEqual([status, 1]);
+      });
+      cleanup();
+      for (const client of clients.splice(0)) client.clear();
+    }
+  });
+
+  it('does not call a failed read a refusal', async () => {
+    /* "You do not have access" when the network dropped sends an organiser to ask somebody for
+       a permission they already have. */
+    const inner = base();
+    const failing: DataAdapter = {
+      ...inner,
+      memberships: {
+        ...inner.memberships,
+        findForUser: () => Promise.reject(new Error('the network, probably')),
+      },
+    };
+
+    mount(failing, ['event_admin']);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('role-gate-error')).toBeTruthy();
+    });
+    expect(screen.queryByTestId('role-gate-refused')).toBeNull();
+    expect(screen.queryByTestId('behind-the-gate')).toBeNull();
+  });
+});

--- a/apps/mobile/src/access/RoleGate.tsx
+++ b/apps/mobile/src/access/RoleGate.tsx
@@ -1,0 +1,97 @@
+import { Button, EmptyState, Screen, Skeleton, SkeletonGroup } from '@occasio/ui';
+import type { ReactNode } from 'react';
+import type { TenantId } from '@occasio/core';
+import { useRole, type Role } from './useRole';
+
+/**
+ * One line at a layout, gating a whole subtree.
+ *
+ * **This is UX, not enforcement, and the difference is not a detail.** Everything below runs on
+ * a device somebody else controls: the bundle can be edited, the check can be deleted, and the
+ * request that follows is made by their machine either way. What actually stops a guest reading
+ * the moderation queue is row-level security in the database, which is why every repository
+ * method takes a tenant and why the eventual RLS policies are the thing to review. The gate is
+ * here so that people are not shown doors they cannot open — a screen that loads, flashes and
+ * then errors is worse than one that was never offered.
+ *
+ * The role comes from the data layer per tenant (see useRole), never from the session, so
+ * revoking somebody's access takes effect on their next read rather than on their next sign-in.
+ */
+
+export type RoleGateProps = {
+  readonly tenantId: TenantId | null;
+  /** The roles that may see this subtree. Written out, so widening it is a visible change. */
+  readonly allow: readonly Role[];
+  /** Offered on the refused screen, when there is somewhere to go. */
+  readonly onLeave?: (() => void) | undefined;
+  readonly leaveLabel?: string | undefined;
+  readonly children: ReactNode;
+};
+
+export function RoleGate({ tenantId, allow, onLeave, leaveLabel, children }: RoleGateProps) {
+  const role = useRole(tenantId);
+
+  /*
+   * Nothing is rendered while the answer is unknown — not the subtree, and not the refusal.
+   *
+   * Rendering the children first and hiding them on refusal is the failure this exists to
+   * prevent: the request they make has already left, and on a slow connection somebody sees the
+   * admin screen for a second. Rendering the refusal first is the opposite mistake, telling a
+   * genuine organiser they have no access every time they open the page.
+   */
+  if (tenantId === null || role.isPending) {
+    return (
+      <Screen testID="role-gate-loading">
+        <SkeletonGroup label="Checking your access">
+          <Skeleton width="70%" height={28} />
+          <Skeleton width="100%" height={120} />
+        </SkeletonGroup>
+      </Screen>
+    );
+  }
+
+  if (role.isError) {
+    /* A failed read is not a refusal. Saying "you do not have access" when the network dropped
+       sends an organiser to ask somebody for a permission they already have. */
+    return (
+      <Screen testID="role-gate-error">
+        <EmptyState
+          title="Could not check your access"
+          message="Something went wrong reaching the server. It may be the connection."
+          action={
+            <Button
+              label="Try again"
+              onPress={() => {
+                void role.refetch();
+              }}
+            />
+          }
+        />
+      </Screen>
+    );
+  }
+
+  if (role.data === null || !allow.includes(role.data)) {
+    /*
+     * One screen for "not in this event" and "in it, but not as an organiser". They are
+     * different facts and the same answer: this is not yours to open, and the way forward is to
+     * ask somebody who can. Distinguishing them here would tell a stranger which events exist
+     * and who runs them.
+     */
+    return (
+      <Screen testID="role-gate-refused">
+        <EmptyState
+          title="You do not have access to this"
+          message="Ask an organiser of this event to give you access, and it will appear here."
+          action={
+            onLeave === undefined ? undefined : (
+              <Button label={leaveLabel ?? 'Go back'} onPress={onLeave} />
+            )
+          }
+        />
+      </Screen>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/apps/mobile/src/access/useRole.ts
+++ b/apps/mobile/src/access/useRole.ts
@@ -1,0 +1,56 @@
+import type { TenantId } from '@occasio/core';
+import type { MembershipRole } from '@occasio/data';
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { useAdapter } from '../data/AdapterProvider';
+import { useCurrentUserId } from '../data/useCurrentUserId';
+import { queryKeys } from '../data/queryKeys';
+
+/**
+ * What this person is in this event.
+ *
+ * **From the data layer, per tenant, and never from a session.** A token is issued once and
+ * believed until it expires, so a role revoked at 9am is still in a token minted at 8:50 — and a
+ * claim inside a token is a client-side fact, which makes it a client-side decision. `AuthUser`
+ * carries no role for that reason (#43), and this is the other half of the arrangement: the role
+ * is a row, read with the tenant in hand, invalidated with everything else about that event.
+ *
+ * `null` means "not in this event", which is a different answer from "not loaded" and from "not
+ * signed in". Every caller that gates on it has to tell them apart, which is why this returns
+ * the query rather than the role.
+ */
+
+export type Role = MembershipRole;
+
+/**
+ * An active membership only.
+ *
+ * A membership that is invited-but-not-accepted, or revoked, is a row that exists and a person
+ * who is not in the event. Treating either as a role would let a revoked organiser keep an admin
+ * screen until their next reload.
+ */
+export const useRole = (tenantId: TenantId | null): UseQueryResult<Role | null> => {
+  const adapter = useAdapter();
+  const userId = useCurrentUserId();
+
+  return useQuery({
+    /* The tenant prefix is what stops a role cached for one event answering for another — the
+       failure the whole key convention exists to prevent, at its most consequential. There is no
+       key for "no tenant" because there is nothing to cache: the query is disabled. */
+    queryKey:
+      tenantId === null
+        ? ['tenant', 'unresolved', 'memberships', 'forUser', userId]
+        : queryKeys.memberships.forUser(tenantId, userId),
+    queryFn: async () => {
+      if (tenantId === null) return null;
+      const membership = await adapter.memberships.findForUser(tenantId, userId);
+      return membership?.status === 'active' ? membership.role : null;
+    },
+    enabled: tenantId !== null,
+    /*
+     * Short, and deliberately shorter than the tenant's own config. A role is the one piece of
+     * this app that is revoked rather than edited, and the gap between it changing and a screen
+     * noticing is exactly the window this cache decides the size of.
+     */
+    staleTime: 30_000,
+  });
+};

--- a/apps/mobile/src/features/access/EventAdminGate.tsx
+++ b/apps/mobile/src/features/access/EventAdminGate.tsx
@@ -1,0 +1,78 @@
+import { Button, EmptyState, Screen, Skeleton, SkeletonGroup } from '@occasio/ui';
+import type { ReactNode } from 'react';
+import { RoleGate } from '../../access/RoleGate';
+import { useTenantBySlug } from '../../data/hooks';
+import { useTenantResolution } from '../../tenant/TenantProvider';
+
+/**
+ * Who may open the admin screens for the event currently being viewed.
+ *
+ * The layout used to do this. Resolving the tenant and choosing which roles are allowed are both
+ * business decisions, and route files here are thin adapters — read params, compose providers,
+ * render a screen. The layout keeps the router callback and nothing else.
+ *
+ * `event_admin` only. A moderator moderates a queue and does not edit the theme or the schedule,
+ * and widening that list is a visible change to one line in one place.
+ */
+
+export type EventAdminGateProps = {
+  readonly onLeave: (slug: string) => void;
+  readonly children: ReactNode;
+};
+
+export function EventAdminGate({ onLeave, children }: EventAdminGateProps) {
+  const resolution = useTenantResolution();
+  const slug = resolution.kind === 'resolved' ? resolution.slug : null;
+  /* Usually a cache hit: `TenantGate` above already loaded the event to decide whether it
+     exists, and both reads share a key. */
+  const tenant = useTenantBySlug(slug);
+
+  if (slug === null || tenant.isPending) {
+    return (
+      <Screen testID="event-admin-loading">
+        <SkeletonGroup label="Checking your access">
+          <Skeleton width="70%" height={28} />
+          <Skeleton width="100%" height={120} />
+        </SkeletonGroup>
+      </Screen>
+    );
+  }
+
+  if (tenant.isError) {
+    /*
+     * Handled here rather than folded into `null`. Passing `null` to `RoleGate` for a *failed*
+     * lookup would read as "no tenant yet" and leave the page on its loading state for good,
+     * long after the retries had stopped — a spinner that is really an error is the worst of
+     * both, because nobody knows to retry it.
+     */
+    return (
+      <Screen testID="event-admin-error">
+        <EmptyState
+          title="Could not check your access"
+          message="Something went wrong reaching this event. It may be the connection."
+          action={
+            <Button
+              label="Try again"
+              onPress={() => {
+                void tenant.refetch();
+              }}
+            />
+          }
+        />
+      </Screen>
+    );
+  }
+
+  return (
+    <RoleGate
+      tenantId={tenant.data.id}
+      allow={['event_admin']}
+      leaveLabel="Back to the event"
+      onLeave={() => {
+        onLeave(slug);
+      }}
+    >
+      {children}
+    </RoleGate>
+  );
+}


### PR DESCRIPTION
Closes #45.

## The role comes from the data layer, never from a session

The other half of #43's arrangement. `AuthUser` carries no role because a token is issued once and believed until it expires — so revoking somebody's access takes effect on their **next read** rather than on their next sign-in.

An inactive membership is not a role at all: a revoked organiser whose row still says `event_admin`, and an invited one who has not accepted, are both people who are not in the event.

## One gate at a layout covers every screen under it

Which is the point of gating there — a screen added to the admin directory is gated by *existing*, rather than by somebody remembering to gate it. `event_admin` only: a moderator moderates a queue and does not edit the theme, and widening that list is a visible change to one line.

**The order of the three states matters more than any of them:**

- **Nothing renders while the answer is unknown.** Rendering children first and hiding them on refusal means their request has already left, and on a slow connection somebody sees the admin screen for a second.
- **A refusal is not the default either.** Rendering it first tells a genuine organiser they have no access every time they open the page.
- **A failed read is not a refusal.** "You do not have access" when the network dropped sends an organiser to ask for a permission they already have.

Not-in-the-event and wrong-role get the same screen, deliberately: distinguishing them would tell a stranger which events exist and who runs them.

## Super admin: the model has no answer, and I did not invent one

`MEMBERSHIP_ROLES` is per event — `event_admin` runs one wedding, not the platform — and `UserRow` carries no staff flag.

`PlatformGate` is therefore an allow-list of user ids, in the same spirit as `useCurrentUserId`: a constant that is honest about being one. Adding a platform role touches `rows.ts`, which mirrors the eventual Postgres tables exactly, and it should arrive with the policy that enforces it rather than with a screen that wants hiding. Until then it fails closed, which is the right direction for a gate to be wrong in.

**Worth a decision from you:** if you want a real platform role, it is a schema change plus an RLS policy, and I would raise it as its own issue rather than fold it in here.

## README

Now states that the gates are UX and not enforcement — they run on a device somebody else controls, and what stops a guest reading a moderation queue is row-level security. The gates exist so people are not shown doors that will not open.

## Verification

| mutation | result |
|---|---|
| render children while the role is pending | 1 test fails |
| treat a failed read as a refusal | 1 test fails |
| ignore the allow-list | 1 test fails |
| count an inactive membership as a role | 1 test fails |

**That last one survived the first pass**, and the fix is the more useful half of this PR: every fixture membership is `active`, so the status check was never exercised and deleting it passed the whole suite. There is now a case returning a revoked and an invited membership — the two ways somebody keeps a role they should not have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145VPJXGgJA9PWqeNXDr1DG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added role-based access controls for event administration screens.
  - Added platform-admin access restrictions with clear access-denied messaging.
  - Added loading, retry, and navigation states when access cannot be confirmed.
  - Unauthorised users can return to their events or the event page.
  - Access reflects current membership status, including revoked or inactive access, on subsequent checks.

- **Documentation**
  - Documented how prototype access controls and database security work together.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->